### PR TITLE
fix: skip exporting AdyenAction as type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export type {AdyenCSEModule} from './modules/AdyenCSEModule';
 export {SessionHelper} from './modules/SessionHelperModule';
 export type {SessionHelperModule} from './modules/SessionHelperModule';
 
-export type {AdyenAction} from './modules/ActionModule';
+export {AdyenAction} from './modules/ActionModule';
 export type {ActionModule}  from './modules/ActionModule';
 
 export type {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
After upgrading from 2.0.0-rc.1 to 2.3.0, we started getting various Typescript errors. 
This PR changes the export from index so that AdyenAction is not exported as a type, but a regular export. 



<img width="1095" alt="Screenshot 2024-08-20 at 16 54 10" src="https://github.com/user-attachments/assets/d423305a-d79f-4f1d-8a01-369b8bc79e29">


## Tested scenarios
Nothing has been tested. Not sure how to link this with Expo locally. 

