### PR TITLE
fix: skip using data object for ComponentCreated to support Kotlin 1.8

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/component/base/ComponentEvent.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/ComponentEvent.kt
@@ -9,6 +9,6 @@ package com.adyenreactnativesdk.component.base
 import com.adyen.checkout.components.core.action.Action
 
 sealed class ComponentEvent {
-    data object ComponentCreated : ComponentEvent()
+    object ComponentCreated : ComponentEvent()
     data class AdditionalAction(val action: Action) : ComponentEvent()
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Kotlin 1.8 is the default version of Expo SDK 50, the latest Expo version. 

## Tested scenarios
<!-- Description of tested scenarios -->
We're only using the Card component in our flow and it works. 

**Fixed issue**:  <!-- #-prefixed issue number -->
Fixes #357 - fixing building apps using Kotlin 1.8. 