### PR TITLE
fix: override fun onNewIntent not nullable param

### DIFF
--- a/plugin/src/setKotlinMainActivity.ts
+++ b/plugin/src/setKotlinMainActivity.ts
@@ -11,18 +11,18 @@ export function setKotlinMainActivity(contents: string): string {
   );
 
   // on NewIntent
-  if (contents.includes('override fun onNewIntent(intent: Intent?) {')) {
+  if (contents.includes('override fun onNewIntent(intent: Intent) {')) {
     contents = contents.replace(
       'super.onNewIntent(intent)\n',
-      'super.onNewIntent(intent)\n    intent?.let { AdyenCheckout.handleIntent(it) }\n'
+      'super.onNewIntent(intent)\n    AdyenCheckout.handleIntent(intent)\n'
     );
   } else {
     contents = contents.replace(
       /}\n$/,
       '\n' +
-        '  override fun onNewIntent(intent: Intent?) {\n' +
+        '  override fun onNewIntent(intent: Intent) {\n' +
         '    super.onNewIntent(intent)\n' +
-        '    intent?.let { AdyenCheckout.handleIntent(it) }\n' +
+        '    AdyenCheckout.handleIntent(intent)\n' +
         '  }\n' +
         '}\n'
     );


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
While trying to implement this package, I encountered a problem when using Expo 52 with a development build, specifically with the Kotlin language during the Android build:
```shell
Android gradle plugin: 8.6.0
Gradle: 8.10.2

> Task :app:compileDebugKotlin FAILED
e: file:///.../android/app/src/main/java/.../MainActivity.kt:69:3 'onNewIntent' overrides nothing
e: file:///.../android/app/src/main/java/.../MainActivity.kt:70:23 Type mismatch: inferred type is Intent? but Intent was expected

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:compileDebugKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details
``` 

After investigating the issue, I found that the problem originates from the following piece of code:
```kotlin
  override fun onNewIntent(intent: Intent?) {
    super.onNewIntent(intent)
    intent?.let { AdyenCheckout.handleIntent(it) }
  }
``` 

The Android documentation for [onNewIntent](https://developer.android.com/reference/android/app/Activity#onNewIntent(android.content.Intent)) specifies that the `intent` parameter is non-nullable. As a result, the null check (`intent?.let`) is unnecessary. This behavior is consistent with the Java implementation provided in the same plugin:

```java
  @Override
  public void onNewIntent(Intent intent) {
    super.onNewIntent(intent);
    AdyenCheckout.handleIntent(intent);
  }
``` 