### PR TITLE
Final fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![React Native Logo](https://user-images.githubusercontent.com/2648655/198584674-f0c46e71-1c21-409f-857e-77acaa4daae0.png)
 
-# Adyen React Native [RELEASE CANDIDATE]
+# Adyen React Native
 
 > This project is currently under development. Timelines and scope are still to be defined.
 
@@ -46,7 +46,14 @@ yarn add @adyen/react-native
   return [ADYRedirectComponent applicationDidOpenURL:url];
 }
 ```
-3. If your `Podfile` has `use_frameworks!`, then change import path in `AppDelegate.m(m)` to use underscore(`_`) instead of hyphens(`_`)
+
+> ❕ If your `Podfile` has `use_frameworks!`, then change import path in `AppDelegate.m(m)` to use underscore(`_`) instead of hyphens(`-`):
+
+```objc
+#import <adyen_react_native/ADYRedirectComponent.h>
+```
+
+3. Add [custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) to your app.
 
 #### For ApplePay
 
@@ -129,7 +136,7 @@ const configuration: Configuration = {
   clientKey: '{YOUR_CLIENT_KEY}',
   countryCode: 'NL',
   amount: { currency: 'EUR', value: 1000 }, // Value in minor units
-  returnUrl: 'myapp://payment', // Custom URL scheme of your iOS app. This value is overridden for Android by `AdyenCheckout`. Can be send from your backend
+  returnUrl: 'myapp://payment', // Custom URL scheme of your iOS app. This value is overridden for Android by `AdyenCheckout`. You can also send this property from your backend.
 };
 ```
 
@@ -206,6 +213,8 @@ const handleSubmit = (paymentData, nativeComponent) => {
 ## Documentation
 
 - [Configuration][configuration]
+- [Localization][]
+- [UI Customization][]
 - [Error codes](/docs/Error%20codes.md)
 - [Drop-in documentation][adyen-docs-dropin]
 - [Component documentation][adyen-docs-components]
@@ -220,5 +229,7 @@ MIT license. For more information, see the LICENSE file.
 
 [client.key]: https://docs.adyen.com/online-payments/android/drop-in#client-key
 [configuration]: /docs/Configuration.md
+[localization]: /docs/Localization.md
+[customization]: /docs/Customization.md
 [adyen-docs-dropin]: https://docs.adyen.com/online-payments/react-native/drop-in
 [adyen-docs-components]: https://docs.adyen.com/online-payments/react-native/components

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ const handleSubmit = (paymentData, nativeComponent) => {
 ## Documentation
 
 - [Configuration][configuration]
-- [Localization][]
-- [UI Customization][]
+- [Localization][localization]
+- [UI Customization][customization]
 - [Error codes](/docs/Error%20codes.md)
 - [Drop-in documentation][adyen-docs-dropin]
 - [Component documentation][adyen-docs-components]

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -4,9 +4,9 @@
 
 - **environment** - Use `test`. When you are ready to go live, change the value to one of our [live environments](https://docs.adyen.com/online-payments/drop-in-web#testing-your-integration).
 - **clientKey** - A public key linked to your API credential, used for [client-side authentication](https://docs.adyen.com/development-resources/client-side-authentication).
-- **amount** - Amount to be displayed on the Pay Button. It expects an object with the minor units value and currency properties. For example, `{ value: 1000, currency: 'USD' }` is **10$**. For card pre-authorisation set amount to `0` (zero).
+- **amount** - Amount to be displayed on the Pay Button. It expects an object with the minor units value and currency properties. For example, `{ value: 1000, currency: 'USD' }` is **10$**. For card pre-authorisation set the amount to `0` (zero).
 - **countryCode** - The shopper's country code in ISO 3166-1 alpha-2 format. Example: `"NL"` or `"US"`.
-- **shopperLocale** - 🚧 Work in progress. In current version this property only localises payment methods names. Default OS's locale is used for localisation.
+- **shopperLocale** - 🚧 Work in progress. In the current version, this property only localizes payment method names. The default OS's locale is used for localization.
 - **returnUrl** - For iOS, this is the URL to your app, where the shopper should return, after a redirection. Maximum of 1024 characters. For more information on setting a custom URL scheme for your app, read the [Apple Developer documentation](https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app).
   For Android, this value is automatically overridden by `AdyenCheckout`.
 
@@ -17,12 +17,12 @@
 - **enabled** - Enable/Disable all analytics. Defaults to `true`. ⚠️ This feature only available from v68 of Adyen API
 - **payload** - Data to be sent along with the event data
 
-## React Native SDK provides following configurations for components:
+## React Native SDK provides the following configurations for components:
 
 ### DropIn component
 
 - **showPreselectedStoredPaymentMethod** - Determines whether to enable the preselected stored payment method view step. Defaults to `true`.
-- **skipListWhenSinglePaymentMethod** - Determines whether to enable skipping payment list step when there is only one non-instant payment method. Defaults to `false`.
+- **skipListWhenSinglePaymentMethod** - If set to `true` allows to skip payment methods list step when there is only one non-instant payment method. Defaults to `false`.
 
 ### Card component
 
@@ -37,9 +37,9 @@
 
 ### ApplePay component
 
-- **merchantID** - The merchant identifier for apple pay.
-- **merchantName** - The merchant name. Used for generation of collection of `PKPaymentSummaryItem`.
-- **allowOnboarding** - The flag to toggle onboarding. If `true`, allow the shopper to add cards to Apple Pay if non exists yet. If `false`, Apple Pay is disabled when the shopper doesn’t have supported cards on Apple Pay wallet. Default is `false`.
+- **merchantID** - The [Merchant ID](https://developer.apple.com/library/archive/ApplePay_Guide/Configuration.html) for Apple Pay.
+- **merchantName** - The merchant name. Used for generation of a collection of `PKPaymentSummaryItem`.
+- **allowOnboarding** - The flag to toggle onboarding. If `true`, allow the shopper to add cards to the Apple Pay if non exists yet. If `false`, Apple Pay is disabled when the shopper doesn’t have supported cards on Apple Pay wallet. Default is `false`.
 
 ### GooglePay component
 
@@ -52,7 +52,7 @@
 - **emailRequired** - Set to `true` to request an email address.
 - **shippingAddressRequired** - Set to `true` to request a full shipping address.
 - **existingPaymentMethodRequired** - If set to `true` then the **IsReadyToPayResponse** object includes an additional paymentMethodPresent property that describes the visitor's readiness to pay with one or more payment methods specified in **allowedPaymentMethods**.
-- **googlePayEnvironment** - The environment to be used by GooglePay. Should be either `WalletConstants.ENVIRONMENT_TEST` or `WalletConstants.ENVIRONMENT_PRODUCTION`. By default is using **environment** from root.
+- **googlePayEnvironment** - The environment to be used by GooglePay. Should be either `WalletConstants.ENVIRONMENT_TEST` or `WalletConstants.ENVIRONMENT_PRODUCTION`. By default is using **environment** from the root.
 
 ## Example
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -21,7 +21,7 @@
 
 ### DropIn component
 
-- **showPreselectedStoredPaymentMethod** - Determines whether to enable preselected stored payment method view step. Defaults to `true`.
+- **showPreselectedStoredPaymentMethod** - Determines whether to enable the preselected stored payment method view step. Defaults to `true`.
 - **skipListWhenSinglePaymentMethod** - Determines whether to enable skipping payment list step when there is only one non-instant payment method. Defaults to `false`.
 
 ### Card component

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -27,7 +27,7 @@
 ### Card component
 
 - **showStorePaymentField** - Indicates if the field for storing the card payment method should be displayed in the form. Defaults to `true`.
-- **holderNameRequired** - Indicates if the field for entering the holder name should be displayed in the form. Defaults to false.
+- **holderNameRequired** - Indicates if the field for entering the holder name should be displayed in the form. Defaults to `false`.
 - **hideCvcStoredCard** - Indicates whether to show the security code field on a stored card payment. Defaults to false.
 - **hideCvc** - Indicates whether to show the security code field at all. Defaults to false.
 - **addressVisibility** - Indicates the display mode of the billing address form. Options: `"none"`, `"postal"`, `"full"`. Defaults to `"none"`.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,48 +1,58 @@
 # Configuration
 
 ## Root configurations
-* **environment** - Use `test`. When you are ready to go live, change the value to one of our [live environments](https://docs.adyen.com/online-payments/drop-in-web#testing-your-integration).
-* **clientKey** - A public key linked to your API credential, used for [client-side authentication](https://docs.adyen.com/development-resources/client-side-authentication).
-* **amount** - Amount to be displayed on the Pay Button. It expects an object with the minor units value and currency properties. For example, `{ value: 1000, currency: 'USD' }` is **10$**. For card pre-authorisation set amount to `0` (zero).
-* **countryCode** - The shopper's country code in ISO 3166-1 alpha-2 format. Example: `"NL"` or `"US"`. 
-* **shopperLocale** - 🚧 Work in progress. In current version this property only localises payment methods names. Default OS's locale is used for localisation.
-* **returnUrl** - For iOS, this is the URL to your app, where the shopper should return, after a redirection. Maximum of 1024 characters. For more information on setting a custom URL scheme for your app, read the [Apple Developer documentation](https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app).
-For Android, this value is automatically overridden by `AdyenCheckout`.
 
-> ⚠️ To show the amount on the **Pay** button both *amount* and *countryCode* must be set.
+- **environment** - Use `test`. When you are ready to go live, change the value to one of our [live environments](https://docs.adyen.com/online-payments/drop-in-web#testing-your-integration).
+- **clientKey** - A public key linked to your API credential, used for [client-side authentication](https://docs.adyen.com/development-resources/client-side-authentication).
+- **amount** - Amount to be displayed on the Pay Button. It expects an object with the minor units value and currency properties. For example, `{ value: 1000, currency: 'USD' }` is **10$**. For card pre-authorisation set amount to `0` (zero).
+- **countryCode** - The shopper's country code in ISO 3166-1 alpha-2 format. Example: `"NL"` or `"US"`.
+- **shopperLocale** - 🚧 Work in progress. In current version this property only localises payment methods names. Default OS's locale is used for localisation.
+- **returnUrl** - For iOS, this is the URL to your app, where the shopper should return, after a redirection. Maximum of 1024 characters. For more information on setting a custom URL scheme for your app, read the [Apple Developer documentation](https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app).
+  For Android, this value is automatically overridden by `AdyenCheckout`.
+
+> ⚠️ To show the amount on the **Pay** button both _amount_ and _countryCode_ must be set.
+
+## Analytics
+
+- **enabled** - Enable/Disable all analytics. Defaults to `true`. ⚠️ This feature only availalbe fron v68 of Adyen API
+- **payload** - Data to be sent along with the event data
 
 ## React Native SDK provides following configurations for components:
 
 ### DropIn component
-* **showPreselectedStoredPaymentMethod** - Determines whether to enable preselected stored payment method view step. Defaults to `true`.
-* **skipListWhenSinglePaymentMethod** - Determines whether to enable skipping payment list step when there is only one non-instant payment method. Defaults to `false`.
+
+- **showPreselectedStoredPaymentMethod** - Determines whether to enable preselected stored payment method view step. Defaults to `true`.
+- **skipListWhenSinglePaymentMethod** - Determines whether to enable skipping payment list step when there is only one non-instant payment method. Defaults to `false`.
 
 ### Card component
-* **showStorePaymentField** - Indicates if the field for storing the card payment method should be displayed in the form. Defaults to true.
-* **holderNameRequired** - Indicates if the field for entering the holder name should be displayed in the form. Defaults to false.
-* **hideCvcStoredCard** - Indicates whether to show the security code field on a stored card payment. Defaults to false.
-* **hideCvc** - Indicates whether to show the security code field at all. Defaults to false.
-* **addressVisibility** - Indicates the display mode of the billing address form. Options: `"none"`, `"postal"`, `"full"`. Defaults to `"none"`.
-* **kcpVisibility** - Indicates whether to show the security fields for South Korea issued cards. Options: `"show"` or `"hide"`. Defaults to `"hide"`.
-* **socialSecurity** - Indicates the visibility mode for the social security number field (CPF/CNPJ) for Brazilian cards. Options: "show" or `"hide"`. Defaults to `"hide"`.
-* **supported** - The list of allowed card types. By default uses list of `brands` from payment method. Fallbacks to list of all known cards.
+
+- **showStorePaymentField** - Indicates if the field for storing the card payment method should be displayed in the form. Defaults to true.
+- **holderNameRequired** - Indicates if the field for entering the holder name should be displayed in the form. Defaults to false.
+- **hideCvcStoredCard** - Indicates whether to show the security code field on a stored card payment. Defaults to false.
+- **hideCvc** - Indicates whether to show the security code field at all. Defaults to false.
+- **addressVisibility** - Indicates the display mode of the billing address form. Options: `"none"`, `"postal"`, `"full"`. Defaults to `"none"`.
+- **kcpVisibility** - Indicates whether to show the security fields for South Korea issued cards. Options: `"show"` or `"hide"`. Defaults to `"hide"`.
+- **socialSecurity** - Indicates the visibility mode for the social security number field (CPF/CNPJ) for Brazilian cards. Options: "show" or `"hide"`. Defaults to `"hide"`.
+- **supported** - The list of allowed card types. By default uses list of `brands` from payment method. Fallbacks to list of all known cards.
 
 ### ApplePay component
-* **merchantID** - The merchant identifier for apple pay.
-* **merchantName** - The merchant name. Used for generation of collection of `PKPaymentSummaryItem`.
-* **allowOnboarding** - The flag to toggle onboarding. If `true`, allow the shopper to add cards to Apple Pay if non exists yet. If `false`, Apple Pay is disabled when the shopper doesn’t have supported cards on Apple Pay wallet. Default is `false`.
+
+- **merchantID** - The merchant identifier for apple pay.
+- **merchantName** - The merchant name. Used for generation of collection of `PKPaymentSummaryItem`.
+- **allowOnboarding** - The flag to toggle onboarding. If `true`, allow the shopper to add cards to Apple Pay if non exists yet. If `false`, Apple Pay is disabled when the shopper doesn’t have supported cards on Apple Pay wallet. Default is `false`.
 
 ### GooglePay component
-* **merchantAccount** - The merchant account to be put in the payment token from Google to Adyen. By default uses value from `brands`
-* **allowedCardNetworks** - One or more card networks that you support, also supported by the Google Pay API.
-* **allowedAuthMethods** - Fields supported to authenticate a card transaction.
-* **totalPriceStatus** - The status of the total price used. Defaults to `"FINAL"`.
-* **allowPrepaidCards** - Set to `false` if you don't support prepaid cards. Default: The prepaid card class is supported for the card networks specified.
-* **billingAddressRequired** - Set to `true` if you require a billing address. A billing address should only be requested if it's required to process the transaction.
-* **emailRequired** - Set to `true` to request an email address.
-* **shippingAddressRequired** - Set to `true` to request a full shipping address.
-* **existingPaymentMethodRequired** - If set to `true` then the **IsReadyToPayResponse** object includes an additional paymentMethodPresent property that describes the visitor's readiness to pay with one or more payment methods specified in **allowedPaymentMethods**.
-* **googlePayEnvironment** - The environment to be used by GooglePay. Should be either `WalletConstants.ENVIRONMENT_TEST` or `WalletConstants.ENVIRONMENT_PRODUCTION`. By default is using **environment** from root.
+
+- **merchantAccount** - The merchant account to be put in the payment token from Google to Adyen. By default uses value from `brands`
+- **allowedCardNetworks** - One or more card networks that you support, also supported by the Google Pay API.
+- **allowedAuthMethods** - Fields supported to authenticate a card transaction.
+- **totalPriceStatus** - The status of the total price used. Defaults to `"FINAL"`.
+- **allowPrepaidCards** - Set to `false` if you don't support prepaid cards. Default: The prepaid card class is supported for the card networks specified.
+- **billingAddressRequired** - Set to `true` if you require a billing address. A billing address should only be requested if it's required to process the transaction.
+- **emailRequired** - Set to `true` to request an email address.
+- **shippingAddressRequired** - Set to `true` to request a full shipping address.
+- **existingPaymentMethodRequired** - If set to `true` then the **IsReadyToPayResponse** object includes an additional paymentMethodPresent property that describes the visitor's readiness to pay with one or more payment methods specified in **allowedPaymentMethods**.
+- **googlePayEnvironment** - The environment to be used by GooglePay. Should be either `WalletConstants.ENVIRONMENT_TEST` or `WalletConstants.ENVIRONMENT_PRODUCTION`. By default is using **environment** from root.
 
 ## Example
 
@@ -55,8 +65,10 @@ For Android, this value is automatically overridden by `AdyenCheckout`.
     currency: 'EUR',
     value: 1000,
   },
-  merchantAccount: '{YOUR_MERCHANT_ACCOUNT}',
   returnUrl: 'myapp://adyencheckout',
+  analytics: {
+    enable: true
+  }
   dropin: {
     skipListWhenSinglePaymentMethod: true,
     showPreselectedStoredPaymentMethod: false
@@ -73,9 +85,8 @@ For Android, this value is automatically overridden by `AdyenCheckout`.
     merchantName: '{YOUR_MERCHANT_NAME}',
     allowOnboarding: true
   },
-  googlepay: {},
-  style: {
-    // Work in progress
-  },
+  googlepay: {
+    billingAddressRequired: true,
+  }
 }
 ```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -14,7 +14,7 @@
 
 ## Analytics
 
-- **enabled** - Enable/Disable all analytics. Defaults to `true`. ⚠️ This feature only availalbe fron v68 of Adyen API
+- **enabled** - Enable/Disable all analytics. Defaults to `true`. ⚠️ This feature only available from v68 of Adyen API
 - **payload** - Data to be sent along with the event data
 
 ## React Native SDK provides following configurations for components:

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -26,7 +26,7 @@
 
 ### Card component
 
-- **showStorePaymentField** - Indicates if the field for storing the card payment method should be displayed in the form. Defaults to true.
+- **showStorePaymentField** - Indicates if the field for storing the card payment method should be displayed in the form. Defaults to `true`.
 - **holderNameRequired** - Indicates if the field for entering the holder name should be displayed in the form. Defaults to false.
 - **hideCvcStoredCard** - Indicates whether to show the security code field on a stored card payment. Defaults to false.
 - **hideCvc** - Indicates whether to show the security code field at all. Defaults to false.

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,135 +1,99 @@
 apply plugin: "com.android.application"
+apply plugin: "com.facebook.react"
 
 import com.android.build.OutputFile
 
 /**
- * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
- * and bundleReleaseJsAndAssets).
- * These basically call `react-native bundle` with the correct arguments during the Android build
- * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
- * bundle directly from the development server. Below you can see all the possible configurations
- * and their defaults. If you decide to add a configuration block, make sure to add it before the
- * `apply from: "../../node_modules/react-native/react.gradle"` line.
- *
- * project.ext.react = [
- *   // the name of the generated asset file containing your JS bundle
- *   bundleAssetName: "index.android.bundle",
- *
- *   // the entry file for bundle generation. If none specified and
- *   // "index.android.js" exists, it will be used. Otherwise "index.js" is
- *   // default. Can be overridden with ENTRY_FILE environment variable.
- *   entryFile: "index.android.js",
- *
- *   // https://reactnative.dev/docs/performance#enable-the-ram-format
- *   bundleCommand: "ram-bundle",
- *
- *   // whether to bundle JS and assets in debug mode
- *   bundleInDebug: false,
- *
- *   // whether to bundle JS and assets in release mode
- *   bundleInRelease: true,
- *
- *   // whether to bundle JS and assets in another build variant (if configured).
- *   // See http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Variants
- *   // The configuration property can be in the following formats
- *   //         'bundleIn${productFlavor}${buildType}'
- *   //         'bundleIn${buildType}'
- *   // bundleInFreeDebug: true,
- *   // bundleInPaidRelease: true,
- *   // bundleInBeta: true,
- *
- *   // whether to disable dev mode in custom build variants (by default only disabled in release)
- *   // for example: to disable dev mode in the staging build type (if configured)
- *   devDisabledInStaging: true,
- *   // The configuration property can be in the following formats
- *   //         'devDisabledIn${productFlavor}${buildType}'
- *   //         'devDisabledIn${buildType}'
- *
- *   // the root of your project, i.e. where "package.json" lives
- *   root: "../../",
- *
- *   // where to put the JS bundle asset in debug mode
- *   jsBundleDirDebug: "$buildDir/intermediates/assets/debug",
- *
- *   // where to put the JS bundle asset in release mode
- *   jsBundleDirRelease: "$buildDir/intermediates/assets/release",
- *
- *   // where to put drawable resources / React Native assets, e.g. the ones you use via
- *   // require('./image.png')), in debug mode
- *   resourcesDirDebug: "$buildDir/intermediates/res/merged/debug",
- *
- *   // where to put drawable resources / React Native assets, e.g. the ones you use via
- *   // require('./image.png')), in release mode
- *   resourcesDirRelease: "$buildDir/intermediates/res/merged/release",
- *
- *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
- *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
- *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
- *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
- *   // for example, you might want to remove it from here.
- *   inputExcludes: ["android/**", "ios/**"],
- *
- *   // override which node gets called and with what additional arguments
- *   nodeExecutableAndArgs: ["node"],
- *
- *   // supply additional arguments to the packager
- *   extraPackagerArgs: []
- * ]
+ * This is the configuration block to customize your React Native Android app.
+ * By default you don't need to apply any configuration, just uncomment the lines you need.
  */
+react {
+    /* Folders */
+    //   The root of your project, i.e. where "package.json" lives. Default is '..'
+    // root = file("../")
+    //   The folder where the react-native NPM package is. Default is ../node_modules/react-native
+    // reactNativeDir = file("../node_modules/react-native")
+    //   The folder where the react-native Codegen package is. Default is ../node_modules/react-native-codegen
+    // codegenDir = file("../node_modules/react-native-codegen")
+    //   The cli.js file which is the React Native CLI entrypoint. Default is ../node_modules/react-native/cli.js
+    // cliFile = file("../node_modules/react-native/cli.js")
 
-project.ext.react = [
-    enableHermes: false,  // clean and rebuild if changing
-]
+    /* Variants */
+    //   The list of variants to that are debuggable. For those we're going to
+    //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
+    //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
+    // debuggableVariants = ["liteDebug", "prodDebug"]
 
-apply from: "../../node_modules/react-native/react.gradle"
+    /* Bundling */
+    //   A list containing the node command and its flags. Default is just 'node'.
+    // nodeExecutableAndArgs = ["node"]
+    //
+    //   The command to run when bundling. By default is 'bundle'
+    // bundleCommand = "ram-bundle"
+    //
+    //   The path to the CLI configuration file. Default is empty.
+    // bundleConfig = file(../rn-cli.config.js)
+    //
+    //   The name of the generated asset file containing your JS bundle
+    // bundleAssetName = "MyApplication.android.bundle"
+    //
+    //   The entry file for bundle generation. Default is 'index.android.js' or 'index.js'
+    // entryFile = file("../js/MyApplication.android.js")
+    //
+    //   A list of extra flags to pass to the 'bundle' commands.
+    //   See https://github.com/react-native-community/cli/blob/main/docs/commands.md#bundle
+    // extraPackagerArgs = []
+
+    /* Hermes Commands */
+    //   The hermes compiler command to run. By default it is 'hermesc'
+    // hermesCommand = "$rootDir/my-custom-hermesc/bin/hermesc"
+    //
+    //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
+    // hermesFlags = ["-O", "-output-source-map"]
+}
 
 /**
- * Set this to true to create two separate APKs instead of one:
- *   - An APK that only works on ARM devices
- *   - An APK that only works on x86 devices
- * The advantage is the size of the APK is reduced by about 4MB.
- * Upload all the APKs to the Play Store and people will download
- * the correct one based on the CPU architecture of their device.
+ * Set this to true to create four separate APKs instead of one,
+ * one for each native architecture. This is useful if you don't
+ * use App Bundles (https://developer.android.com/guide/app-bundle/)
+ * and want to have separate APKs to upload to the Play Store.
  */
 def enableSeparateBuildPerCPUArchitecture = false
 
 /**
- * Run Proguard to shrink the Java bytecode in release builds.
+ * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
 def enableProguardInReleaseBuilds = false
 
 /**
- * The preferred build flavor of JavaScriptCore.
+ * The preferred build flavor of JavaScriptCore (JSC)
  *
  * For example, to use the international variant, you can use:
  * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
  *
  * The international variant includes ICU i18n library and necessary data
  * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
- * give correct results when using with locales other than en-US.  Note that
+ * give correct results when using with locales other than en-US. Note that
  * this variant is about 6MiB larger per architecture than default.
  */
 def jscFlavor = 'org.webkit:android-jsc-intl:+'
 
 /**
- * Whether to enable the Hermes VM.
- *
- * This should be set on project.ext.react and mirrored here.  If it is not set
- * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
- * and the benefits of using Hermes will therefore be sharply reduced.
+ * Private function to get the list of Native Architectures you want to build.
+ * This reads the value from reactNativeArchitectures in your gradle.properties
+ * file and works together with the --active-arch-only flag of react-native run-android.
  */
-def enableHermes = project.ext.react.get("enableHermes", false);
-
-/**
- * Architectures to build native code for in debug.
- */
-def nativeArchitectures = project.getProperties().get("reactNativeDebugArchitectures")
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
 
 android {
     ndkVersion rootProject.ext.ndkVersion
 
     compileSdkVersion rootProject.ext.compileSdkVersion
 
+    namespace "com.adyenexample"
     defaultConfig {
         applicationId "com.adyenexample"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -138,12 +102,13 @@ android {
         versionName "1.0"
         manifestPlaceholders = [redirectScheme: rootProject.ext.adyenReactNativeRedirectScheme]
     }
+
     splits {
         abi {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+            include (*reactNativeArchitectures())
         }
     }
     signingConfigs {
@@ -157,11 +122,6 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
-            if (nativeArchitectures) {
-                ndk {
-                    abiFilters nativeArchitectures.split(',')
-                }
-            }
         }
         release {
             // Caution! In production, you need to generate your own keystore file.
@@ -190,39 +150,22 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
-    //noinspection GradleDynamicVersion
-    implementation "com.facebook.react:react-native:+"  // From node_modules
-
+    // The version of react-native is set by the React Native Gradle Plugin
+    implementation("com.facebook.react:react-android")
     implementation project(path: ':adyenreactnativesdk')
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.0.0")
 
-    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
-        exclude group:'com.facebook.fbjni'
-    }
-
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
-        exclude group:'com.facebook.flipper'
         exclude group:'com.squareup.okhttp3', module:'okhttp'
     }
 
-    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
-        exclude group:'com.facebook.flipper'
-    }
-
-    if (enableHermes) {
-        def hermesPath = "../../node_modules/hermes-engine/android/";
-        debugImplementation files(hermesPath + "hermes-debug.aar")
-        releaseImplementation files(hermesPath + "hermes-release.aar")
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}")
+    if (hermesEnabled.toBoolean()) {
+        implementation("com.facebook.react:hermes-android")
     } else {
         implementation jscFlavor
     }
-}
-
-// Run this once to be able to run the application with BUCK
-// puts all compile dependencies into folder libs for BUCK to use
-task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.implementation
-    into 'libs'
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.adyenexample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,37 +2,20 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 32
-        targetSdkVersion = 30
-        ndkVersion = "21.4.7075529"
+        compileSdkVersion = 33
+        targetSdkVersion = 33
+
+        // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
+        ndkVersion = "23.1.7779620"
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:7.3.1')
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        mavenCentral()
-        mavenLocal()
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url("$rootDir/../node_modules/react-native/android")
-        }
-        maven {
-            // Android JSC is installed from npm
-            url("$rootDir/../node_modules/jsc-android/dist")
-        }
-
-        google()
-        maven { url 'https://www.jitpack.io' }
+        classpath("com.android.tools.build:gradle:7.3.1")
+        classpath("com.facebook.react:react-native-gradle-plugin")
     }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -9,9 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-org.gradle.jvmargs=-Xmx4096m
+# Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
@@ -26,4 +25,20 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.182.0
+FLIPPER_VERSION=0.125.0
+
+# Use this property to specify which architecture you want to build.
+# You can also override it from the CLI using
+# ./gradlew <task> -PreactNativeArchitectures=x86_64
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+
+# Use this property to enable support to the new architecture.
+# This will allow you to use TurboModules and the Fabric render in
+# your application. You should enable this flag either if you want
+# to write custom TurboModules/Fabric components OR use libraries that
+# are providing them.
+newArchEnabled=false
+
+# Use this property to enable or disable the Hermes JS engine.
+# If set to false, you will be using JSC instead.
+hermesEnabled=true

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -4,3 +4,4 @@ include ':app'
 
 include ':adyenreactnativesdk'
 project(':adyenreactnativesdk').projectDir = new File(rootProject.projectDir, '../../android')
+includeBuild('../node_modules/react-native-gradle-plugin')

--- a/example/src/Configuration.js
+++ b/example/src/Configuration.js
@@ -27,7 +27,7 @@ export const ENVIRONMENT = {
   /** @type {import('@adyen/react-native').Environment} */
   environment: 'test',
   apiKey: '{YOUR_DEMO_SERVER_API_KEY}',
-  url: 'https://checkout-test.adyen.com/v67/',
+  url: 'https://checkout-test.adyen.com/v70/',
   publicKey: '{YOUR_PUBLIC_KEY}',
   clientKey: '{YOUR_CLIENT_KEY}',
   returnUrl: 'myapp://payment', // Only used for iOS

--- a/src/AdyenCheckoutContext.tsx
+++ b/src/AdyenCheckoutContext.tsx
@@ -90,9 +90,13 @@ const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
       data: any,
       nativeComponent: AdyenActionComponent
     ) => {
+      const checkoutAttemptId = analytics.current?.checkoutAttemptId;
+      if (data.paymentMethod && checkoutAttemptId) {
+        data.paymentMethod.checkoutAttemptId = checkoutAttemptId;
+      }
+
       const payload = {
         ...data,
-        checkoutAttemptId: analytics.current?.checkoutAttemptIdSession?.id,
         returnUrl: data.returnUrl ?? configuration.returnUrl,
       };
       onSubmit(payload, nativeComponent);

--- a/src/Core/Analytics/Analytics.ts
+++ b/src/Core/Analytics/Analytics.ts
@@ -14,11 +14,15 @@ class Analytics {
     enabled: true,
   };
 
-  public checkoutAttemptIdSession?: CheckoutAttemptIdSession = undefined;
+  private checkoutAttemptIdSession?: CheckoutAttemptIdSession = undefined;
   public props;
   private readonly logTelemetry;
   private readonly queue = new EventsQueue();
   public readonly collectId;
+
+  public get checkoutAttemptId(): string | undefined {
+    return this.checkoutAttemptIdSession?.id;
+  }
 
   constructor({
     clientKey,


### PR DESCRIPTION
# Open PR

## Changes

* update `example/android/app/build.gradle` to latest React-Native v0.71+ template
* fix "deprecated namespace in Manifest" warning
* update default example API version to v70 to enable telemetry
* fix placement of `checkoutAttemptId` in payment details payload