### PR TITLE
Fixes #246 - crash when selecting Online Banking PL payment method

### DIFF
--- a/src/AdyenNativeModules.tsx
+++ b/src/AdyenNativeModules.tsx
@@ -182,11 +182,11 @@ export function getNativeComponent(
     throw new Error(UNKNOWN_PAYMENT_METHOD_ERROR + typeName);
   }
 
-  if (UNSUPPORTED_PAYMENT_METHODS.includes(type)) {
+  if (UNSUPPORTED_PAYMENT_METHODS.includes(typeName)) {
     throw new Error(UNSUPPORTED_PAYMENT_METHOD_ERROR + typeName);
   }
 
-  if (NATIVE_COMPONENTS.includes(type)) {
+  if (NATIVE_COMPONENTS.includes(typeName)) {
     return {
       nativeComponent: new AdyenNativeComponentWrapper(AdyenDropIn),
       paymentMethod: paymentMethod,


### PR DESCRIPTION
## Summary
The fields `NATIVE_COMPONENTS` and `UNSUPPORTED_PAYMENT_METHODS` contains uppercase letters such as `mealVoucher_FR_natixis, onlineBanking_PL`

but the field that is comparing it is lowered case 
`const type = typeName.toLowerCase();`

So the fix is just to use `typeName `which contains the original type

**Fixed issue**:  #246 
