### PR TITLE
fixed requires main queue setup warning

### DIFF
--- a/ios/CSE/AdyenCSE.swift
+++ b/ios/CSE/AdyenCSE.swift
@@ -12,6 +12,9 @@ import React
 final internal class AdyenCSE: NSObject {
 
     @objc
+    override static func requiresMainQueueSetup() -> Bool { return false }
+
+    @objc
     func encryptCard(_ payload: NSDictionary,
                      publicKey: NSString,
                      resolver: RCTPromiseResolveBlock,

--- a/ios/Components/BaseModule.swift
+++ b/ios/Components/BaseModule.swift
@@ -12,7 +12,7 @@ import Adyen3DS2
 internal class BaseModule: RCTEventEmitter {
         
     @objc
-    override static func requiresMainQueueSetup() -> Bool { true }
+    override static func requiresMainQueueSetup() -> Bool { return true }
     override func stopObserving() { /* No JS events expected */ }
     override func startObserving() { /* No JS events expected */ }
     override open func supportedEvents() -> [String]! { Events.allCases.map(\.rawValue) }


### PR DESCRIPTION
Fixed:
```console
 WARN  Module AdyenCSE requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```