### PR TITLE
Use CFBundleExecutable instead of CFBundleIdentifier

### DIFF
--- a/ios/Components/AdyenApperance.swift
+++ b/ios/Components/AdyenApperance.swift
@@ -22,7 +22,7 @@ internal class AdyenAppearanceLoader: NSObject {
     private static let bundleExecutableKey = "CFBundleExecutable"
     
     static func findStyle() -> Adyen.DropInComponent.Style? {
-        var appearanceProviders = Bundle.allBundles
+        let appearanceProviders = Bundle.allBundles
             .compactMap { $0.infoDictionary?[bundleExecutableKey] as? String }
             .map { $0.replacingOccurrences(of: " ", with: "_")}
             .compactMap { NSClassFromString("\($0).\(expectedClassName)") }

--- a/ios/Components/AdyenApperance.swift
+++ b/ios/Components/AdyenApperance.swift
@@ -19,16 +19,19 @@ public protocol AdyenAppearanceProvider: AnyObject {
 internal class AdyenAppearanceLoader: NSObject {
     
     private static let expectedClassName = "AdyenAppearance"
+    private static let bundleExecutableKey = "CFBundleExecutable"
     
     static func findStyle() -> Adyen.DropInComponent.Style? {
-        let bundleName = Bundle.main.bundleIdentifier?.components(separatedBy: ".").last ?? ""
-        guard let nsClass = NSClassFromString("\(bundleName).\(expectedClassName)"),
-              let appearanceProvider = nsClass as? AdyenAppearanceProvider.Type else {
-            adyenPrint("AdyenAppearance: class \("\(bundleName).\(expectedClassName)") not found or does not conform to AdyenAppearanceProvider protocol")
+        var appearanceProviders = Bundle.allBundles
+            .compactMap { $0.infoDictionary?[bundleExecutableKey] as? String }
+            .map { $0.replacingOccurrences(of: " ", with: "_")}
+            .compactMap { NSClassFromString("\($0).\(expectedClassName)") }
+            .compactMap { $0 as? AdyenAppearanceProvider.Type }
+        
+        guard let appearanceProvider = appearanceProviders.first else {
+            adyenPrint("AdyenAppearance: class not linked or does not conform to AdyenAppearanceProvider protocol")
             return nil
         }
         return appearanceProvider.createStyle()
     }
 }
-
-


### PR DESCRIPTION
# Open PR

## Changes

* `AdeyncChecout` on iOS now uses `CFBundleExecutable` property to find `AdyenAppearance` class
