### PR TITLE
Upodate to `gradle/actions/setup-gradle@v3`

### DIFF
--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -47,7 +47,7 @@ jobs:
         run: yarn
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4


### PR DESCRIPTION
# Open PR

## Changes

* update to `gradle/actions/setup-gradle@v3`. See [GitHub deprecation upgrade guide](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle)