### PR TITLE
Allow BundleExecutable names with `-`

### DIFF
--- a/ios/Components/AdyenApperance.swift
+++ b/ios/Components/AdyenApperance.swift
@@ -25,6 +25,7 @@ internal class AdyenAppearanceLoader: NSObject {
         let appearanceProviders = Bundle.allBundles
             .compactMap { $0.infoDictionary?[bundleExecutableKey] as? String }
             .map { $0.replacingOccurrences(of: " ", with: "_") }
+            .map { $0.replacingOccurrences(of: "-", with: "_") }
             .compactMap { NSClassFromString("\($0).\(expectedClassName)") }
             .compactMap { $0 as? AdyenAppearanceProvider.Type }
         


### PR DESCRIPTION
# Open PR

## Changes

* Fix bug when AdyenAppearance were not found in case Bundle Executable have "-" in the name