### PR TITLE
Prevent AdyenAction from being dragged and dismissed

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
@@ -30,7 +30,6 @@ class ActionFragment(
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        dialog?.setCanceledOnTouchOutside(false)
         return inflater.inflate(R.layout.fragment_instant, container)
     }
 

--- a/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
@@ -49,6 +49,7 @@ class ActionFragment(
         )
 
         this.component = component
+        this.isCancelable = false
         AdyenCheckout.setComponent(component)
         view?.findViewById<AdyenComponentView>(R.id.component_view)
             ?.attach(component, this)


### PR DESCRIPTION
# Open PR

## Changes

* Android `AdyenAction`: The redirect action dialog no longer disappears when a user swipes or taps outside the dialog view.