### PR TITLE
Fix wrong SessionConfiguration interface

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -223,7 +223,7 @@ export interface PaymentDetailsData {
  * Session configuration
  */
 export interface SessionConfiguration {
-  sessionID: string,
+  id: string,
   sessionData: string
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The `SessionConfiguartion` interface signature is differs from what native modules expect.

The native modules expect `id` but `SessionConfiguration` contains `sessionID` as you can see here:
https://github.com/Adyen/adyen-react-native/blob/bcf5b4eda7e6aed2bf5c59a4d0b264f1ec9d349c/ios/Components/SessionHelperModule.swift#L45

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
