### PR TITLE
Mark Boletobancario as unsupported

### DIFF
--- a/src/ComponentMap.ts
+++ b/src/ComponentMap.ts
@@ -56,6 +56,12 @@ export const UNSUPPORTED_PAYMENT_METHODS = [
   'dragonpay_otc_banking',
   'dragonpay_otc_non_banking',
   'dragonpay_otc_philippines',
+  'boletobancario',
+  'boletobancario_bancodobrasil',
+  'boletobancario_bradesco',
+  'boletobancario_hsbc',
+  'boletobancario_itau',
+  'boletobancario_santander',
   /** Voucher payment methods that are not yet supported */
 
   /** Giftcard payment methods that are not yet supported */
@@ -103,15 +109,6 @@ export const NATIVE_COMPONENTS = [
   'paybybank',
   'wallet_IN',
   /** issuerList */
-
-  /** Voucher */
-  'boletobancario',
-  'boletobancario_bancodobrasil',
-  'boletobancario_bradesco',
-  'boletobancario_hsbc',
-  'boletobancario_itau',
-  'boletobancario_santander',
-  /** Voucher */
 
   /** Await */
   'blik',


### PR DESCRIPTION
# Open PR

## Changes

* `AdyenCheckout` on Android now throws an exception when attempting to pay with Boletobancario instead of failing with an unknown error.