### PR TITLE
fixed hot realod

### DIFF
--- a/ios/Components/AdyenDropIn.swift
+++ b/ios/Components/AdyenDropIn.swift
@@ -14,12 +14,17 @@ final internal class AdyenDropIn: BaseModule {
 
     private var dropInComponent: DropInComponent?
 
+    override func invalidate() {
+        hide(false, event: [:])
+    }
+
     override func supportedEvents() -> [String]! { super.supportedEvents() }
+
     @objc
     func hide(_ success: NSNumber, event: NSDictionary) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            
+
             self.dropInComponent?.finalizeIfNeeded(with: success.boolValue) {
                 self.cleanUp()
                 self.dropInComponent = nil

--- a/ios/Components/ApplePayComponent.swift
+++ b/ios/Components/ApplePayComponent.swift
@@ -13,7 +13,12 @@ import React
 @objc(AdyenApplePay)
 final internal class ApplePayComponent: BaseModule {
 
+    override func invalidate() {
+        hide(false, event: [:])
+    }
+
     override func supportedEvents() -> [String]! { super.supportedEvents() }
+
     @objc
     func hide(_ success: NSNumber, event: NSDictionary) {
         DispatchQueue.main.async {[weak self] in
@@ -41,7 +46,7 @@ final internal class ApplePayComponent: BaseModule {
         } catch {
             return sendEvent(error: error)
         }
-        
+
 
         let apiContext = APIContext(environment: parser.environment, clientKey: clientKey)
         let applePayComponent: Adyen.ApplePayComponent

--- a/ios/Components/InstantComponent.swift
+++ b/ios/Components/InstantComponent.swift
@@ -12,13 +12,18 @@ import React
 
 @objc(AdyenInstant)
 final internal class InstantComponent: BaseModule {
+
+    override func invalidate() {
+        hide(false, event: [:])
+    }
+
     override func supportedEvents() -> [String]! { super.supportedEvents() }
 
     @objc
     func hide(_ success: NSNumber, event: NSDictionary) {
         DispatchQueue.main.async {[weak self] in
             guard let self = self else { return }
-            
+
             self.currentComponent?.finalizeIfNeeded(with: success.boolValue) {
                 self.cleanUp()
             }
@@ -47,7 +52,7 @@ final internal class InstantComponent: BaseModule {
         component.payment = parser.payment
         component.delegate = self
         currentComponent = component
-        
+
         DispatchQueue.main.async {
             component.initiatePayment()
         }
@@ -61,7 +66,7 @@ final internal class InstantComponent: BaseModule {
         } catch {
             return sendEvent(error: error)
         }
-        
+
         DispatchQueue.main.async { [weak self] in
             self?.actionHandler?.handle(action)
         }


### PR DESCRIPTION
Improved developer experience by hide the payment components.

How to proof:

Open the example app and dropin
hot reload
action sheet is not closable because the js bridge was destroyed