### PR TITLE
Prevent dismiss when nothing is presented

### DIFF
--- a/ios/Components/BaseModule.swift
+++ b/ios/Components/BaseModule.swift
@@ -146,6 +146,10 @@ internal class BaseModule: RCTEventEmitter {
         requestOrderHandler = nil
         checkBalanceHandler = nil
 
+        guard BaseModule.currentPresenter?.presentedViewController != nil else {
+            BaseModule.currentPresenter = nil
+            return
+        }
         BaseModule.currentPresenter?.dismiss(animated: true) {
             BaseModule.currentPresenter = nil
         }


### PR DESCRIPTION
# Open PR

## Changes

* fix bug on iOS when self-dismissing VC cause SDK `BaseModule` to dismiss presenter itself