### PR TITLE
Improve invalid client key error handling

### DIFF
--- a/ios/CSE/ActionModule.swift
+++ b/ios/CSE/ActionModule.swift
@@ -30,11 +30,7 @@ internal final class ActionModule: BaseModule, ActionComponentDelegate {
     }
 
     func didFail(with error: Error, from component: Adyen.ActionComponent) {
-        let errorToSend = checkErrorType(error)
-        if let error = error as? NativeModuleError {
-            return reject(with: error)
-        }
-        rejecter?(Constant.componentError, error.localizedDescription, error)
+        reject(with: error)
     }
 
     @objc
@@ -50,12 +46,8 @@ internal final class ActionModule: BaseModule, ActionComponentDelegate {
         do {
             action = try parseAction(from: actionJson)
             context = try parser.fetchContext(session: BaseModule.session)
-        } catch NativeModuleError.invalidAction {
-            return reject(with: NativeModuleError.invalidAction)
-        } catch NativeModuleError.noClientKey {
-            return reject(with: NativeModuleError.noClientKey)
         } catch {
-            return rejecter(Constant.parsingErrorCode, error.localizedDescription, error)
+            return reject(with: error)
         }
 
         let style = AdyenAppearanceLoader.findStyle()?.actionComponent ?? .init()
@@ -89,5 +81,13 @@ internal final class ActionModule: BaseModule, ActionComponentDelegate {
 
     func reject(with error: NativeModuleError) {
         rejecter?(error.errorCode, error.errorDescription, error)
+    }
+
+    func reject(with error: any Error) {
+        let errorToSend = NativeModuleError.checkErrorType(error)
+        if let error = errorToSend as? NativeModuleError {
+            return reject(with: error)
+        }
+        rejecter?(Constant.componentError, errorToSend.localizedDescription, errorToSend)
     }
 }

--- a/ios/CSE/ActionModule.swift
+++ b/ios/CSE/ActionModule.swift
@@ -73,9 +73,7 @@ internal final class ActionModule: BaseModule, ActionComponentDelegate {
     }
 
     private enum Constant {
-        static var moduleName = "ActionModule"
         static var threeDS2SdkVersionName = "threeDS2SdkVersion"
-        static var parsingErrorCode = "parsingError"
         static var componentError = "actionError"
     }
 
@@ -84,10 +82,9 @@ internal final class ActionModule: BaseModule, ActionComponentDelegate {
     }
 
     func reject(with error: any Error) {
-        let errorToSend = NativeModuleError.checkErrorType(error)
-        if let error = errorToSend as? NativeModuleError {
-            return reject(with: error)
+        if let nativeError = NativeModuleError.checkErrorType(error) as? NativeModuleError {
+            return reject(with: nativeError)
         }
-        rejecter?(Constant.componentError, errorToSend.localizedDescription, errorToSend)
+        rejecter?(Constant.componentError, error.localizedDescription, error)
     }
 }

--- a/ios/Components/ApplePay/ApplePayModule.swift
+++ b/ios/Components/ApplePay/ApplePayModule.swift
@@ -130,7 +130,7 @@ struct PKPaymentAuthorizationServiceAdapter: PKPaymentAuthorizationService {
     func canMakePayments(usingNetworks: [PKPaymentNetwork]) -> Bool {
         PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: usingNetworks)
     }
-    
+
     func getAuthorizationViewController(paymentRequest: PKPaymentRequest) -> PKPaymentAuthorizationViewController? {
         PKPaymentAuthorizationViewController(paymentRequest: paymentRequest)
     }

--- a/ios/Components/BaseModule.swift
+++ b/ios/Components/BaseModule.swift
@@ -6,6 +6,7 @@
 
 import Adyen
 import Adyen3DS2
+import AdyenNetworking
 import React
 import UIKit
 
@@ -41,7 +42,9 @@ internal class BaseModule: RCTEventEmitter {
     internal var actionHandler: AdyenActionComponent?
 
     internal func present(_ component: PresentableComponent) {
-        guard let presenter = BaseModule.currentPresenter ?? UIViewController.topPresenter else { return sendEvent(error: NativeModuleError.notKeyWindow) }
+        guard let presenter = BaseModule.currentPresenter ?? UIViewController.topPresenter else {
+            return sendEvent(error: NativeModuleError.notKeyWindow)
+        }
 
         defer {
             BaseModule.currentPresenter = presenter
@@ -72,15 +75,8 @@ internal class BaseModule: RCTEventEmitter {
         sendEvent(withName: event.rawValue, body: [:])
     }
 
-    internal func checkErrorType(_ error: Error) -> Error {
-        if error.isComponentCanceled || error.is3DSCanceled {
-            return NativeModuleError.canceled
-        }
-        return error
-    }
-
     internal func sendEvent(error: Error) {
-        let errorToSend = checkErrorType(error)
+        let errorToSend = NativeModuleError.checkErrorType(error)
         sendEvent(withName: Events.didFail.rawValue, body: errorToSend.jsonObject)
     }
 
@@ -161,87 +157,6 @@ internal class BaseModule: RCTEventEmitter {
 
             self.currentComponent?.finalizeIfNeeded(with: result) {
                 self.cleanUp()
-            }
-        }
-    }
-}
-
-extension Error {
-
-    var isComponentCanceled: Bool { (self as? ComponentError) == ComponentError.cancelled }
-
-    var is3DSCanceled: Bool {
-        (self as NSError).domain == "com.adyen.Adyen3DS2.ADYRuntimeError" &&
-            (self as NSError).code == ADYRuntimeErrorCode.challengeCancelled.rawValue
-    }
-}
-
-extension BaseModule {
-
-    enum NativeModuleError: LocalizedError, KnownError {
-        case canceled
-        case noClientKey
-        case noPayment
-        case notSupported
-        case invalidPaymentMethods
-        case invalidAction
-        case notKeyWindow
-        case paymentMethodNotFound(PaymentMethod.Type)
-        case balanceCheck(message: String)
-        case orderRequest(message: String)
-        case sessionError
-
-        var errorCode: String {
-            switch self {
-            case .canceled:
-                return "canceledByShopper"
-            case .notSupported:
-                return "notSupported"
-            case .noClientKey:
-                return "noClientKey"
-            case .noPayment:
-                return "noPayment"
-            case .invalidPaymentMethods:
-                return "invalidPaymentMethods"
-            case .invalidAction:
-                return "invalidAction"
-            case .paymentMethodNotFound:
-                return "noPaymentMethod"
-            case .notKeyWindow:
-                return "notKeyWindow"
-            case .balanceCheck:
-                return "balanceCheck"
-            case .orderRequest:
-                return "orderRequest"
-            case .sessionError:
-                return "sessionError"
-            }
-        }
-
-        var errorDescription: String? {
-            switch self {
-            case .canceled:
-                return "Payment canceled by shopper"
-            case .notSupported:
-                return "Not supported on iOS"
-            case .noClientKey:
-                return "No clientKey in configuration"
-            case .noPayment:
-                return "No payment in configuration"
-            case .invalidPaymentMethods:
-                return "Can not parse paymentMethods or the list is empty"
-            case .invalidAction:
-                return "Can not parse action"
-            case let .paymentMethodNotFound(type):
-                return "Can not find payment method of type \(type) in provided list"
-            case .notKeyWindow:
-                return "Can not find root ViewController"
-            case let .balanceCheck(message):
-                return "Balance check error: \(message)"
-            case let .orderRequest(message):
-                return "Order request error: \(message)"
-            case .sessionError:
-                return "Something went wrong while starting session"
             }
         }
     }

--- a/ios/Components/DropInModule.swift
+++ b/ios/Components/DropInModule.swift
@@ -31,7 +31,9 @@ internal final class DropInModule: BaseModule {
     func update(_ results: NSArray) {
         guard let lookupHandler else { return }
 
-        let addressModels: [LookupAddressModel] = results.compactMap { $0 as? NSDictionary }.compactMap { try? $0.decode() }
+        let addressModels: [LookupAddressModel] = results
+            .compactMap { $0 as? NSDictionary }
+            .compactMap { try? $0.decode() }
         DispatchQueue.main.async {
             lookupHandler(addressModels)
         }
@@ -136,7 +138,9 @@ internal final class DropInModule: BaseModule {
 }
 
 extension DropInModule: DropInComponentDelegate {
-    func didSubmit(_ data: Adyen.PaymentComponentData, from component: Adyen.PaymentComponent, in dropInComponent: Adyen.AnyDropInComponent) {
+    func didSubmit(_ data: Adyen.PaymentComponentData,
+                   from component: Adyen.PaymentComponent,
+                   in dropInComponent: Adyen.AnyDropInComponent) {
         let response: SubmitData
         if let appleData = data.paymentMethod as? ApplePayDetails {
             response = SubmitData(paymentData: data.jsonObject, extra: appleData.extraData)
@@ -146,24 +150,32 @@ extension DropInModule: DropInComponentDelegate {
         sendEvent(event: .didSubmit, body: response.jsonObject)
     }
 
-    func didFail(with error: Error, from component: Adyen.PaymentComponent, in dropInComponent: Adyen.AnyDropInComponent) {
+    func didFail(with error: Error,
+                 from component: Adyen.PaymentComponent,
+                 in dropInComponent: Adyen.AnyDropInComponent) {
         sendEvent(error: error)
     }
 
-    func didProvide(_ data: Adyen.ActionComponentData, from component: Adyen.ActionComponent, in dropInComponent: Adyen.AnyDropInComponent) {
+    func didProvide(_ data: Adyen.ActionComponentData,
+                    from component: Adyen.ActionComponent,
+                    in dropInComponent: Adyen.AnyDropInComponent) {
         sendEvent(event: .didProvide, body: data.jsonObject)
     }
 
-    func didComplete(from component: Adyen.ActionComponent, in dropInComponent: Adyen.AnyDropInComponent) {
+    func didComplete(from component: Adyen.ActionComponent,
+                     in dropInComponent: Adyen.AnyDropInComponent) {
         let result = ResultDTO(result: .presentToShopper)
         sendEvent(event: .didComplete, body: result.jsonObject)
     }
 
-    func didFail(with error: Error, from component: Adyen.ActionComponent, in dropInComponent: Adyen.AnyDropInComponent) {
+    func didFail(with error: Error,
+                 from component: Adyen.ActionComponent,
+                 in dropInComponent: Adyen.AnyDropInComponent) {
         sendEvent(error: error)
     }
 
-    func didFail(with error: Error, from dropInComponent: Adyen.AnyDropInComponent) {
+    func didFail(with error: Error,
+                 from dropInComponent: Adyen.AnyDropInComponent) {
         sendEvent(error: error)
     }
 }
@@ -175,7 +187,8 @@ extension DropInModule: AddressLookupProvider {
         sendEvent(event: .didUpdateAddress, body: searchTerm)
     }
 
-    func complete(incompleteAddress: LookupAddressModel, resultHandler: @escaping (Result<PostalAddress, any Error>) -> Void) {
+    func complete(incompleteAddress: LookupAddressModel,
+                  resultHandler: @escaping (Result<PostalAddress, any Error>) -> Void) {
         lookupCompliationHandler = resultHandler
         sendEvent(event: .didConfirmAddress, body: incompleteAddress.jsonObject)
     }
@@ -183,7 +196,8 @@ extension DropInModule: AddressLookupProvider {
 }
 
 extension DropInModule: StoredPaymentMethodsDelegate {
-    func disable(storedPaymentMethod: any Adyen.StoredPaymentMethod, completion: @escaping Adyen.Completion<Bool>) {
+    func disable(storedPaymentMethod: any Adyen.StoredPaymentMethod,
+                 completion: @escaping Adyen.Completion<Bool>) {
         disableStoredPaymentMethodHandler = completion
         sendEvent(event: .didDisableStoredPaymentMethod, body: storedPaymentMethod.jsonObject)
     }
@@ -204,7 +218,9 @@ struct AddressError: Error, LocalizedError, Codable {
 
 extension DropInModule: PartialPaymentDelegate {
 
-    func checkBalance(with data: PaymentComponentData, component: any Adyen.Component, completion: @escaping (Result<Balance, any Error>) -> Void) {
+    func checkBalance(with data: PaymentComponentData,
+                      component: any Adyen.Component,
+                      completion: @escaping (Result<Balance, any Error>) -> Void) {
         sendEvent(event: .didCheckBalance, body: data.jsonObject)
         checkBalanceHandler = completion
     }
@@ -222,7 +238,8 @@ extension DropInModule: PartialPaymentDelegate {
         }
     }
 
-    func requestOrder(for component: any Adyen.Component, completion: @escaping (Result<PartialPaymentOrder, any Error>) -> Void) {
+    func requestOrder(for component: any Adyen.Component,
+                      completion: @escaping (Result<PartialPaymentOrder, any Error>) -> Void) {
         sendEvent(event: .didRequestOrder)
         requestOrderHandler = completion
     }
@@ -270,11 +287,11 @@ extension DropInModule: CardComponentDelegate {
     func didSubmit(lastFour: String, finalBIN: String, component: Adyen.CardComponent) {
         /* No Callback implemented */
     }
-    
+
     func didChangeBIN(_ value: String, component: Adyen.CardComponent) {
         sendEvent(event: .didChangeBinValue, body: value)
     }
-    
+
     func didChangeCardBrand(_ value: [Adyen.CardBrand]?, component: Adyen.CardComponent) {
         guard let value, !value.isEmpty else { return }
         let jsonData = value.map { BinLookupDataDTO(brand: $0.type.rawValue).jsonObject }

--- a/ios/Components/NativeModuleError.swift
+++ b/ios/Components/NativeModuleError.swift
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+import Adyen3DS2
+import AdyenNetworking
+import React
+import UIKit
+
+enum NativeModuleError: LocalizedError, KnownError {
+    case canceled
+    case noClientKey
+    case noPayment
+    case notSupported
+    case invalidPaymentMethods
+    case invalidAction
+    case notKeyWindow
+    case paymentMethodNotFound(PaymentMethod.Type)
+    case balanceCheck(message: String)
+    case orderRequest(message: String)
+    case sessionError
+    case invalidClientKey
+
+    var errorCode: String {
+        switch self {
+        case .canceled:
+            return "canceledByShopper"
+        case .notSupported:
+            return "notSupported"
+        case .noClientKey:
+            return "noClientKey"
+        case .noPayment:
+            return "noPayment"
+        case .invalidPaymentMethods:
+            return "invalidPaymentMethods"
+        case .invalidAction:
+            return "invalidAction"
+        case .paymentMethodNotFound:
+            return "noPaymentMethod"
+        case .notKeyWindow:
+            return "notKeyWindow"
+        case .balanceCheck:
+            return "balanceCheck"
+        case .orderRequest:
+            return "orderRequest"
+        case .sessionError:
+            return "sessionError"
+        case .invalidClientKey:
+            return "invalidClientKey"
+        }
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .canceled:
+            return "Payment canceled by shopper"
+        case .notSupported:
+            return "Not supported on iOS"
+        case .noClientKey:
+            return "No clientKey in configuration"
+        case .invalidClientKey:
+            return "Invalid clientKey"
+        case .noPayment:
+            return "No payment in configuration"
+        case .invalidPaymentMethods:
+            return "Can not parse paymentMethods or the list is empty"
+        case .invalidAction:
+            return "Can not parse action"
+        case let .paymentMethodNotFound(type):
+            return "Can not find payment method of type \(type) in provided list"
+        case .notKeyWindow:
+            return "Can not find root ViewController"
+        case let .balanceCheck(message):
+            return "Balance check error: \(message)"
+        case let .orderRequest(message):
+            return "Order request error: \(message)"
+        case .sessionError:
+            return "Something went wrong while starting session"
+        }
+    }
+
+    static func checkErrorType(_ error: Error) -> Error {
+        if error.isComponentCanceled || error.is3DSCanceled {
+            return NativeModuleError.canceled
+        }
+        if error is HTTPResponse<EmptyErrorResponse> {
+            return NativeModuleError.invalidClientKey
+        }
+        return error
+    }
+}
+
+extension Error {
+
+    var isComponentCanceled: Bool { (self as? ComponentError) == ComponentError.cancelled }
+
+    var is3DSCanceled: Bool {
+        (self as NSError).domain == "com.adyen.Adyen3DS2.ADYRuntimeError" &&
+            (self as NSError).code == ADYRuntimeErrorCode.challengeCancelled.rawValue
+    }
+}

--- a/ios/Components/NativeModuleError.swift
+++ b/ios/Components/NativeModuleError.swift
@@ -86,7 +86,7 @@ enum NativeModuleError: LocalizedError, KnownError {
         if error.isComponentCanceled || error.is3DSCanceled {
             return NativeModuleError.canceled
         }
-        if error is HTTPResponse<EmptyErrorResponse> {
+        if error.isEmpty401NetworkingResponseError {
             return NativeModuleError.invalidClientKey
         }
         return error
@@ -100,5 +100,9 @@ extension Error {
     var is3DSCanceled: Bool {
         (self as NSError).domain == "com.adyen.Adyen3DS2.ADYRuntimeError" &&
             (self as NSError).code == ADYRuntimeErrorCode.challengeCancelled.rawValue
+    }
+
+    var isEmpty401NetworkingResponseError: Bool {
+        self is HTTPResponse<EmptyErrorResponse>
     }
 }

--- a/ios/Components/SessionHelperModule.swift
+++ b/ios/Components/SessionHelperModule.swift
@@ -58,8 +58,11 @@ internal final class SessionHelperModule: BaseModule, AdyenSessionDelegate {
                     resolver(dto.jsonObject)
                     BaseModule.session = session
                 case let .failure(error):
-                    let errorToSend = NativeModuleError.checkErrorType(error)
-                    rejecter(errorCode, nil, errorToSend)
+                    if let nativeError = NativeModuleError.checkErrorType(error) as? NativeModuleError {
+                        rejecter(nativeError.errorCode, nativeError.errorDescription, nativeError)
+                    } else {
+                        rejecter(errorCode, error.localizedDescription, error)
+                    }
                 }
             }
         }

--- a/ios/Components/SessionHelperModule.swift
+++ b/ios/Components/SessionHelperModule.swift
@@ -58,11 +58,8 @@ internal final class SessionHelperModule: BaseModule, AdyenSessionDelegate {
                     resolver(dto.jsonObject)
                     BaseModule.session = session
                 case let .failure(error):
-                    if error is HTTPResponse<EmptyErrorResponse> {
-                        rejecter(errorCode, NativeModuleError.sessionError.errorDescription, nil)
-                    } else {
-                        rejecter(errorCode, nil, error)
-                    }
+                    let errorToSend = NativeModuleError.checkErrorType(error)
+                    rejecter(errorCode, nil, errorToSend)
                 }
             }
         }

--- a/ios/Configuration/ApplePay/ApplePayRecurringConfigurationParser.swift
+++ b/ios/Configuration/ApplePay/ApplePayRecurringConfigurationParser.swift
@@ -7,7 +7,7 @@
 import PassKit
 
 class ApplePayRecurringConfigurationParser {
-    
+
     private var dict: [String: Any]
 
     init(configuration: NSDictionary) {

--- a/ios/Configuration/RootConfigurationParser.swift
+++ b/ios/Configuration/RootConfigurationParser.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
+@_spi(AdyenInternal) import Adyen
 
 public struct RootConfigurationParser {
 
@@ -59,8 +59,13 @@ extension RootConfigurationParser {
 
     internal func fetchContext(session: AdyenSession?) throws -> AdyenContext {
         guard let clientKey = self.clientKey else {
-            throw BaseModule.NativeModuleError.noClientKey
+            throw NativeModuleError.noClientKey
         }
+
+        guard ClientKeyValidator().isValid(clientKey) else {
+            throw NativeModuleError.invalidClientKey
+        }
+
         let apiContext = try APIContext(environment: self.environment, clientKey: clientKey)
 
         let analytics = AnalyticsParser(configuration: configuration).configuration

--- a/ios/Model/EncodableAdyenSessionResult.swift
+++ b/ios/Model/EncodableAdyenSessionResult.swift
@@ -13,7 +13,7 @@ extension AdyenSessionResult: Encodable {
         try container.encode(self.resultCode.rawValue, forKey: .resultCode)
         try container.encode(self.encodedResult, forKey: .encodedResult)
     }
-    
+
     private enum CodingKeys: String, CodingKey {
         case resultCode
         case encodedResult = "sessionResult"


### PR DESCRIPTION
# Changes

## Functional

* add validation for `clientKey`
* remap empty API response into "Invalid Client Key" error
   * BaseModule now remap error before sending event
   * SessionHelperModule remap before rejecting
   * ActionModule remap before rejecting

## Internal

* move `NativeModuleError` to a standalone file
* code cleanup with `swiftlint`


| Before | After |
| -- | -- |
| <img height="600" alt="Screenshot 2026-01-14 at 13 30 12" src="https://github.com/user-attachments/assets/ef066f06-7067-4d0e-8ba7-bba637ffa25f" /> | <img height="600" alt="Screenshot 2026-01-14 at 13 22 35" src="https://github.com/user-attachments/assets/e5c577ef-bdd0-4a22-8128-4702189fd674" /> |