### PR TITLE
fix: Use CFBundleName rather than CFBundleIdentifier for finding the …

### DIFF
--- a/ios/Components/AdyenApperance.swift
+++ b/ios/Components/AdyenApperance.swift
@@ -21,7 +21,7 @@ internal class AdyenAppearanceLoader: NSObject {
     private static let expectedClassName = "AdyenAppearance"
     
     static func findStyle() -> Adyen.DropInComponent.Style? {
-        let bundleName = Bundle.main.bundleIdentifier?.components(separatedBy: ".").last ?? ""
+        let bundleName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? ""
         guard let nsClass = NSClassFromString("\(bundleName).\(expectedClassName)"),
               let appearanceProvider = nsClass as? AdyenAppearanceProvider.Type else {
             adyenPrint("AdyenAppearance: class \("\(bundleName).\(expectedClassName)") not found or does not conform to AdyenAppearanceProvider protocol")


### PR DESCRIPTION
…AdyenAppearance class

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Use CFBundleName rather than CFBundleIdentifier for finding the AdyenAppearance class

## Tested scenarios
N/A

**Fixed issue**:  

https://github.com/Adyen/adyen-react-native/issues/8#issuecomment-1620102660
