### PR TITLE
Forced locale

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/component/base/BaseModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/BaseModule.kt
@@ -232,6 +232,7 @@ abstract class BaseModule(context: ReactApplicationContext?) : ReactContextBaseJ
         val config = RootConfigurationParser(json)
         this.environment = config.environment
         this.clientKey = config.clientKey ?: throw ModuleException.NoClientKey()
+        // TODO: add session.sessionSetupResponse.locale as ultimate source of locale
         this.locale = config.locale ?: currentLocale(reactApplicationContext)
         return config
     }

--- a/android/src/main/java/com/adyenreactnativesdk/configuration/RootConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/RootConfigurationParser.kt
@@ -21,7 +21,7 @@ class RootConfigurationParser(private val config: ReadableMap) {
         const val CLIENT_KEY_KEY = "clientKey"
         const val COUNTRY_CODE_KEY = "countryCode"
         const val ENVIRONMENT_KEY = "environment"
-        const val SHOPPER_LOCALE_KEY = "shopperLocale"
+        const val LOCALE_KEY = "locale"
     }
 
     val amount: Amount?
@@ -50,8 +50,8 @@ class RootConfigurationParser(private val config: ReadableMap) {
         } else null
 
     val locale: Locale?
-        get() = if (config.hasKey(SHOPPER_LOCALE_KEY)) {
-            Locale.forLanguageTag(config.getString(SHOPPER_LOCALE_KEY)!!)
+        get() = if (config.hasKey(LOCALE_KEY)) {
+            Locale.forLanguageTag(config.getString(LOCALE_KEY)!!)
         } else null
 
     val environment: Environment

--- a/example/src/Utilities/AppContext.js
+++ b/example/src/Utilities/AppContext.js
@@ -20,6 +20,7 @@ export const checkoutConfiguration = (config) => {
     clientKey: ENVIRONMENT.clientKey,
     environment: ENVIRONMENT.environment,
     returnUrl: ENVIRONMENT.returnUrl,
+    locale: config.shopperLocale,
     amount: {
       value: config.amount,
       currency: config.currency,

--- a/ios/CSE/ActionModule.swift
+++ b/ios/CSE/ActionModule.swift
@@ -60,7 +60,7 @@ internal final class ActionModule: BaseModule, ActionComponentDelegate {
 
         let style = AdyenAppearanceLoader.findStyle()?.actionComponent ?? .init()
         var config = AdyenActionComponent.Configuration(style: style)
-        if let locale = parser.shopperLocale {
+        if let locale = BaseModule.session?.sessionContext.shopperLocale ?? parser.shopperLocale {
             config.localizationParameters = LocalizationParameters(enforcedLocale: locale)
         }
         actionHandler = AdyenActionComponent(context: context, configuration: config)

--- a/ios/CSE/ActionModule.swift
+++ b/ios/CSE/ActionModule.swift
@@ -59,7 +59,11 @@ internal final class ActionModule: BaseModule, ActionComponentDelegate {
         }
 
         let style = AdyenAppearanceLoader.findStyle()?.actionComponent ?? .init()
-        actionHandler = AdyenActionComponent(context: context, configuration: .init(style: style))
+        var config = AdyenActionComponent.Configuration(style: style)
+        if let locale = parser.shopperLocale {
+            config.localizationParameters = LocalizationParameters(enforcedLocale: locale)
+        }
+        actionHandler = AdyenActionComponent(context: context, configuration: config)
         actionHandler?.delegate = self
         actionHandler?.presentationDelegate = self
         currentComponent = actionHandler

--- a/ios/Components/DropInModule.swift
+++ b/ios/Components/DropInModule.swift
@@ -38,6 +38,9 @@ internal final class DropInModule: BaseModule {
         let config = DropInConfigurationParser(configuration: configuration).configuration
         config.card = CardConfigurationParser(configuration: configuration).dropinConfiguration
         config.style = AdyenAppearanceLoader.findStyle() ?? DropInComponent.Style()
+        if let locale = parser.shopperLocale {
+            config.localizationParameters = LocalizationParameters(enforcedLocale: locale)
+        }
 
         if let payment = context.payment {
             (try? ApplepayConfigurationParser(configuration: configuration).buildConfiguration(payment: payment)).map {

--- a/ios/Components/DropInModule.swift
+++ b/ios/Components/DropInModule.swift
@@ -38,7 +38,7 @@ internal final class DropInModule: BaseModule {
         let config = DropInConfigurationParser(configuration: configuration).configuration
         config.card = CardConfigurationParser(configuration: configuration).dropinConfiguration
         config.style = AdyenAppearanceLoader.findStyle() ?? DropInComponent.Style()
-        if let locale = parser.shopperLocale {
+        if let locale = BaseModule.session?.sessionContext.shopperLocale ?? parser.shopperLocale {
             config.localizationParameters = LocalizationParameters(enforcedLocale: locale)
         }
 

--- a/ios/Components/InstantModule.swift
+++ b/ios/Components/InstantModule.swift
@@ -33,7 +33,7 @@ internal final class InstantModule: BaseModule {
 
         let style = AdyenAppearanceLoader.findStyle()?.actionComponent ?? .init()
         var config = AdyenActionComponent.Configuration(style: style)
-        if let locale = parser.shopperLocale {
+        if let locale = BaseModule.session?.sessionContext.shopperLocale ??  parser.shopperLocale {
             config.localizationParameters = LocalizationParameters(enforcedLocale: locale)
         }
 

--- a/ios/Components/InstantModule.swift
+++ b/ios/Components/InstantModule.swift
@@ -32,7 +32,12 @@ internal final class InstantModule: BaseModule {
         }
 
         let style = AdyenAppearanceLoader.findStyle()?.actionComponent ?? .init()
-        actionHandler = AdyenActionComponent(context: context, configuration: .init(style: style))
+        var config = AdyenActionComponent.Configuration(style: style)
+        if let locale = parser.shopperLocale {
+            config.localizationParameters = LocalizationParameters(enforcedLocale: locale)
+        }
+
+        actionHandler = AdyenActionComponent(context: context, configuration: config)
         actionHandler?.delegate = self
         actionHandler?.presentationDelegate = self
 

--- a/ios/Configuration/Parameters.swift
+++ b/ios/Configuration/Parameters.swift
@@ -24,7 +24,7 @@ internal enum Keys {
     static var value = "value"
     static var countryCode = "countryCode"
     static var currency = "currency"
-    static var shopperLocale = "shopperLocale"
+    static var locale = "locale"
 }
 
 internal enum AnalyticsKeys: SubConfig {

--- a/ios/Configuration/RootConfigurationParser.swift
+++ b/ios/Configuration/RootConfigurationParser.swift
@@ -54,14 +54,9 @@ public struct RootConfigurationParser {
         return Payment(amount: amount, countryCode: countryCode)
     }
 
-    public var shopperLocale: Locale? {
-        guard let shopperLocaleString = configuration[Keys.shopperLocale] as? String else {
-            return nil
-        }
-
-        return Locale(identifier: shopperLocaleString)
+    public var shopperLocale: String? {
+        return configuration[Keys.locale] as? String
     }
-
 }
 
 extension RootConfigurationParser {

--- a/src/Core/configuration.ts
+++ b/src/Core/configuration.ts
@@ -23,7 +23,6 @@ export interface BaseConfiguration {
   * The shopper's locale. This is used to enforce the language rendered in the UI.
   * If no value is set, will rely on the system to choose the best fitting locale based on the device's locale and locales supported by the app.
   * Fallback locale is 'en-US'.
-  * @todo not implemented on on iOS.
   * @defaultValue null.
   */
   locale?: string;


### PR DESCRIPTION
# Open PR

## Changes

### New

* add `locale` configuration on iOS
* enforce `shopperLocale` from session as ultimate source of "locale"

### Fixes

* now `locale` configuration works on Android

### Notes

* `shopperLocale` from session not available on Android 5.1.0