### PR TITLE
Update example app expiry date input to auto-prefix '0' for 2-9

### DIFF
--- a/example/src/components/CustomCard/components/ExpiryDateInput.tsx
+++ b/example/src/components/CustomCard/components/ExpiryDateInput.tsx
@@ -16,10 +16,7 @@ const ExpiryDateInput = (props: ExpiryDateInputProps) => {
       const digits = input.replace(/\D/g, '');
 
       // Auto-prefix '0' when first digit is 2-9
-      const prefixed =
-        digits.length === 1 && parseInt(digits[0]!, 10) > 1
-          ? `0${digits}`
-          : digits;
+      const prefixed = digits.replace(/^[2-9]$/, '0$&');
 
       // Limit to 4 digits
       const limitedDigits = prefixed.slice(0, 4);

--- a/example/src/components/CustomCard/components/ExpiryDateInput.tsx
+++ b/example/src/components/CustomCard/components/ExpiryDateInput.tsx
@@ -15,8 +15,14 @@ const ExpiryDateInput = (props: ExpiryDateInputProps) => {
       // Remove all non-digit characters
       const digits = input.replace(/\D/g, '');
 
+      // Auto-prefix '0' when first digit is 2-9
+      const prefixed =
+        digits.length === 1 && parseInt(digits[0]!, 10) > 1
+          ? `0${digits}`
+          : digits;
+
       // Limit to 4 digits
-      const limitedDigits = digits.slice(0, 4);
+      const limitedDigits = prefixed.slice(0, 4);
 
       // Format as MM/YY
       let formatted = limitedDigits;


### PR DESCRIPTION
# Changes

* improve API-Only card integration expired entry field