### PR TITLE
Add helper for AppDelegate.mm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add `@adyen/react-native` to your react-native project.
   ...
 
   - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-    return [ADYRedirectComponent applicationOpenURL:url];
+    return [ADYRedirectComponent applicationDidOpenURL:url];
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Add `@adyen/react-native` to your react-native project.
 1. run `pod install`
 2. add return URL handler to your `AppDelegate.m`
   ```objc
-  @import adyen_react_native;
+  #import <adyen-react-native/ADYRedirectComponent.h>
 
   ...
 
   - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-    return [RedirectComponentProxy proccessURL:url];
+    return [ADYRedirectComponent applicationOpenURL:url];
   }
   ```
 

--- a/ios/ADYRedirectComponent.h
+++ b/ios/ADYRedirectComponent.h
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2023 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ADYRedirectComponent : NSObject
+
++ (BOOL)applicationOpenURL:(nonnull NSURL *)url;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/ADYRedirectComponent.h
+++ b/ios/ADYRedirectComponent.h
@@ -8,8 +8,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Handles any redirect Url whether its an App custom scheme url, or an app universal link.
 @interface ADYRedirectComponent : NSObject
 
+/// This function should be invoked from the application's delegate when the application is opened through a URL.
+///
+/// - Parameter url: The URL through which the application was opened.
+/// - Returns: A boolean value indicating whether the URL was handled by the redirect component.
 + (BOOL)applicationOpenURL:(nonnull NSURL *)url;
 
 @end

--- a/ios/ADYRedirectComponent.h
+++ b/ios/ADYRedirectComponent.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// - Parameter url: The URL through which the application was opened.
 /// - Returns: A boolean value indicating whether the URL was handled by the redirect component.
-+ (BOOL)applicationOpenURL:(nonnull NSURL *)url;
++ (BOOL)applicationDidOpenURL:(nonnull NSURL *)url;
 
 @end
 

--- a/ios/ADYRedirectComponent.m
+++ b/ios/ADYRedirectComponent.m
@@ -1,0 +1,16 @@
+//
+// Copyright (c) 2023 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+#import "ADYRedirectComponent.h"
+#import <adyen_react_native-Swift.h>
+
+@implementation ADYRedirectComponent
+
++ (BOOL)applicationOpenURL:(nonnull NSURL *)url {
+    return [RedirectComponentProxy proccessURL: url];
+}
+
+@end

--- a/ios/ADYRedirectComponent.m
+++ b/ios/ADYRedirectComponent.m
@@ -9,7 +9,7 @@
 
 @implementation ADYRedirectComponent
 
-+ (BOOL)applicationOpenURL:(nonnull NSURL *)url {
++ (BOOL)applicationDidOpenURL:(nonnull NSURL *)url {
     return [RedirectComponentProxy proccessURL: url];
 }
 


### PR DESCRIPTION
# Open PR

## Changes

### Fix

* Allow easy access to iOS `RedirecComponent.applicationDidOpen` via `ADYRedirectComponent.h` for Objective-C++(.mm) and Objective-C(.m)