### PR TITLE
Use  AdyenCheckout for activity handling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,20 @@ Add `@adyen/react-native` to your react-native project.
 
 #### Android integration
 
-##### For Drop-In
-
 1. Add `AdyenDropInService` to manifest:
 
 ```xml
 <service android:name="com.adyenreactnativesdk.component.dropin.AdyenDropInService" />
+```
+
+2. Provide your Checkout activity to `AdyenCheckout`. This will improve responsiveness of DropIn and standalone native components:
+
+```java
+@Override
+protected void onCreate(Bundle savedInstanceState) {
+  super.onCreate(savedInstanceState);
+  AdyenCheckout.setLauncherActivity(this);
+}
 ```
 
 ##### For standalone components
@@ -74,33 +82,23 @@ defaultConfig {
 </intent-filter>
 ```
 
-3. Provide your Checkout activity as `DropInLauncher`. This will improve responsiveness of DropIn and standalone native components:
-
-```java
-@Override
-protected void onCreate(Bundle savedInstanceState) {
-  super.onCreate(savedInstanceState);
-  AdyenDropInComponent.setDropInLauncher(this);
-}
-```
-
-4. To enable standalone redirect components, return URL handler to your Checkout activity `onNewIntent`:
+3. To enable standalone redirect components, return URL handler to your Checkout activity `onNewIntent`:
 
 ```java
 @Override
 public void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
-    ActionHandler.Companion.handle(intent);
+    AdyenCheckout.Companion.handle(intent);
 }
 ```
 
-5. To enable GooglePay, pass state to your Checkout activity `onActivityResult`:
+4. To enable GooglePay, pass state to your Checkout activity `onActivityResult`:
 
 ```java
 @Override
 public void onActivityResult(int requestCode, int resultCode, Intent data) {
   super.onActivityResult(requestCode, resultCode, data);
-  AdyenGooglePayComponent.handleActivityResult(requestCode, resultCode, data);
+  AdyenCheckout.handleActivityResult(requestCode, resultCode, data);
 }
 ```
 
@@ -118,9 +116,7 @@ const configuration = {
   clientKey: '{YOUR_CLIENT_KEY}',
   countryCode: 'NL',
   amount: { currency: 'EUR', value: 1000 }, // Value in minor units
-  reference: 'React Native', // The reference to uniquely identify a payment. Can be send from your backend
-  shopperReference: 'Checkout Shopper', // Your reference to uniquely identify this shopper
-  returnUrl: 'myapp://', // Custom URL scheme of your iOS app. This value is overridden for Android by `AdyenCheckout`. Can be send from your backend
+  returnUrl: 'myapp://payment', // Custom URL scheme of your iOS app. This value is overridden for Android by `AdyenCheckout`. Can be send from your backend
 };
 ```
 

--- a/android/src/main/java/com/adyenreactnativesdk/AdyenCheckout.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/AdyenCheckout.kt
@@ -1,0 +1,136 @@
+package com.adyenreactnativesdk
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import com.adyen.checkout.components.base.IntentHandlingComponent
+import com.adyen.checkout.dropin.DropIn
+import com.adyen.checkout.dropin.DropInCallback
+import com.adyen.checkout.dropin.DropInResult
+import com.adyenreactnativesdk.action.ActionHandler
+import com.adyenreactnativesdk.component.dropin.ReactDropInCallback
+import com.adyenreactnativesdk.component.googlepay.AdyenGooglePayComponent
+import java.lang.ref.WeakReference
+
+/**
+ * Umbrella class for setting DropIn and Component specific parameters
+ */
+class AdyenCheckout {
+
+    companion object {
+        private const val TAG = "AdyenCheckout"
+        internal var dropInLauncher: ActivityResultLauncher<Intent>? = null
+        private val dropInCallback = DropInCallbackListener()
+        private var intentHandlingComponent: WeakReference<IntentHandlingComponent> = WeakReference(null)
+        private var googleComponent: WeakReference<AdyenGooglePayComponent> = WeakReference(null)
+
+        @JvmStatic
+        internal fun addDropInListener(callback: ReactDropInCallback) {
+            dropInCallback.callback = WeakReference(callback)
+        }
+
+        @JvmStatic
+        internal fun removeDropInListener() {
+            dropInCallback.callback.clear()
+        }
+
+        /**
+         * Persist a reference to Activity that will present DropIn or Component
+         * @param activity  parent activity for DropIn or Component
+         */
+        @JvmStatic
+        fun setLauncherActivity(activity: ActivityResultCaller) {
+            dropInLauncher = activity.registerForActivityResult(
+                    ReactDropInResultContract(),
+                    dropInCallback::onDropInResult
+            )
+        }
+
+        /**
+         * Release a reference to current Activity that presenting DropIn or Component
+         */
+        @JvmStatic
+        fun removeLauncherActivity() {
+            dropInLauncher = null
+        }
+
+        /**
+         * Allow Adyen Components to process intents.
+         * @param intent  received redirect intent
+         * @return  `true` when intent could be handled by AdyenCheckout
+         */
+        @JvmStatic
+        fun handleIntent(intent: Intent): Boolean {
+            val data = intent.data
+            val handler = intentHandlingComponent.get()
+            return if (data != null && handler != null && data.toString().startsWith(ActionHandler.REDIRECT_RESULT_SCHEME)) {
+                handler.handleIntent(intent)
+                true
+            } else false
+        }
+
+        @JvmStatic
+        internal fun setIntentHandler(component: IntentHandlingComponent) {
+            intentHandlingComponent = WeakReference(component)
+        }
+
+        @JvmStatic
+        internal fun removeIntentHandler() {
+            intentHandlingComponent.clear()
+        }
+
+        /**
+         * Allow Adyen Components to process intents.
+         * @param requestCode  received redirect intent
+         * @param resultCode  received redirect intent
+         * @param data  received redirect intent
+         */
+        @JvmStatic
+        fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+            if (requestCode == AdyenGooglePayComponent.GOOGLEPAY_REQUEST_CODE) {
+                googleComponent.get()?.handleActivityResult(resultCode, data)
+            }
+        }
+
+        @JvmStatic
+        internal fun setGooglePayComponent(component: AdyenGooglePayComponent) {
+            googleComponent = WeakReference(component)
+        }
+
+        @JvmStatic
+        internal fun removeGooglePayComponent() {
+            googleComponent.clear()
+        }
+
+    }
+
+}
+
+private class ReactDropInResultContract : ActivityResultContract<Intent, DropInResult?>() {
+    override fun createIntent(context: Context, input: Intent): Intent {
+        return input
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): DropInResult? {
+        return DropIn.handleActivityResult(DropIn.DROP_IN_REQUEST_CODE, resultCode, intent)
+    }
+}
+
+private class DropInCallbackListener : DropInCallback {
+
+    internal var callback: WeakReference<ReactDropInCallback> =
+            WeakReference(null)
+
+    override fun onDropInResult(dropInResult: DropInResult?) {
+        if (dropInResult == null ) return
+        val callback = callback.get()?.let {
+            when (dropInResult) {
+                is DropInResult.CancelledByUser -> it.onCancel()
+                is DropInResult.Error -> it.onError(dropInResult.reason)
+                is DropInResult.Finished -> it.onCompleted(dropInResult.result)
+            }
+        }
+    }
+}

--- a/android/src/main/java/com/adyenreactnativesdk/action/ActionHandler.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/action/ActionHandler.kt
@@ -38,6 +38,7 @@ import com.adyen.checkout.voucher.VoucherConfiguration
 import com.adyen.checkout.voucher.VoucherView
 import com.adyen.checkout.wechatpay.WeChatPayActionComponent
 import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
+import com.adyenreactnativesdk.AdyenCheckout
 import com.adyenreactnativesdk.BuildConfig
 import com.adyenreactnativesdk.ui.Cancelable
 import com.adyenreactnativesdk.ui.PendingPaymentDialogFragment
@@ -129,10 +130,8 @@ class ActionHandler(
 
     companion object {
         private val TAG = LogUtil.getTag()
-        private var intentHandlingComponent: WeakReference<IntentHandlingComponent> =
-            WeakReference(null)
         const val ACTION_FRAGMENT_TAG = "ACTION_DIALOG_FRAGMENT"
-        private const val REDIRECT_RESULT_SCHEME = BuildConfig.adyenRectNativeRedirectScheme + "://"
+        internal const val REDIRECT_RESULT_SCHEME = BuildConfig.adyenRectNativeRedirectScheme + "://"
 
         internal fun getReturnUrl(context: Context): String {
             return REDIRECT_RESULT_SCHEME + context.packageName
@@ -140,17 +139,10 @@ class ActionHandler(
 
         @JvmStatic
         @Deprecated(
-            message = "This method is deprecated",
-            replaceWith = ReplaceWith("handleIntent(intent)"))
-        fun handle(intent: Intent) {
-            handleIntent(intent)
-        }
-
-        @JvmStatic
+            message = "This method is deprecated on beta-8",
+            replaceWith = ReplaceWith("AdyenCheckout.handleIntent(intent)"))
         fun handleIntent(intent: Intent) {
-            val data = intent.data
-            if (data != null && data.toString().startsWith(REDIRECT_RESULT_SCHEME))
-                intentHandlingComponent.get()?.handleIntent(intent)
+            AdyenCheckout.handleIntent(intent)
         }
 
         private inline fun <reified T : Configuration> getDefaultConfigForAction(
@@ -260,7 +252,7 @@ class ActionHandler(
             }
 
             if (actionComponent is IntentHandlingComponent)
-                intentHandlingComponent = WeakReference(actionComponent)
+                AdyenCheckout.setIntentHandler(actionComponent)
 
             return actionComponent
         }

--- a/android/src/main/java/com/adyenreactnativesdk/component/dropin/AdyenDropInComponent.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/dropin/AdyenDropInComponent.kt
@@ -5,21 +5,16 @@
  */
 package com.adyenreactnativesdk.component.dropin
 
-import android.content.Context
 import android.content.Intent
 import androidx.activity.result.ActivityResultCaller
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContract
 import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
 import com.adyen.checkout.bcmc.BcmcConfiguration
 import com.adyen.checkout.card.CardConfiguration
-import com.adyen.checkout.dropin.DropIn
 import com.adyen.checkout.dropin.DropIn.startPayment
-import com.adyen.checkout.dropin.DropInCallback
 import com.adyen.checkout.dropin.DropInConfiguration.Builder
-import com.adyen.checkout.dropin.DropInResult
 import com.adyen.checkout.googlepay.GooglePayConfiguration
 import com.adyen.checkout.redirect.RedirectComponent
+import com.adyenreactnativesdk.AdyenCheckout
 import com.adyenreactnativesdk.component.BaseModule
 import com.adyenreactnativesdk.component.BaseModuleException
 import com.adyenreactnativesdk.component.KnownException
@@ -80,8 +75,8 @@ class AdyenDropInComponent(context: ReactApplicationContext?) : BaseModule(conte
         val resultIntent = Intent(currentActivity, currentActivity!!.javaClass)
         resultIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
 
-        dropInCallback.dropInCallback = this
-        dropInLauncher?.let {
+        AdyenCheckout.addDropInListener(this)
+        AdyenCheckout.dropInLauncher?.let {
             startPayment(currentActivity, it, paymentMethodsResponse, builder.build(), resultIntent)
         } ?: run {
             startPayment(currentActivity, paymentMethodsResponse, builder.build(), resultIntent)
@@ -106,7 +101,7 @@ class AdyenDropInComponent(context: ReactApplicationContext?) : BaseModule(conte
     @ReactMethod
     fun hide(success: Boolean, message: ReadableMap?) {
         proxyHideDropInCommand(success, message)
-        dropInCallback.dropInCallback = null
+        AdyenCheckout.removeDropInListener()
     }
 
     override fun onCancel() {
@@ -224,20 +219,18 @@ class AdyenDropInComponent(context: ReactApplicationContext?) : BaseModule(conte
     companion object {
         private const val TAG = "DropInComponent"
         private const val COMPONENT_NAME = "AdyenDropIn"
-        private var dropInLauncher: ActivityResultLauncher<Intent>? = null
-        private val dropInCallback = DropInCallbackListener()
 
         @JvmStatic
+        @Deprecated(
+            message = "This method is deprecated on beta-8",
+            replaceWith = ReplaceWith("AdyenCheckout.setLauncherActivity(activity)"))
         fun setDropInLauncher(activity: ActivityResultCaller) {
-            dropInLauncher = activity.registerForActivityResult(
-                ReactDropInResultContract(),
-                dropInCallback::onDropInResult
-            )
+            AdyenCheckout.setLauncherActivity(activity);
         }
 
         @JvmStatic
         fun removeDropInLauncher() {
-            dropInLauncher = null
+            AdyenCheckout.removeLauncherActivity();
         }
     }
 
@@ -247,30 +240,6 @@ internal interface ReactDropInCallback {
     fun onCancel()
     fun onError(reason: String?)
     fun onCompleted(result: String)
-}
-
-private class ReactDropInResultContract : ActivityResultContract<Intent, DropInResult?>() {
-    override fun createIntent(context: Context, input: Intent): Intent {
-        return input
-    }
-
-    override fun parseResult(resultCode: Int, intent: Intent?): DropInResult? {
-        return DropIn.handleActivityResult(DropIn.DROP_IN_REQUEST_CODE, resultCode, intent)
-    }
-}
-
-private class DropInCallbackListener : DropInCallback {
-
-    var dropInCallback: ReactDropInCallback? = null
-
-    override fun onDropInResult(dropInResult: DropInResult?) {
-        if (dropInResult == null) return
-        when (dropInResult) {
-            is DropInResult.CancelledByUser -> dropInCallback?.onCancel()
-            is DropInResult.Error -> dropInCallback?.onError(dropInResult.reason)
-            is DropInResult.Finished -> dropInCallback?.onCompleted(dropInResult.result)
-        }
-    }
 }
 
 sealed class DropInException(code: String, message: String, cause: Throwable? = null) :

--- a/android/src/main/java/com/adyenreactnativesdk/component/dropin/AdyenDropInComponent.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/dropin/AdyenDropInComponent.kt
@@ -229,6 +229,9 @@ class AdyenDropInComponent(context: ReactApplicationContext?) : BaseModule(conte
         }
 
         @JvmStatic
+        @Deprecated(
+            message = "This method is deprecated on beta-8",
+            replaceWith = ReplaceWith("AdyenCheckout.removeLauncherActivity()"))
         fun removeDropInLauncher() {
             AdyenCheckout.removeLauncherActivity();
         }

--- a/android/src/main/java/com/adyenreactnativesdk/component/googlepay/AdyenGooglePayComponent.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/googlepay/AdyenGooglePayComponent.kt
@@ -6,6 +6,7 @@ import com.adyen.checkout.components.model.payments.request.PaymentComponentData
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.googlepay.GooglePayComponent
 import com.adyen.checkout.googlepay.GooglePayConfiguration
+import com.adyenreactnativesdk.AdyenCheckout
 import com.adyenreactnativesdk.action.ActionHandler
 import com.adyenreactnativesdk.component.BaseModule
 import com.adyenreactnativesdk.component.BaseModuleException
@@ -105,7 +106,7 @@ class AdyenGooglePayComponent(context: ReactApplicationContext?) : BaseModule(co
                 GOOGLEPAY_REQUEST_CODE
             )
 
-            shared = this
+            AdyenCheckout.setGooglePayComponent(this)
             pendingPaymentDialogFragment = dialogFragment
             googlePayComponent = component
         }
@@ -122,7 +123,7 @@ class AdyenGooglePayComponent(context: ReactApplicationContext?) : BaseModule(co
             pendingPaymentDialogFragment = null
             googlePayComponent = null
         }
-        shared = null
+        AdyenCheckout.removeGooglePayComponent()
     }
 
     private fun onError(error: Exception) {
@@ -154,16 +155,15 @@ class AdyenGooglePayComponent(context: ReactApplicationContext?) : BaseModule(co
     companion object {
         private const val TAG = "GooglePayComponent"
         private const val COMPONENT_NAME = "AdyenGooglePay"
-        private const val GOOGLEPAY_REQUEST_CODE = 1001
+        internal const val GOOGLEPAY_REQUEST_CODE = 1001
         private val PAYMENT_METHOD_KEYS = setOf("paywithgoogle", "googlepay")
 
-        private var shared: AdyenGooglePayComponent? = null
-
         @JvmStatic
+        @Deprecated(
+            message = "This method is deprecated on beta-8",
+            replaceWith = ReplaceWith("AdyenCheckout.handleActivityResult(requestCode, resultCode, data)"))
         fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-            if (requestCode == GOOGLEPAY_REQUEST_CODE) {
-                shared?.handleActivityResult(resultCode, data)
-            }
+            AdyenCheckout.handleActivityResult(requestCode, resultCode, data)
         }
     }
 }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/AdyenInstantComponent.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/AdyenInstantComponent.kt
@@ -5,6 +5,7 @@ import com.adyen.checkout.components.model.payments.request.GenericPaymentMethod
 import com.adyen.checkout.components.model.payments.request.PaymentComponentData
 import com.adyen.checkout.components.model.payments.request.PaymentMethodDetails
 import com.adyen.checkout.components.model.payments.response.Action
+import com.adyenreactnativesdk.AdyenCheckout
 import com.adyenreactnativesdk.action.ActionHandler
 import com.adyenreactnativesdk.action.ActionHandlerConfiguration
 import com.adyenreactnativesdk.action.ActionHandlingInterface
@@ -78,6 +79,7 @@ class AdyenInstantComponent(context: ReactApplicationContext?) : BaseModule(cont
         appCompatActivity.runOnUiThread {
             actionHandler?.hide(appCompatActivity)
             actionHandler = null
+            AdyenCheckout.removeIntentHandler()
         }
     }
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,6 @@
             </intent-filter>
         </activity>
 
-        <service android:name="com.adyenreactnativesdk.component.dropin.AdyenDropInService" />
+        <service android:name="com.adyenreactnativesdk.component.dropin.AdyenDropInService" android:exported="false" />
     </application>
 </manifest>

--- a/example/android/app/src/main/java/com/adyenexample/MainActivity.java
+++ b/example/android/app/src/main/java/com/adyenexample/MainActivity.java
@@ -5,18 +5,13 @@ import android.os.Bundle;
 import android.util.Log;
 
 import com.adyenreactnativesdk.action.ActionHandler;
-import com.adyenreactnativesdk.component.dropin.AdyenDropInComponent;
+import com.adyenreactnativesdk.AdyenCheckout;
 import com.adyenreactnativesdk.component.googlepay.AdyenGooglePayComponent;
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
 
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    Log.d("MainActivity", "onCreate");
-    AdyenDropInComponent.setDropInLauncher(this);
-  }
+  private static final String TAG = "MainActivity";
 
   /**
    * Returns the name of the main component registered from JavaScript. This is used to schedule
@@ -28,16 +23,23 @@ public class MainActivity extends ReactActivity {
   }
 
   @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    Log.d(TAG, "onCreate");
+    AdyenCheckout.setLauncherActivity(this);
+  }
+
+  @Override
   public void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
-    Log.d("MainActivity", "onNewIntent");
-    ActionHandler.handleIntent(intent);
+    Log.d(TAG, "onNewIntent");
+    AdyenCheckout.handleIntent(intent);
   }
 
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
-    Log.d("MainActivity", "onActivityResult");
-    AdyenGooglePayComponent.handleActivityResult(requestCode, resultCode, data);
+    Log.d(TAG, "onActivityResult");
+    AdyenCheckout.handleActivityResult(requestCode, resultCode, data);
   }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -11,6 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4608m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
# Open PR

## Changes

### Feature

* add `AdyenCheckout` that could be used as a single point of interaction with SDK 

### Deprecated

* `AdyenGooglePayComponent.handleActivityResult(requestCode, resultCode, data)` replaced with `AdyenCheckout.handleActivityResult(requestCode, resultCode, data)`
* `AdyenDropInComponent.removeDropInLauncher()` replaced with `AdyenCheckout.removeLauncherActivity()`
* `AdyenDropInComponent.setDropInLauncher(activity)` replaced with `AdyenCheckout. setLauncherActivity(activity)` 
* `ActionHandler.handleIntent(intent)` replaced with `AdyenCheckout.handleIntent(intent)`

### Removed

* Deprecated `AdyenDropInComponent.handle(intent: Intent)` removed

### Misc

* update documentation
* update example code

