### PR TITLE
dismiss dialog on hot reload

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/action/ActionHandler.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/action/ActionHandler.kt
@@ -103,7 +103,7 @@ class ActionHandler(
         }
     }
 
-    fun hide(activity: FragmentActivity) {
+    fun hide() {
         dialog.get()?.dismiss()
         dialog.clear()
         loadedComponent = null

--- a/android/src/main/java/com/adyenreactnativesdk/component/BaseModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/BaseModule.kt
@@ -24,6 +24,10 @@ abstract class BaseModule(context: ReactApplicationContext?) : ReactContextBaseJ
 
     protected var actionHandler: ActionHandler? = null
 
+    override fun onCatalystInstanceDestroy() {
+        actionHandler?.hide()
+    }
+
     protected fun sendEvent(eventName: String, map: ReadableMap?) {
         reactApplicationContext
             .getJSModule(RCTDeviceEventEmitter::class.java)

--- a/android/src/main/java/com/adyenreactnativesdk/component/googlepay/AdyenGooglePayComponent.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/googlepay/AdyenGooglePayComponent.kt
@@ -31,6 +31,10 @@ class AdyenGooglePayComponent(context: ReactApplicationContext?) : BaseModule(co
         return COMPONENT_NAME
     }
 
+    override fun onCatalystInstanceDestroy() {
+        pendingPaymentDialogFragment?.dismiss()
+    }
+
     @ReactMethod
     fun addListener(eventName: String?) { /* No JS events expected */ }
 

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/AdyenInstantComponent.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/AdyenInstantComponent.kt
@@ -77,7 +77,7 @@ class AdyenInstantComponent(context: ReactApplicationContext?) : BaseModule(cont
     @ReactMethod
     fun hide(success: Boolean?, message: ReadableMap?) {
         appCompatActivity.runOnUiThread {
-            actionHandler?.hide(appCompatActivity)
+            actionHandler?.hide()
             actionHandler = null
             AdyenCheckout.removeIntentHandler()
         }


### PR DESCRIPTION
Improved developer experience by dismissing the pending dialog fragment on hot reload.

How to proof:
1. Open the example app and open e.g. klarna
2. close the webview
3. hot reload
4. the dialog is no closable because the js bridge was destroyed