### PR TITLE
Address countries picker improvements

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/component/dropin/AdyenDropInComponent.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/dropin/AdyenDropInComponent.kt
@@ -62,7 +62,6 @@ class AdyenDropInComponent(context: ReactApplicationContext?) : BaseModule(conte
 
         parser.locale?.let { builder.setShopperLocale(it) }
         configureDropIn(builder, configuration)
-        configureCards(builder, configuration)
         configureBcmc(builder, configuration)
         configure3DS(builder)
 
@@ -72,6 +71,7 @@ class AdyenDropInComponent(context: ReactApplicationContext?) : BaseModule(conte
             builder.setAmount(amount)
             configureGooglePay(builder, configuration, countryCode)
         }
+        configureCards(builder, configuration, countryCode)
         val currentActivity = reactApplicationContext.currentActivity
         val resultIntent = Intent(currentActivity, currentActivity!!.javaClass)
         resultIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
@@ -184,7 +184,7 @@ class AdyenDropInComponent(context: ReactApplicationContext?) : BaseModule(conte
         if (bcmcConfig == null) {
             bcmcConfig = JavaOnlyMap()
         }
-        val parser = CardConfigurationParser(bcmcConfig)
+        val parser = CardConfigurationParser(bcmcConfig, null)
         val bcmcBuilder = BcmcConfiguration.Builder(
             builder.builderShopperLocale,
             builder.builderEnvironment,
@@ -193,8 +193,8 @@ class AdyenDropInComponent(context: ReactApplicationContext?) : BaseModule(conte
         builder.addBcmcConfiguration(parser.getConfiguration(bcmcBuilder))
     }
 
-    private fun configureCards(builder: Builder, configuration: ReadableMap) {
-        val parser = CardConfigurationParser(configuration)
+    private fun configureCards(builder: Builder, configuration: ReadableMap, countryCode: String?) {
+        val parser = CardConfigurationParser(configuration, countryCode)
         val cardBuilder = CardConfiguration.Builder(
             builder.builderShopperLocale,
             builder.builderEnvironment,

--- a/android/src/main/java/com/adyenreactnativesdk/configuration/CardConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/CardConfigurationParser.kt
@@ -16,7 +16,7 @@ import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.SocialSecurityNumberVisibility
 import java.util.ArrayList
 
-class CardConfigurationParser(config: ReadableMap) {
+class CardConfigurationParser(config: ReadableMap, private val countryCode: String?) {
 
     companion object {
         const val TAG = "CardConfigurationParser"
@@ -29,6 +29,7 @@ class CardConfigurationParser(config: ReadableMap) {
         const val KCP_VISIBILITY_KEY = "kcpVisibility"
         const val SOCIAL_SECURITY_VISIBILITY_KEY = "socialSecurity"
         const val SUPPORTED_CARD_TYPES_KEY = "supported"
+        const val SUPPORTED_COUNTRY_LIST_KEY = "allowedAddressCountryCodes"
     }
 
     private var config: ReadableMap
@@ -82,6 +83,11 @@ class CardConfigurationParser(config: ReadableMap) {
             config.getBoolean(HIDE_CVC_KEY)
         } else false
 
+    private val supportedCountries: List<String>
+        get() = if (config.hasKey(SUPPORTED_COUNTRY_LIST_KEY)) {
+            config.getArray(SUPPORTED_COUNTRY_LIST_KEY)?.toArrayList() as? List<String> ?: emptyList()
+        } else emptyList()
+
     private val kcpVisibility: KCPAuthVisibility
         get() {
             return if (config.hasKey(KCP_VISIBILITY_KEY)) {
@@ -100,7 +106,7 @@ class CardConfigurationParser(config: ReadableMap) {
                     val value = config.getString(ADDRESS_VISIBILITY_KEY)!!
                     when (value.lowercase()) {
                         "postal_code", "postal", "postalcode" -> PostalCode()
-                        "full" -> FullAddress(null, emptyList())
+                        "full" -> FullAddress(countryCode, supportedCountries)
                         else -> None
                     }
                 }

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -34,6 +34,7 @@
 - `kcpVisibility` - Indicates whether to show the security fields for South Korea issued cards. Options: **"show"** or **"hide"**. Defaults to **"hide"**.
 - `socialSecurity` - Indicates the visibility mode for the social security number field (CPF/CNPJ) for Brazilian cards. Options: "show" or **"hide"**. Defaults to **"hide"**.
 - `supported` - The list of allowed card types. By default uses list of `brands` from payment method. Fallbacks to list of all known cards.
+- `allowedAddressCountryCodes` - List of ISO 3166-1 alpha-2 country code values. Default is empty list.
 
 ### ApplePay component
 
@@ -54,15 +55,17 @@
 - `allowPrepaidCards` - Set to **false** if you don't support prepaid cards. Default: The prepaid card class is supported for the card networks specified.
 - `billingAddressRequired` - Set to **true** if you require a billing address. A billing address should only be requested if it's required to process the transaction.
 - `billingAddressParameters` - Set billing address parameters:
-  - `format` - Billing address format required to complete the transaction. 
+
+  - `format` - Billing address format required to complete the transaction.
     Possible values:
-      MIN (default): Name, country code, and postal code.
-      FULL: Name, street address, locality, region, country code, and postal code.
+    MIN (default): Name, country code, and postal code.
+    FULL: Name, street address, locality, region, country code, and postal code.
   - `phoneNumberRequired` - Set to true if a phone number is required for the provided shipping address.
 
 - `emailRequired` - Set to **true** to request an email address.
 - `shippingAddressRequired` - Set to **true** to request a full shipping address.
 - `shippingAddressParameters` - Set shipping address parameters.
+
   - `allowedCountryCodes` - List of ISO 3166-1 alpha-2 country code values of the countries where shipping is allowed. If this object isn't specified, all shipping address countries are allowed.
   - `phoneNumberRequired` - Set to true if a phone number is required for the provided shipping address.
 
@@ -93,7 +96,8 @@
     addressVisibility: 'postalCode',
     showStorePaymentField : false,
     hideCvcStoredCard: true,
-    hideCvc: true
+    hideCvc: true,
+    supportedCountries: ['US', 'UK', 'CA', 'NL']
   },
   applepay: {
     merchantID: '{YOUR_APPLE_MERCHANT_ID}',

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -26,15 +26,15 @@
 
 ### Card component
 
-- `showStorePaymentField` - Indicates if the field for storing the card payment method should be displayed in the form. Defaults to **true**.
-- `holderNameRequired` - Indicates if the field for entering the holder name should be displayed in the form. Defaults to **false**.
-- `hideCvcStoredCard` - Indicates whether to show the security code field on a stored card payment. Defaults to false.
-- `hideCvc` - Indicates whether to show the security code field at all. Defaults to false.
 - `addressVisibility` - Indicates the display mode of the billing address form. Options: **"none"**, **"postal"**, **"full"**. Defaults to **"none"**.
+- `allowedAddressCountryCodes` - List of ISO 3166-1 alpha-2 country code values to control country picker options in full address form.
+- `hideCvc` - Indicates whether to show the security code field at all. Defaults to false.
+- `hideCvcStoredCard` - Indicates whether to show the security code field on a stored card payment. Defaults to false.
+- `holderNameRequired` - Indicates if the field for entering the holder name should be displayed in the form. Defaults to **false**.
 - `kcpVisibility` - Indicates whether to show the security fields for South Korea issued cards. Options: **"show"** or **"hide"**. Defaults to **"hide"**.
+- `showStorePaymentField` - Indicates if the field for storing the card payment method should be displayed in the form. Defaults to **true**.
 - `socialSecurity` - Indicates the visibility mode for the social security number field (CPF/CNPJ) for Brazilian cards. Options: "show" or **"hide"**. Defaults to **"hide"**.
 - `supported` - The list of allowed card types. By default uses list of `brands` from payment method. Fallbacks to list of all known cards.
-- `allowedAddressCountryCodes` - List of ISO 3166-1 alpha-2 country code values. Default is empty list.
 
 ### ApplePay component
 
@@ -57,9 +57,11 @@
 - `billingAddressParameters` - Set billing address parameters:
 
   - `format` - Billing address format required to complete the transaction.
+    
     Possible values:
-    MIN (default): Name, country code, and postal code.
-    FULL: Name, street address, locality, region, country code, and postal code.
+      MIN *(default)*: Name, country code, and postal code.
+      FULL: Name, street address, locality, region, country code, and postal code.
+
   - `phoneNumberRequired` - Set to true if a phone number is required for the provided shipping address.
 
 - `emailRequired` - Set to **true** to request an email address.
@@ -97,7 +99,7 @@
     showStorePaymentField : false,
     hideCvcStoredCard: true,
     hideCvc: true,
-    supportedCountries: ['US', 'UK', 'CA', 'NL']
+    allowedAddressCountryCodes: ['US', 'UK', 'CA', 'NL']
   },
   applepay: {
     merchantID: '{YOUR_APPLE_MERCHANT_ID}',

--- a/example/ios/AdyenExample.xcodeproj/project.pbxproj
+++ b/example/ios/AdyenExample.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		945936B12AE185B700F3E676 /* ApplePayConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945936B02AE185B700F3E676 /* ApplePayConfigurationTests.swift */; };
 		948B9B022A83D269003D15B4 /* DropInTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 948B9B012A83D269003D15B4 /* DropInTest.swift */; };
+		94FC2FEC2AF28DAE009F6FC1 /* CardConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94FC2FEB2AF28DAE009F6FC1 /* CardConfigurationTests.swift */; };
 		B6CB27F7E4011E633F2A25A7 /* libPods-AdyenExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 74FF1EDD8A3337F905F9FF61 /* libPods-AdyenExample.a */; };
 		F5C555F429F6C9F5008E7AA8 /* AdyenAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C555F329F6C9F5008E7AA8 /* AdyenAppearance.swift */; };
 /* End PBXBuildFile section */
@@ -45,6 +46,7 @@
 		945936B02AE185B700F3E676 /* ApplePayConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplePayConfigurationTests.swift; sourceTree = "<group>"; };
 		948B9B002A83D269003D15B4 /* AdyenExampleTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AdyenExampleTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		948B9B012A83D269003D15B4 /* DropInTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropInTest.swift; sourceTree = "<group>"; };
+		94FC2FEB2AF28DAE009F6FC1 /* CardConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardConfigurationTests.swift; sourceTree = "<group>"; };
 		A1C8461E16734A59CA0E7714 /* Pods-AdyenExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdyenExample.release.xcconfig"; path = "Target Support Files/Pods-AdyenExample/Pods-AdyenExample.release.xcconfig"; sourceTree = "<group>"; };
 		E757C9D727737E6700B62256 /* AdyenExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = AdyenExample.entitlements; path = AdyenExample/AdyenExample.entitlements; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -75,9 +77,10 @@
 		00E356EF1AD99517003FC87E /* AdyenExampleTests */ = {
 			isa = PBXGroup;
 			children = (
-				945936B02AE185B700F3E676 /* ApplePayConfigurationTests.swift */,
 				00E356F01AD99517003FC87E /* Supporting Files */,
+				945936B02AE185B700F3E676 /* ApplePayConfigurationTests.swift */,
 				948B9B012A83D269003D15B4 /* DropInTest.swift */,
+				94FC2FEB2AF28DAE009F6FC1 /* CardConfigurationTests.swift */,
 				948B9B002A83D269003D15B4 /* AdyenExampleTests-Bridging-Header.h */,
 			);
 			path = AdyenExampleTests;
@@ -413,6 +416,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				94FC2FEC2AF28DAE009F6FC1 /* CardConfigurationTests.swift in Sources */,
 				945936B12AE185B700F3E676 /* ApplePayConfigurationTests.swift in Sources */,
 				948B9B022A83D269003D15B4 /* DropInTest.swift in Sources */,
 			);

--- a/example/ios/AdyenExampleTests/ApplePayConfigurationTests.swift
+++ b/example/ios/AdyenExampleTests/ApplePayConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/example/ios/AdyenExampleTests/CardConfigurationTests.swift
+++ b/example/ios/AdyenExampleTests/CardConfigurationTests.swift
@@ -1,0 +1,91 @@
+//
+// Copyright (c) 2023 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+import adyen_react_native
+import PassKit
+import XCTest
+
+final class CardConfigurationTests: XCTestCase {
+  
+    let mockAmount = Amount(value: 1000, currencyCode: "USD", localeIdentifier: "en-US")
+
+    func testNewDictionary() throws {
+        let sut = CardConfigurationParser(configuration: NSDictionary())
+        XCTAssertNotNil(sut.configuration)
+    }
+  
+    func testEmptyDictionary() throws {
+        let sut = CardConfigurationParser(configuration: [:])
+        XCTAssertNotNil(sut.configuration)
+    }
+  
+    func testEmptySubDictionary() throws {
+        let sut = CardConfigurationParser(configuration: ["card": [:]])
+        XCTAssertNotNil(sut.configuration)
+    }
+
+    func testShowStorePaymentField() throws {
+        let sut = CardConfigurationParser(configuration: ["card": ["showStorePaymentField": false]])
+        XCTAssertFalse(sut.configuration.showsStorePaymentMethodField)
+    }
+
+    func testHolderNameRequired() throws {
+        let sut = CardConfigurationParser(configuration: ["card": ["holderNameRequired": true]])
+        XCTAssertTrue(sut.configuration.showsHolderNameField)
+    }
+
+    func testHideCvcStoredCard() throws {
+        let sut = CardConfigurationParser(configuration: ["card": ["hideCvcStoredCard": false]])
+        XCTAssertTrue(sut.configuration.stored.showsSecurityCodeField) // inverted
+    }
+
+    func testHideCvc() throws {
+        let sut = CardConfigurationParser(configuration: ["card": ["hideCvc": false]])
+      XCTAssertTrue(sut.configuration.showsSecurityCodeField) // inverted
+    }
+
+    func testFullAddressVisibility() throws {
+        let sut = CardConfigurationParser(configuration: ["card": ["addressVisibility": "full"]])
+      XCTAssertEqual(sut.configuration.billingAddressMode, .full)
+    }
+  
+  func testPostalAddressVisibility() throws {
+      let sut = CardConfigurationParser(configuration: ["card": ["addressVisibility": "postal"]])
+    XCTAssertEqual(sut.configuration.billingAddressMode, .postalCode)
+  }
+
+    func testHideKcpVisibility() throws {
+        let sut = CardConfigurationParser(configuration: ["card": ["kcpVisibility": "hide"]])
+      XCTAssertEqual(sut.configuration.koreanAuthenticationMode, .hide)
+    }
+  
+  func testShowKcpVisibility() throws {
+      let sut = CardConfigurationParser(configuration: ["card": ["kcpVisibility": "show"]])
+    XCTAssertEqual(sut.configuration.koreanAuthenticationMode, .show)
+  }
+
+    func testHideSocialSecurity() throws {
+        let sut = CardConfigurationParser(configuration: ["card": ["socialSecurity": "hide"]])
+      XCTAssertEqual(sut.configuration.socialSecurityNumberMode, .hide)
+    }
+  
+  func testShowSocialSecurity() throws {
+      let sut = CardConfigurationParser(configuration: ["card": ["socialSecurity": "show"]])
+    XCTAssertEqual(sut.configuration.socialSecurityNumberMode, .show)
+  }
+
+    func testAllowedCardTypes() throws {
+      let sut = CardConfigurationParser(configuration: ["card": ["supported": ["visa", "mc", "maestro"]]])
+      XCTAssertEqual(sut.configuration.allowedCardTypes?.count, 3)
+    }
+
+    func testBillingAddressCountryCodes() throws {
+        let sut = CardConfigurationParser(configuration: ["card": ["allowedAddressCountryCodes": ["GB", "US"]]])
+      XCTAssertEqual(sut.configuration.billingAddressCountryCodes?.count, 2)
+    }
+
+}

--- a/ios/Configuration/CardConfigurationParser.swift
+++ b/ios/Configuration/CardConfigurationParser.swift
@@ -68,12 +68,16 @@ public struct CardConfigurationParser {
         return strings.map { CardType(rawValue: $0) }
     }
     
+    var billingAddressCountryCodes: [String]? {
+        return dict[CardKeys.billingAddressCountryCodes] as? [String]
+    }
+    
     // TODO: add installmentConfiguration: InstallmentConfiguration?
     
     public var configuration: CardComponent.Configuration {
         var storedConfiguration = StoredCardConfiguration()
         storedConfiguration.showsSecurityCodeField = showsStoredSecurityCodeField
-
+        
         return .init(showsHolderNameField: showsHolderNameField,
                      showsStorePaymentMethodField: showsStorePaymentMethodField,
                      showsSecurityCodeField: showsSecurityCodeField,
@@ -81,7 +85,8 @@ public struct CardConfigurationParser {
                      socialSecurityNumberMode: socialSecurityVisibility,
                      billingAddressMode: addressVisibility,
                      storedCardConfiguration: storedConfiguration,
-                     allowedCardTypes: allowedCardTypes)
+                     allowedCardTypes: allowedCardTypes,
+                     billingAddressCountryCodes: billingAddressCountryCodes)
     }
     
     private func parseVisibility(_ key: String) -> CardComponent.FieldVisibility {

--- a/ios/Configuration/CardConfigurationParser.swift
+++ b/ios/Configuration/CardConfigurationParser.swift
@@ -61,15 +61,18 @@ public struct CardConfigurationParser {
     }
     
     var allowedCardTypes: [CardType]? {
-        guard let strings = dict[CardKeys.allowedCardTypes] as? [String] else {
+        guard let strings = dict[CardKeys.allowedCardTypes] as? [String], !strings.isEmpty else {
             return nil
         }
         
         return strings.map { CardType(rawValue: $0) }
     }
-    
+
     var billingAddressCountryCodes: [String]? {
-        return dict[CardKeys.billingAddressCountryCodes] as? [String]
+        guard let strings = dict[CardKeys.billingAddressCountryCodes] as? [String], !strings.isEmpty else {
+            return nil
+        }
+        return strings
     }
     
     // TODO: add installmentConfiguration: InstallmentConfiguration?

--- a/ios/Configuration/Parameters.swift
+++ b/ios/Configuration/Parameters.swift
@@ -43,6 +43,7 @@ internal enum CardKeys: SubConfig {
     static var kcpVisibility = "kcpVisibility"
     static var socialSecurity = "socialSecurity"
     static var allowedCardTypes = "supported"
+    static var billingAddressCountryCodes = "allowedAddressCountryCodes"
 }
 
 internal enum ApplePayKeys: SubConfig {

--- a/src/Core/configuration.ts
+++ b/src/Core/configuration.ts
@@ -85,6 +85,8 @@ export interface CardsConfiguration {
   socialSecurity?: FieldVisibility;
   /** The list of allowed card types. By default uses list of brands from payment method. Fallbacks to list of all known cards. */
   supported?: string[];
+  /** List of ISO 3166-1 alpha-2 country code values. */
+  allowedAddressCountryCodes?: string[];
 }
 
 export interface ApplePayConfiguration {


### PR DESCRIPTION
# Open PR

## Changes

* For Cards, you can now control the options that appear in the picker for the **Country** field in the payment form. Use `allowedAddressCountryCodes`, passing a list of [ISO 3166-1 alpha-2 country codes](https://www.iso.org/iso-3166-country-codes.html).
* For Android, in the payment form, the picker for the **Country** field is pre-populated with value specified in the [`countryCode` parameter](https://docs.adyen.com/online-payments/build-your-integration/?platform=Cross-platform&integration=React+Native+Components&version=1.0.0#get-available-payment-methods).