### PR TITLE
Add sessionResult to iOS callback

### DIFF
--- a/ios/Components/BaseModule.swift
+++ b/ios/Components/BaseModule.swift
@@ -236,6 +236,12 @@ extension BaseModule {
             }
         }
     }
+
+    enum Keys {
+        static let sessionId = "sessionId"
+        static let sessionData = "sessionData"
+        static let order = "order"
+    }
 }
 
 extension BaseModule: PresentationDelegate {
@@ -250,7 +256,12 @@ extension BaseModule: PresentationDelegate {
 
 extension BaseModule: SessionResultListener {
     func didComplete(with result: Adyen.AdyenSessionResult) {
-        sendEvent(event: Events.didComplete, body: result.jsonObject)
+        var result = result.jsonObject
+        result[Keys.sessionId] = Self.session?.sessionContext.identifier
+        result[Keys.sessionData] = Self.session?.sessionContext.data
+        result[Keys.order] = self.currentPaymentComponent?.order?.jsonObject
+
+        sendEvent(event: Events.didComplete, body: result)
     }
 
     func didFail(with error: Error) {

--- a/ios/Model/EncodableAdyenSessionResult.swift
+++ b/ios/Model/EncodableAdyenSessionResult.swift
@@ -11,9 +11,11 @@ extension AdyenSessionResult: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.resultCode.rawValue, forKey: .resultCode)
+        try container.encode(self.encodedResult, forKey: .encodedResult)
     }
-
+    
     private enum CodingKeys: String, CodingKey {
         case resultCode
+        case encodedResult = "sessionResult"
     }
 }


### PR DESCRIPTION
# Open PR

## Changes

* add `sessionResult` parameter to `didComplete` callback output
* align [Android](https://github.com/Adyen/adyen-android/blob/develop/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionPaymentResult.kt#L27-L31) and iOS session completion callback