### PR TITLE
Some params was not mapped to native versions

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/AdyenDropInModule.java
+++ b/android/src/main/java/com/adyenreactnativesdk/AdyenDropInModule.java
@@ -62,6 +62,7 @@ public class AdyenDropInModule extends BaseModule implements DropInServiceProxy.
         final Boolean holderNameRequired;
         final Boolean skipListWhenSinglePaymentMethod;
         final Boolean hideCvcStoredCard;
+        final Boolean showPreselectedStoredPaymentMethod;
 
         try {
             environment = config.getEnvironment();
@@ -73,6 +74,7 @@ public class AdyenDropInModule extends BaseModule implements DropInServiceProxy.
             holderNameRequired = config.getHolderNameRequired();
             skipListWhenSinglePaymentMethod = config.getSkipListWhenSinglePaymentMethod();
             hideCvcStoredCard = config.getHideCvcStoredCard();
+            showPreselectedStoredPaymentMethod = config.getShowPreselectedStoredPaymentMethod();
 
         } catch (NoSuchFieldException e) {
             sendEvent(DID_FAILED, ReactNativeError.mapError(e));
@@ -83,6 +85,7 @@ public class AdyenDropInModule extends BaseModule implements DropInServiceProxy.
         builder = new DropInConfiguration.Builder(getReactApplicationContext(), AdyenDropInService.class, clientKey)
                 .setShopperLocale(shopperLocale)
                 .setSkipListWhenSinglePaymentMethod(skipListWhenSinglePaymentMethod)
+                .setShowPreselectedStoredPaymentMethod(showPreselectedStoredPaymentMethod)
                 .setEnvironment(environment);
 
         CardConfiguration cardConfiguration;

--- a/android/src/main/java/com/adyenreactnativesdk/AdyenDropInModule.java
+++ b/android/src/main/java/com/adyenreactnativesdk/AdyenDropInModule.java
@@ -58,6 +58,10 @@ public class AdyenDropInModule extends BaseModule implements DropInServiceProxy.
         final String countryCode;
         final String shopperReference;
         final Amount amount = config.getAmount();
+        final Boolean showStorePaymentField;
+        final Boolean holderNameRequired;
+        final Boolean skipListWhenSinglePaymentMethod;
+        final Boolean hideCvcStoredCard;
 
         try {
             environment = config.getEnvironment();
@@ -65,6 +69,11 @@ public class AdyenDropInModule extends BaseModule implements DropInServiceProxy.
             shopperLocale = config.getLocale();
             shopperReference = config.getShopperReference();
             countryCode = config.getCountryCode();
+            showStorePaymentField = config.getShowStorePaymentField();
+            holderNameRequired = config.getHolderNameRequired();
+            skipListWhenSinglePaymentMethod = config.getSkipListWhenSinglePaymentMethod();
+            hideCvcStoredCard = config.getHideCvcStoredCard();
+
         } catch (NoSuchFieldException e) {
             sendEvent(DID_FAILED, ReactNativeError.mapError(e));
             return;
@@ -73,11 +82,15 @@ public class AdyenDropInModule extends BaseModule implements DropInServiceProxy.
         DropInConfiguration.Builder builder;
         builder = new DropInConfiguration.Builder(getReactApplicationContext(), AdyenDropInService.class, clientKey)
                 .setShopperLocale(shopperLocale)
+                .setSkipListWhenSinglePaymentMethod(skipListWhenSinglePaymentMethod)
                 .setEnvironment(environment);
 
         CardConfiguration cardConfiguration;
         cardConfiguration = new CardConfiguration.Builder(shopperLocale, environment, clientKey)
                 .setShopperReference(shopperReference)
+                .setShowStorePaymentField(showStorePaymentField)
+                .setHideCvcStoredCard(hideCvcStoredCard)
+                .setHolderNameRequired(holderNameRequired)
                 .build();
 
         BcmcConfiguration bcmcConfiguration;

--- a/android/src/main/java/com/adyenreactnativesdk/ConfigurationParser.java
+++ b/android/src/main/java/com/adyenreactnativesdk/ConfigurationParser.java
@@ -32,6 +32,11 @@ final public class ConfigurationParser {
     final String ENVIRONMENT_KEY = "environment";
     final String SHOPPERLOCALE_KEY = "shopperLocale";
     final String SHOPPERREFERENCE_KEY = "shopperReference";
+    final String SHOWSTOREPAYMENTFIELD_KEY = "showStorePaymentField";
+    final String HOLDERNAMEREQUIRED_KEY = "holderNameRequired";
+    final String SKIPLISTWHENSINGLEPAYMENTMETHOD_KEY = "skipListWhenSinglePaymentMethod";
+    final String HIDECVCSTOREDCARD_KEY = "hideCvcStoredCard";
+
 
     private final ReadableMap config;
 
@@ -96,6 +101,46 @@ final public class ConfigurationParser {
         }
 
         return Locale.forLanguageTag(value);
+    }
+
+    @NonNull
+    public Boolean getShowStorePaymentField() throws NoSuchFieldException {
+        Boolean value = config.getBoolean(SHOWSTOREPAYMENTFIELD_KEY);
+        if (value == null) {
+            throw new NoSuchFieldException("No " + SHOWSTOREPAYMENTFIELD_KEY);
+        }
+
+        return value;
+    }
+
+    @NonNull
+    public Boolean getHolderNameRequired() throws NoSuchFieldException {
+        Boolean value = config.getBoolean(HOLDERNAMEREQUIRED_KEY);
+        if (value == null) {
+            throw new NoSuchFieldException("No " + HOLDERNAMEREQUIRED_KEY);
+        }
+
+        return value;
+    }
+
+    @NonNull
+    public Boolean getSkipListWhenSinglePaymentMethod() throws NoSuchFieldException {
+        Boolean value = config.getBoolean(SKIPLISTWHENSINGLEPAYMENTMETHOD_KEY);
+        if (value == null) {
+            throw new NoSuchFieldException("No " + SKIPLISTWHENSINGLEPAYMENTMETHOD_KEY);
+        }
+
+        return value;
+    }
+
+    @NonNull
+    public Boolean getHideCvcStoredCard() throws NoSuchFieldException {
+        Boolean value = config.getBoolean(HIDECVCSTOREDCARD_KEY);
+        if (value == null) {
+            throw new NoSuchFieldException("No " + HIDECVCSTOREDCARD_KEY);
+        }
+
+        return value;
     }
 
     @NonNull

--- a/android/src/main/java/com/adyenreactnativesdk/ConfigurationParser.java
+++ b/android/src/main/java/com/adyenreactnativesdk/ConfigurationParser.java
@@ -36,7 +36,7 @@ final public class ConfigurationParser {
     final String HOLDERNAMEREQUIRED_KEY = "holderNameRequired";
     final String SKIPLISTWHENSINGLEPAYMENTMETHOD_KEY = "skipListWhenSinglePaymentMethod";
     final String HIDECVCSTOREDCARD_KEY = "hideCvcStoredCard";
-
+    final String SHOWPRESELECTEDSTOREDPAYMENTMETHOD_KEY = "showPreselectedStoredPaymentMethod";
 
     private final ReadableMap config;
 
@@ -105,42 +105,62 @@ final public class ConfigurationParser {
 
     @NonNull
     public Boolean getShowStorePaymentField() throws NoSuchFieldException {
-        Boolean value = config.getBoolean(SHOWSTOREPAYMENTFIELD_KEY);
-        if (value == null) {
-            throw new NoSuchFieldException("No " + SHOWSTOREPAYMENTFIELD_KEY);
+        if(config.hasKey(SHOWSTOREPAYMENTFIELD_KEY)) {
+            Boolean value = config.getBoolean(SHOWSTOREPAYMENTFIELD_KEY);
+            if (value == null) {
+                throw new NoSuchFieldException("No " + SHOWSTOREPAYMENTFIELD_KEY);
+            }
+            return value;
         }
-
-        return value;
+        return true;
     }
 
     @NonNull
     public Boolean getHolderNameRequired() throws NoSuchFieldException {
-        Boolean value = config.getBoolean(HOLDERNAMEREQUIRED_KEY);
-        if (value == null) {
-            throw new NoSuchFieldException("No " + HOLDERNAMEREQUIRED_KEY);
+        if(config.hasKey(HOLDERNAMEREQUIRED_KEY)) {
+            Boolean value = config.getBoolean(HOLDERNAMEREQUIRED_KEY);
+            if (value == null) {
+                throw new NoSuchFieldException("No " + HOLDERNAMEREQUIRED_KEY);
+            }
+            return value;
         }
-
-        return value;
+        return false;
     }
 
     @NonNull
     public Boolean getSkipListWhenSinglePaymentMethod() throws NoSuchFieldException {
-        Boolean value = config.getBoolean(SKIPLISTWHENSINGLEPAYMENTMETHOD_KEY);
-        if (value == null) {
-            throw new NoSuchFieldException("No " + SKIPLISTWHENSINGLEPAYMENTMETHOD_KEY);
+        if(config.hasKey(SKIPLISTWHENSINGLEPAYMENTMETHOD_KEY)) {
+            Boolean value = config.getBoolean(SKIPLISTWHENSINGLEPAYMENTMETHOD_KEY);
+            if (value == null) {
+                throw new NoSuchFieldException("No " + SKIPLISTWHENSINGLEPAYMENTMETHOD_KEY);
+            }
+            return value;
         }
-
-        return value;
+        return false;
     }
 
     @NonNull
     public Boolean getHideCvcStoredCard() throws NoSuchFieldException {
-        Boolean value = config.getBoolean(HIDECVCSTOREDCARD_KEY);
-        if (value == null) {
-            throw new NoSuchFieldException("No " + HIDECVCSTOREDCARD_KEY);
+        if(config.hasKey(HIDECVCSTOREDCARD_KEY)) {
+            Boolean value = config.getBoolean(HIDECVCSTOREDCARD_KEY);
+            if (value == null) {
+                throw new NoSuchFieldException("No " + HIDECVCSTOREDCARD_KEY);
+            }
+            return value;
         }
+        return true;
+    }
 
-        return value;
+    @NonNull
+    public Boolean getShowPreselectedStoredPaymentMethod() throws NoSuchFieldException {
+        if(config.hasKey(SHOWPRESELECTEDSTOREDPAYMENTMETHOD_KEY)){
+            Boolean value = config.getBoolean(SHOWPRESELECTEDSTOREDPAYMENTMETHOD_KEY);
+            if (value == null) {
+                throw new NoSuchFieldException("No " + SHOWPRESELECTEDSTOREDPAYMENTMETHOD_KEY);
+            }
+            return value;
+        }
+        return true;
     }
 
     @NonNull

--- a/example/src/Configuration.js
+++ b/example/src/Configuration.js
@@ -17,10 +17,11 @@ export const defaultConfiguration = {
   merchantAccount: '{YOUR_MERCHANT_ACCOUNT}',
   shopperLocale: 'en-US',
   additionalData: { allow3DS2: true },
-  holderNameRequired: true,
-  showStorePaymentField : false,
-  hideCvcStoredCard: false,
-  skipListWhenSinglePaymentMethod: true,
+  holderNameRequired: false,
+  showStorePaymentField : true,
+  hideCvcStoredCard: true,
+  skipListWhenSinglePaymentMethod: false,
+  showPreselectedStoredPaymentMethod: true,
 };
 
 export const environment = {

--- a/example/src/Configuration.js
+++ b/example/src/Configuration.js
@@ -17,6 +17,10 @@ export const defaultConfiguration = {
   merchantAccount: '{YOUR_MERCHANT_ACCOUNT}',
   shopperLocale: 'en-US',
   additionalData: { allow3DS2: true },
+  holderNameRequired: true,
+  showStorePaymentField : false,
+  hideCvcStoredCard: false,
+  skipListWhenSinglePaymentMethod: true,
 };
 
 export const environment = {

--- a/ios/AdyenDropIn.swift
+++ b/ios/AdyenDropIn.swift
@@ -41,7 +41,24 @@ internal class AdyenDropIn: BaseModule {
         else { return }
 
         let apiContext = APIContext(environment: Environment.parse(environment), clientKey: clientKey)
-        let config = DropInComponent.Configuration(apiContext: apiContext)
+        
+        let allowsSkippingPaymentList = configuration[Keys.skipListWhenSinglePaymentMethod] as? Bool
+        
+        let config = DropInComponent.Configuration(apiContext: apiContext,allowsSkippingPaymentList: allowsSkippingPaymentList ?? false)
+        
+        
+        if let showsHolderNameField = configuration[Keys.holderNameRequired] as? Bool {
+            config.card.showsHolderNameField = showsHolderNameField
+        }
+       
+        if let showsStorePaymentMethodField = configuration[Keys.showStorePaymentField] as? Bool {
+            config.card.showsStorePaymentMethodField = showsStorePaymentMethodField
+        }
+        
+        if let showsSecurityCodeField = configuration[Keys.hideCvcStoredCard] as? Bool {
+            config.card.stored.showsSecurityCodeField  = showsSecurityCodeField
+        }
+
         
         if let paymentObject = configuration[Keys.amount] as? [String: Any],
            let paymentAmount = paymentObject[Keys.value] as? Int,

--- a/ios/AdyenDropIn.swift
+++ b/ios/AdyenDropIn.swift
@@ -44,8 +44,9 @@ internal class AdyenDropIn: BaseModule {
         
         let allowsSkippingPaymentList = configuration[Keys.skipListWhenSinglePaymentMethod] as? Bool
         
-        let config = DropInComponent.Configuration(apiContext: apiContext,allowsSkippingPaymentList: allowsSkippingPaymentList ?? false)
+        let allowPreselectedPaymentView = configuration[Keys.showPreselectedStoredPaymentMethod] as? Bool
         
+        let config = DropInComponent.Configuration(apiContext: apiContext,allowsSkippingPaymentList: allowsSkippingPaymentList ?? false,allowPreselectedPaymentView: allowPreselectedPaymentView ?? true)
         
         if let showsHolderNameField = configuration[Keys.holderNameRequired] as? Bool {
             config.card.showsHolderNameField = showsHolderNameField

--- a/ios/Constants.swift
+++ b/ios/Constants.swift
@@ -25,4 +25,5 @@ internal enum Keys {
     static var showStorePaymentField = "showStorePaymentField"
     static var holderNameRequired = "holderNameRequired"
     static var hideCvcStoredCard = "hideCvcStoredCard"
+    static var showPreselectedStoredPaymentMethod = "showPreselectedStoredPaymentMethod"
 }

--- a/ios/Constants.swift
+++ b/ios/Constants.swift
@@ -21,4 +21,8 @@ internal enum Keys {
     static var countryCode = "countryCode"
     static var currency = "currency"
     static var applepayMerchantID = "applepayMerchantID"
+    static var skipListWhenSinglePaymentMethod = "skipListWhenSinglePaymentMethod"
+    static var showStorePaymentField = "showStorePaymentField"
+    static var holderNameRequired = "holderNameRequired"
+    static var hideCvcStoredCard = "hideCvcStoredCard"
 }


### PR DESCRIPTION
## Summary
As react-native SDK is a wrapper on native SDKs version, so On some places configurations keys were not being mapped on native SDK versions. 

In this PR, I have mapped 4 params to native SDK configurations:

* **showStorePaymentField** this will hide/show the saved cards in the drop-in.
* **hideCvcStoredCard** this will skip or show the popup for CVC input on the saved card
* **skipListWhenSinglePaymentMethod** this will skip showing the payment methods list if the list contains only one component
* **holderNameRequired** this will hide/show the cardholder name field in the card component,

## Tested scenarios
Tested all mentioned parameters by changing the values in the config object, on **both Android & iOS**

## Summary 
## **showStorePaymentField**
Highlighted view is now, mapped on this **showStorePaymentField** values specified in config.

![MicrosoftTeams-image (8)](https://user-images.githubusercontent.com/18231674/170438561-062cfd00-d2f6-4fd1-b452-5ff73358c404.png)

## **hideCvcStoredCard**
Highlighted view is now, mapped on this **hideCvcStoredCard** values specified in config.

![image](https://user-images.githubusercontent.com/18231674/170437916-f19da0f6-ebeb-4d77-8e9d-860234566643.png) ![MicrosoftTeams-image (7)](https://user-images.githubusercontent.com/18231674/170437945-c9486b8c-e314-4113-9c01-ad915e182a8f.png)

## **hideCvcStoredCard**
Pre-selected view is now, mapped on this **showPreselectedStoredPaymentMethod** values specified in config.

![MicrosoftTeams-image (15)](https://user-images.githubusercontent.com/18231674/170486600-0ca3c263-4005-43ff-b27c-6900add05c46.png)




**Fixed issue**:  <!-- #-prefixed issue number -->
https://github.com/Adyen/adyen-react-native/issues/11
https://github.com/Adyen/adyen-react-native/issues/12
https://github.com/Adyen/adyen-react-native/issues/13
https://github.com/Adyen/adyen-react-native/issues/14
https://github.com/Adyen/adyen-react-native/issues/17