### PR TITLE
Fix android crash on invalid actiondata

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/component/dropin/AdyenDropInComponent.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/dropin/AdyenDropInComponent.kt
@@ -93,7 +93,7 @@ class AdyenDropInComponent(context: ReactApplicationContext?) : BaseModule(conte
         try {
             val jsonObject = ReactNativeJson.convertMapToJson(actionMap)
             listener.onAction(jsonObject)
-        } catch (e: JSONException) {
+        } catch (e: Exception) {
             sendErrorEvent(BaseModuleException.InvalidAction(e))
         }
     }


### PR DESCRIPTION
## Summary
When the handle function was invoked from an invalid action response the android app would crash.
In my case this would result in a fatal crash with the error description:
sdkData not found for type paymentMethodType - paypal

Changing the catch handler to catch all exceptions fixes this crash.