### PR TITLE
Update README.md to clarify we should not restore savedInstanceState

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ import android.os.Bundle;
 
 @Override
 protected void onCreate(Bundle savedInstanceState) {
-  super.onCreate(savedInstanceState);
+  super.onCreate(null);
   AdyenCheckout.setLauncherActivity(this);
 }
 ```


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
We found a crash in our app in a piece of code we added because of these installation instructions.
<img width="1538" alt="Screenshot 2023-06-27 at 08 53 03" src="https://github.com/Adyen/adyen-react-native/assets/457653/fb928bd7-a641-4440-861a-27f03d78c564">
In this projects README.md it's suggested that consumers add a `onCreate() @override` and pass in `Bundle savedInstanceState` to it, this is the same as is done in [ReactFragment main file](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java#L44-L47) that we are overriding. However from this [discussion over at `react-native-screens`](https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067) they talk and reason about RN Apps not being able to restore from background on Android if the app has been killed.

This is also the way they describe it in installation instructions of the react-navigation package. I can't help to think that mDelegate in https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java#L44-L47 is now missing data it's expecting, but a lot of people smarter than me have poked at this issue it seems from the discussion above.

**What am I expecting of this library?** 
1. Would calling onCreate with null like this mess with this library in any way?
2. Nothing more really, but if you'd like to clarify your Readme about this issue now you are aware :)

Have a great day!