### PR TITLE
Clarify import path for projects with use_framework!

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ yarn add @adyen/react-native
 ### iOS integration
 
 1. run `pod install`
-2. add return URL handler to your `AppDelegate.m`
+2. add return URL handler to your `AppDelegate.m(m)`
 ```objc
 #import <adyen-react-native/ADYRedirectComponent.h>
 
@@ -46,6 +46,7 @@ yarn add @adyen/react-native
   return [ADYRedirectComponent applicationDidOpenURL:url];
 }
 ```
+3. If your `Podfile` has `use_frameworks!`, then change import path in `AppDelegate.m(m)` to use underscore(`_`) instead of hyphens(`_`)
 
 #### For ApplePay
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
I've been struggling a couple of days to get this Adyen library to compile on iOS. And finally, three days later found issue https://github.com/Adyen/adyen-react-native/issues/159, tried changing import path and boom it works. It was quite hard to google my way to this resolution. I hope this will help others.

**What's changed:**
- Changed README to clarify that in some projects AppDelegate can be suffixed with `.mm` if you've enabled fabric
- Added step to manually retype import path, replacing hyphens with underscores for projects with `use_frameworks!` in their `Podfile`.

**Other solutions**
Other packages seem to have solved this by naming their folders with different casing strategies, such as:
```
#import <Firebase.h>
#import "AppDelegate.h"
#import <React/RCTBundleURLProvider.h>
#import <adyen_react_native/ADYRedirectComponent.h>
```
Maybe the proper solution would be to instead rename the folder where `ADYRedirectComponent.h` resides is a more sustainable path making installation more straight forward. This however is outside of my scope of understand so I will not be authoring that PR.

## Tested scenarios
- Compiling iOS and launching app on simulator.


**Fixed issue**:  

```
AppDelegate.mm ... 'adyen-react-native/ADYRedirectComponent.h' file not found
```
