### PR TITLE
Decouple AdyenCheckout theme from AppTheme

### DIFF
--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Default theme for DropIn theme. Could be overrided on app level with decendent of Theme.MaterialComponents -->
-    <style name="AdyenCheckout" parent="Theme.MaterialComponents.DayNight">
-        <item name="android:textColor">?android:textColorPrimary</item>
-    </style>
+    <!-- Default theme for Adyen library. Could be overridden on the app level with a descendant of Theme.MaterialComponents -->
+    <style name="AdyenCheckout" parent="Adyen"/>
 </resources>


### PR DESCRIPTION
# Open PR

## Changes

* Decouple the `AdyenCheckout` theme from `AppTheme` and use the library's internal `Adyen ` theme instead. This allows DropIn and dropping-based Components to be agnostic of the current app's theme.