### PR TITLE
:bug: (googlepay) fix googlepay configuration key type

### DIFF
--- a/src/Core/configuration.ts
+++ b/src/Core/configuration.ts
@@ -38,7 +38,7 @@ export interface Configuration {
   applepay?: ApplePayConfiguration;
 
   /** Google Pay component configuration. */
-  google?: GooglePayConfiguration;
+  googlepay?: GooglePayConfiguration;
 }
 
 export interface DropInConfiguration {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

In the definition of type Configuration, `google` key is used instead of `googlepay`.

## Tested scenarios

- Payement with googlepay 

**Fixed issue**:  #175 

