### PR TITLE
Fixes #904

### DIFF
--- a/src/modules/base/getWrapper.ts
+++ b/src/modules/base/getWrapper.ts
@@ -6,7 +6,10 @@ import {
   type PaymentMethod,
   type PaymentMethodsResponse,
 } from '../../core';
-import { AdyenApplePay, AdyenDropIn, AdyenGooglePay, AdyenInstant } from '..';
+import { AdyenDropIn } from '../dropin/AdyenDropIn';
+import { AdyenApplePay } from '../applepay/AdyenApplePay';
+import { AdyenGooglePay } from '../googlepay/AdyenGooglePay';
+import { AdyenInstant } from '../instant/AdyenInstant';
 import type { ApplePayWrapper } from '../applepay/ApplePayWrapper';
 import type { DropInWrapper } from '../dropin/DropInWrapper';
 import type { GooglePayWrapper } from '../googlepay/GooglePayWrapper';

--- a/src/modules/base/getWrapper.ts
+++ b/src/modules/base/getWrapper.ts
@@ -6,8 +6,8 @@ import {
   type PaymentMethod,
   type PaymentMethodsResponse,
 } from '../../core';
-import { AdyenDropIn } from '../dropin/AdyenDropIn';
 import { AdyenApplePay } from '../applepay/AdyenApplePay';
+import { AdyenDropIn } from '../dropin/AdyenDropIn';
 import { AdyenGooglePay } from '../googlepay/AdyenGooglePay';
 import { AdyenInstant } from '../instant/AdyenInstant';
 import type { ApplePayWrapper } from '../applepay/ApplePayWrapper';


### PR DESCRIPTION
Issue: Invariant Violation: new NativeEventEmitter() requires a non-null argument on iOS when opening Drop-in (React Native 0.80.2)
Root cause: In v2.9.0, getWrapper.ts imports AdyenDropIn through a barrel re-export:

```
import { AdyenApplePay, AdyenDropIn, AdyenGooglePay, AdyenInstant } from '..';
```

This resolves through modules/index.ts, which re-exports from each submodule. On React Native 0.80.2 with Metro bundler, AdyenDropIn is undefined at the time getWrapper() is called, causing new NativeEventEmitter(undefined) to throw the invariant violation on iOS.

This was not an issue in v2.8.0 because getWrapper created a new wrapper instance each call (new DropInComponentWrapper()) using a directly imported native module, rather than referencing a pre-constructed singleton through a barrel export.

Fix: Replace the barrel import with direct imports:

```
import { AdyenDropIn } from '../dropin/AdyenDropIn';
import { AdyenApplePay } from '../applepay/AdyenApplePay';
import { AdyenGooglePay } from '../googlepay/AdyenGooglePay';
import { AdyenInstant } from '../instant/AdyenInstant';
```

This is likely not reproducible on RN 0.83.1 due to Metro bundler improvements in newer React Native versions.
