### PR TITLE
Add support for Expo 52 in ADYPlatformPayView

### DIFF
--- a/ios/Views/PlatformView/ADYPlatformPayView.mm
+++ b/ios/Views/PlatformView/ADYPlatformPayView.mm
@@ -123,3 +123,9 @@ Class<RCTComponentViewProtocol> ADYPlatformPayViewCls(void) {
 }
 
 @end
+
+// Add support for Expo 52
+Class<RCTComponentViewProtocol> PlatformPayViewCls(void) {
+  return RCTViewComponentView.class;
+}
+


### PR DESCRIPTION
# Changes

* Now React Native 0.76 (used by Expo 52) correctly link the auto-generated provider and the native implementation.