### PR TITLE
Remove cleanup step for gradlew.bat

### DIFF
--- a/.github/workflows/update_sdk_versions.yml
+++ b/.github/workflows/update_sdk_versions.yml
@@ -47,10 +47,6 @@ jobs:
         sed -i "s|${PLATFORM_PREFIX}-v[^-]*|${PLATFORM_PREFIX}-v$VERSION|g" README.md
         sed -i "s|${PLATFORM_PREFIX}/releases/tag/[^)]*|${PLATFORM_PREFIX}/releases/tag/$VERSION|g" README.md
 
-    - name: Clean up unwanted file changes
-      run: |
-        git checkout -- example/android/gradlew.bat
-
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v8
       with:
@@ -61,6 +57,7 @@ jobs:
           README.md
           adyen-react-native.podspec
           android/dependencies.gradle
+          !example/android/gradlew.bat
         body: |
           # Open PR
           This PR updates the ${{ inputs.platform }} SDK version to ${{ inputs.version }}.


### PR DESCRIPTION
# Changes

* ignoring `example/android/gradlew.bat` path