### PR TITLE
Add component settings to Example app

### DIFF
--- a/example/src/Configuration.ts
+++ b/example/src/Configuration.ts
@@ -21,7 +21,6 @@ export const DEFAULT_CONFIGURATION = {
   currency: 'EUR',
   amount: 1000, // The amount value in minor units.
   merchantAccount: merchantAccount,
-  merchantName: 'Test Merchant',
   shopperLocale: DEVICE_LOCALE,
   shopperReference: 'Checkout Shopper',
 };

--- a/example/src/api/types.ts
+++ b/example/src/api/types.ts
@@ -27,52 +27,13 @@ export interface PaymentResponse {
   resultCode: ResultCode;
 }
 
-export type CardSettings = {
-  holderNameRequired?: boolean;
-  addressVisibility?: 'full' | 'postalCode' | 'none' | 'lookup';
-  showStorePaymentField?: boolean;
-  hideCvcStoredCard?: boolean;
-  hideCvc?: boolean;
-  kcpVisibility?: 'show' | 'hide';
-  socialSecurity?: 'show' | 'hide';
-};
-
-export type DropInSettings = {
-  showPreselectedStoredPaymentMethod?: boolean;
-  skipListWhenSinglePaymentMethod?: boolean;
-  showRemovePaymentMethodButton?: boolean;
-  title?: string;
-};
-
-export type ApplePaySettings = {
-  merchantID?: string;
-  merchantName?: string;
-  allowOnboarding?: boolean;
-  shippingType?: 'shipping' | 'delivery' | 'storePickup' | 'servicePickup';
-};
-
-export type GooglePaySettings = {
-  allowPrepaidCards?: boolean;
-  allowCreditCards?: boolean;
-  billingAddressRequired?: boolean;
-  emailRequired?: boolean;
-  shippingAddressRequired?: boolean;
-  existingPaymentMethodRequired?: boolean;
-  totalPriceStatus?: 'NOT_CURRENTLY_KNOWN' | 'ESTIMATED' | 'FINAL';
-};
-
 export type PaymentConfiguration = {
   shopperLocale: string;
   amount: number;
   currency: string;
   countryCode: string;
-  merchantName?: string;
   merchantAccount: string;
   shopperReference: string;
-  cardSettings?: CardSettings;
-  dropInSettings?: DropInSettings;
-  applePaySettings?: ApplePaySettings;
-  googlePaySettings?: GooglePaySettings;
 };
 
 export interface BalanceResponse {

--- a/example/src/api/types.ts
+++ b/example/src/api/types.ts
@@ -27,6 +27,40 @@ export interface PaymentResponse {
   resultCode: ResultCode;
 }
 
+export type CardSettings = {
+  holderNameRequired?: boolean;
+  addressVisibility?: 'full' | 'postalCode' | 'none' | 'lookup';
+  showStorePaymentField?: boolean;
+  hideCvcStoredCard?: boolean;
+  hideCvc?: boolean;
+  kcpVisibility?: 'show' | 'hide';
+  socialSecurity?: 'show' | 'hide';
+};
+
+export type DropInSettings = {
+  showPreselectedStoredPaymentMethod?: boolean;
+  skipListWhenSinglePaymentMethod?: boolean;
+  showRemovePaymentMethodButton?: boolean;
+  title?: string;
+};
+
+export type ApplePaySettings = {
+  merchantID?: string;
+  merchantName?: string;
+  allowOnboarding?: boolean;
+  shippingType?: 'shipping' | 'delivery' | 'storePickup' | 'servicePickup';
+};
+
+export type GooglePaySettings = {
+  allowPrepaidCards?: boolean;
+  allowCreditCards?: boolean;
+  billingAddressRequired?: boolean;
+  emailRequired?: boolean;
+  shippingAddressRequired?: boolean;
+  existingPaymentMethodRequired?: boolean;
+  totalPriceStatus?: 'NOT_CURRENTLY_KNOWN' | 'ESTIMATED' | 'FINAL';
+};
+
 export type PaymentConfiguration = {
   shopperLocale: string;
   amount: number;
@@ -35,6 +69,10 @@ export type PaymentConfiguration = {
   merchantName?: string;
   merchantAccount: string;
   shopperReference: string;
+  cardSettings?: CardSettings;
+  dropInSettings?: DropInSettings;
+  applePaySettings?: ApplePaySettings;
+  googlePaySettings?: GooglePaySettings;
 };
 
 export interface BalanceResponse {

--- a/example/src/checkoutConfiguration.ts
+++ b/example/src/checkoutConfiguration.ts
@@ -26,7 +26,13 @@ export const checkoutConfiguration = (config: PaymentConfiguration) => {
       verboseLogs: true,
     },
     dropin: {
-      showRemovePaymentMethodButton: true,
+      showPreselectedStoredPaymentMethod:
+        config.dropInSettings?.showPreselectedStoredPaymentMethod,
+      skipListWhenSinglePaymentMethod:
+        config.dropInSettings?.skipListWhenSinglePaymentMethod,
+      showRemovePaymentMethodButton:
+        config.dropInSettings?.showRemovePaymentMethodButton ?? true,
+      title: config.dropInSettings?.title,
       onDisableStoredPaymentMethod: async (
         storedPaymentMethod: StoredPaymentMethod,
         resolve: () => void,
@@ -44,14 +50,18 @@ export const checkoutConfiguration = (config: PaymentConfiguration) => {
       },
     },
     card: {
-      addressVisibility: 'lookup',
+      holderNameRequired: config.cardSettings?.holderNameRequired,
+      addressVisibility: config.cardSettings?.addressVisibility ?? 'lookup',
+      showStorePaymentField: config.cardSettings?.showStorePaymentField,
+      hideCvcStoredCard: config.cardSettings?.hideCvcStoredCard,
+      hideCvc: config.cardSettings?.hideCvc,
+      kcpVisibility: config.cardSettings?.kcpVisibility,
+      socialSecurity: config.cardSettings?.socialSecurity,
       allowedAddressCountryCodes: ['US', 'GB', 'CA', 'NL'],
       onUpdateAddress: (_prompt: string, lookup: AddressLookup) => {
-        // Make request to Google Maps API or other address provider.
         lookup.update(mockAddresses);
       },
       onConfirmAddress: (address: AddressLookupItem, lookup: AddressLookup) => {
-        // Make request to Google Maps API or other address provider.
         lookup.confirm(address);
       },
       onBinValue: (binValue: string) => {
@@ -62,8 +72,12 @@ export const checkoutConfiguration = (config: PaymentConfiguration) => {
       },
     },
     applepay: {
-      merchantID: ENVIRONMENT.applepayMerchantID,
-      merchantName: config.merchantName,
+      merchantID:
+        config.applePaySettings?.merchantID ?? ENVIRONMENT.applepayMerchantID,
+      merchantName:
+        config.applePaySettings?.merchantName ?? config.merchantName,
+      allowOnboarding: config.applePaySettings?.allowOnboarding,
+      shippingType: config.applePaySettings?.shippingType,
       requiredBillingContactFields: ['phoneticName', 'postalAddress'],
       requiredShippingContactFields: [
         'name',
@@ -74,17 +88,24 @@ export const checkoutConfiguration = (config: PaymentConfiguration) => {
       recurringPaymentRequest: mockApplePayRecurringPayment,
     },
     googlepay: {
-      billingAddressRequired: true,
+      allowPrepaidCards: config.googlePaySettings?.allowPrepaidCards,
+      allowCreditCards: config.googlePaySettings?.allowCreditCards,
+      billingAddressRequired:
+        config.googlePaySettings?.billingAddressRequired ?? true,
       billingAddressParameters: {
         format: 'FULL',
         phoneNumberRequired: true,
       },
-      shippingAddressRequired: true,
+      shippingAddressRequired:
+        config.googlePaySettings?.shippingAddressRequired ?? true,
       shippingAddressParameters: {
         allowedCountryCodes: ['US', 'MX'],
         phoneNumberRequired: true,
       },
-      emailRequired: true,
+      emailRequired: config.googlePaySettings?.emailRequired ?? true,
+      existingPaymentMethodRequired:
+        config.googlePaySettings?.existingPaymentMethodRequired,
+      totalPriceStatus: config.googlePaySettings?.totalPriceStatus,
     },
   };
   return configuration;

--- a/example/src/components/Checkout/AdvancedCheckout.tsx
+++ b/example/src/components/Checkout/AdvancedCheckout.tsx
@@ -17,7 +17,7 @@ import { processAdyenError } from './utils/processAdyenError';
 import { processError } from './utils/processError';
 import { PaymentResponse } from '../../api/types';
 import { CheckoutNavigator } from '../../router/CheckoutNavigator';
-import { checkoutConfiguration } from '../../checkoutConfiguration';
+import { checkoutConfiguration } from '../../settings/checkoutConfiguration';
 
 const AdvancedCheckout = () => {
   const { configuration, processResult } = useAppContext();

--- a/example/src/components/Checkout/PartialPaymentCheckout.tsx
+++ b/example/src/components/Checkout/PartialPaymentCheckout.tsx
@@ -18,7 +18,7 @@ import Styles from '../common/Styles';
 import TopView from './components/TopView';
 import ApiClient from '../../api/APIClient';
 import { useAppContext } from '../../hooks/useAppContext';
-import { checkoutConfiguration } from '../../checkoutConfiguration';
+import { checkoutConfiguration } from '../../settings/checkoutConfiguration';
 import { processAdyenError } from './utils/processAdyenError';
 import { processError } from './utils/processError';
 import { processPartialPaymentResult } from './utils/processPartialPaymentResult';

--- a/example/src/components/Checkout/SessionsComponentsCheckout.tsx
+++ b/example/src/components/Checkout/SessionsComponentsCheckout.tsx
@@ -12,7 +12,7 @@ import Styles from '../common/Styles';
 import TopView from './components/TopView';
 import ApiClient from '../../api/APIClient';
 import { useAppContext } from '../../hooks/useAppContext';
-import { checkoutConfiguration } from '../../checkoutConfiguration';
+import { checkoutConfiguration } from '../../settings/checkoutConfiguration';
 import { processAdyenError } from './utils/processAdyenError';
 import { ENVIRONMENT } from '../../Configuration';
 

--- a/example/src/components/Checkout/SessionsDropInCheckout.tsx
+++ b/example/src/components/Checkout/SessionsDropInCheckout.tsx
@@ -12,7 +12,7 @@ import Styles from '../common/Styles';
 import TopView from './components/TopView';
 import ApiClient from '../../api/APIClient';
 import { useAppContext } from '../../hooks/useAppContext';
-import { checkoutConfiguration } from '../../checkoutConfiguration';
+import { checkoutConfiguration } from '../../settings/checkoutConfiguration';
 import { processAdyenError } from './utils/processAdyenError';
 import { ENVIRONMENT } from '../../Configuration';
 

--- a/example/src/components/Settings/ApplePaySettingsView.tsx
+++ b/example/src/components/Settings/ApplePaySettingsView.tsx
@@ -20,7 +20,7 @@ const shippingTypes = [
 ] as const;
 
 const ApplePaySettingsView = ({ navigation }: Props) => {
-  const { configuration, save } = useAppContext();
+  const { configuration, update } = useAppContext();
   const existing = configuration.applePaySettings ?? {};
 
   const [merchantID, setMerchantID] = useState(
@@ -35,8 +35,7 @@ const ApplePaySettingsView = ({ navigation }: Props) => {
   >(existing.shippingType ?? 'shipping');
 
   const saveAndGoBack = useCallback(() => {
-    save({
-      ...configuration,
+    update({
       applePaySettings: {
         merchantID: merchantID || undefined,
         merchantName: merchantName || undefined,
@@ -46,8 +45,7 @@ const ApplePaySettingsView = ({ navigation }: Props) => {
     });
     navigation.goBack();
   }, [
-    configuration,
-    save,
+    update,
     navigation,
     merchantID,
     merchantName,
@@ -76,7 +74,7 @@ const ApplePaySettingsView = ({ navigation }: Props) => {
         title="Shipping Type"
         value={shippingType ?? 'shipping'}
         options={[...shippingTypes]}
-        onChange={(v) => setShippingType(v as ApplePaySettings['shippingType'])}
+        onChange={setShippingType}
       />
       <View style={Styles.formAction}>
         <Button title="Save" onPress={saveAndGoBack} />

--- a/example/src/components/Settings/ApplePaySettingsView.tsx
+++ b/example/src/components/Settings/ApplePaySettingsView.tsx
@@ -1,0 +1,85 @@
+import { useCallback, useState } from 'react';
+import { Button, ScrollView, View } from 'react-native';
+import { useAppContext } from '../../hooks/useAppContext';
+import Styles from '../common/Styles';
+import FormToggle from '../common/FormToggle';
+import FormTextInput from '../common/FormTextInput';
+import FormDropdown from '../common/FormDropdown';
+import type { ApplePaySettings } from '../../api/types';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { SettingsStackParamList } from './SettingsNavigator';
+
+type Props = NativeStackScreenProps<SettingsStackParamList, 'ApplePaySettings'>;
+
+const shippingTypes = [
+  'shipping',
+  'delivery',
+  'storePickup',
+  'servicePickup',
+] as const;
+
+const ApplePaySettingsView = ({ navigation }: Props) => {
+  const { configuration, save } = useAppContext();
+  const existing = configuration.applePaySettings ?? {};
+
+  const [merchantID, setMerchantID] = useState(existing.merchantID ?? '');
+  const [merchantName, setMerchantName] = useState(existing.merchantName ?? '');
+  const [allowOnboarding, setAllowOnboarding] = useState(
+    existing.allowOnboarding ?? false
+  );
+  const [shippingType, setShippingType] = useState<
+    ApplePaySettings['shippingType']
+  >(existing.shippingType ?? 'shipping');
+
+  const saveAndGoBack = useCallback(() => {
+    save({
+      ...configuration,
+      applePaySettings: {
+        merchantID: merchantID || undefined,
+        merchantName: merchantName || undefined,
+        allowOnboarding,
+        shippingType,
+      },
+    });
+    navigation.goBack();
+  }, [
+    configuration,
+    save,
+    navigation,
+    merchantID,
+    merchantName,
+    allowOnboarding,
+    shippingType,
+  ]);
+
+  return (
+    <ScrollView style={Styles.page}>
+      <FormTextInput
+        title="Merchant ID"
+        value={merchantID}
+        onChangeText={setMerchantID}
+      />
+      <FormTextInput
+        title="Merchant Name"
+        value={merchantName}
+        onChangeText={setMerchantName}
+      />
+      <FormToggle
+        title="Allow Onboarding"
+        value={allowOnboarding}
+        onValueChange={setAllowOnboarding}
+      />
+      <FormDropdown
+        title="Shipping Type"
+        value={shippingType ?? 'shipping'}
+        options={[...shippingTypes]}
+        onChange={(v) => setShippingType(v as ApplePaySettings['shippingType'])}
+      />
+      <View style={Styles.formAction}>
+        <Button title="Save" onPress={saveAndGoBack} />
+      </View>
+    </ScrollView>
+  );
+};
+
+export default ApplePaySettingsView;

--- a/example/src/components/Settings/ApplePaySettingsView.tsx
+++ b/example/src/components/Settings/ApplePaySettingsView.tsx
@@ -5,7 +5,8 @@ import Styles from '../common/Styles';
 import FormToggle from '../common/FormToggle';
 import FormTextInput from '../common/FormTextInput';
 import FormDropdown from '../common/FormDropdown';
-import type { ApplePaySettings } from '../../api/types';
+import { ENVIRONMENT } from '../../Configuration';
+import type { ApplePaySettings } from '../../settings/types';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { SettingsStackParamList } from './SettingsNavigator';
 
@@ -22,7 +23,9 @@ const ApplePaySettingsView = ({ navigation }: Props) => {
   const { configuration, save } = useAppContext();
   const existing = configuration.applePaySettings ?? {};
 
-  const [merchantID, setMerchantID] = useState(existing.merchantID ?? '');
+  const [merchantID, setMerchantID] = useState(
+    existing.merchantID ?? ENVIRONMENT.applepayMerchantID
+  );
   const [merchantName, setMerchantName] = useState(existing.merchantName ?? '');
   const [allowOnboarding, setAllowOnboarding] = useState(
     existing.allowOnboarding ?? false

--- a/example/src/components/Settings/CardSettingsView.tsx
+++ b/example/src/components/Settings/CardSettingsView.tsx
@@ -4,7 +4,7 @@ import { useAppContext } from '../../hooks/useAppContext';
 import Styles from '../common/Styles';
 import FormToggle from '../common/FormToggle';
 import FormDropdown from '../common/FormDropdown';
-import type { CardSettings } from '../../api/types';
+import type { CardSettings } from '../../settings/types';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { SettingsStackParamList } from './SettingsNavigator';
 
@@ -22,7 +22,7 @@ const CardSettingsView = ({ navigation }: Props) => {
   );
   const [addressVisibility, setAddressVisibility] = useState<
     CardSettings['addressVisibility']
-  >(existing.addressVisibility ?? 'none');
+  >(existing.addressVisibility ?? 'lookup');
   const [showStorePaymentField, setShowStorePaymentField] = useState(
     existing.showStorePaymentField ?? true
   );
@@ -73,7 +73,7 @@ const CardSettingsView = ({ navigation }: Props) => {
       />
       <FormDropdown
         title="Address Visibility"
-        value={addressVisibility ?? 'none'}
+        value={addressVisibility ?? 'lookup'}
         options={[...addressModes]}
         onChange={(v) =>
           setAddressVisibility(v as CardSettings['addressVisibility'])

--- a/example/src/components/Settings/CardSettingsView.tsx
+++ b/example/src/components/Settings/CardSettingsView.tsx
@@ -14,7 +14,7 @@ const addressModes = ['none', 'postalCode', 'full', 'lookup'] as const;
 const fieldVisibilities = ['show', 'hide'] as const;
 
 const CardSettingsView = ({ navigation }: Props) => {
-  const { configuration, save } = useAppContext();
+  const { configuration, update } = useAppContext();
   const existing = configuration.cardSettings ?? {};
 
   const [holderNameRequired, setHolderNameRequired] = useState(
@@ -38,8 +38,7 @@ const CardSettingsView = ({ navigation }: Props) => {
   >(existing.socialSecurity ?? 'hide');
 
   const saveAndGoBack = useCallback(() => {
-    save({
-      ...configuration,
+    update({
       cardSettings: {
         holderNameRequired,
         addressVisibility,
@@ -52,8 +51,7 @@ const CardSettingsView = ({ navigation }: Props) => {
     });
     navigation.goBack();
   }, [
-    configuration,
-    save,
+    update,
     navigation,
     holderNameRequired,
     addressVisibility,
@@ -75,9 +73,7 @@ const CardSettingsView = ({ navigation }: Props) => {
         title="Address Visibility"
         value={addressVisibility ?? 'lookup'}
         options={[...addressModes]}
-        onChange={(v) =>
-          setAddressVisibility(v as CardSettings['addressVisibility'])
-        }
+        onChange={setAddressVisibility}
       />
       <FormToggle
         title="Show Store Payment Field"
@@ -94,13 +90,13 @@ const CardSettingsView = ({ navigation }: Props) => {
         title="KCP Visibility"
         value={kcpVisibility ?? 'hide'}
         options={[...fieldVisibilities]}
-        onChange={(v) => setKcpVisibility(v as CardSettings['kcpVisibility'])}
+        onChange={setKcpVisibility}
       />
       <FormDropdown
         title="Social Security"
         value={socialSecurity ?? 'hide'}
         options={[...fieldVisibilities]}
-        onChange={(v) => setSocialSecurity(v as CardSettings['socialSecurity'])}
+        onChange={setSocialSecurity}
       />
       <View style={Styles.formAction}>
         <Button title="Save" onPress={saveAndGoBack} />

--- a/example/src/components/Settings/CardSettingsView.tsx
+++ b/example/src/components/Settings/CardSettingsView.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useState } from 'react';
+import { Button, ScrollView, View } from 'react-native';
+import { useAppContext } from '../../hooks/useAppContext';
+import Styles from '../common/Styles';
+import FormToggle from '../common/FormToggle';
+import FormDropdown from '../common/FormDropdown';
+import type { CardSettings } from '../../api/types';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { SettingsStackParamList } from './SettingsNavigator';
+
+type Props = NativeStackScreenProps<SettingsStackParamList, 'CardSettings'>;
+
+const addressModes = ['none', 'postalCode', 'full', 'lookup'] as const;
+const fieldVisibilities = ['show', 'hide'] as const;
+
+const CardSettingsView = ({ navigation }: Props) => {
+  const { configuration, save } = useAppContext();
+  const existing = configuration.cardSettings ?? {};
+
+  const [holderNameRequired, setHolderNameRequired] = useState(
+    existing.holderNameRequired ?? false
+  );
+  const [addressVisibility, setAddressVisibility] = useState<
+    CardSettings['addressVisibility']
+  >(existing.addressVisibility ?? 'none');
+  const [showStorePaymentField, setShowStorePaymentField] = useState(
+    existing.showStorePaymentField ?? true
+  );
+  const [hideCvcStoredCard, setHideCvcStoredCard] = useState(
+    existing.hideCvcStoredCard ?? false
+  );
+  const [hideCvc, setHideCvc] = useState(existing.hideCvc ?? false);
+  const [kcpVisibility, setKcpVisibility] = useState<
+    CardSettings['kcpVisibility']
+  >(existing.kcpVisibility ?? 'hide');
+  const [socialSecurity, setSocialSecurity] = useState<
+    CardSettings['socialSecurity']
+  >(existing.socialSecurity ?? 'hide');
+
+  const saveAndGoBack = useCallback(() => {
+    save({
+      ...configuration,
+      cardSettings: {
+        holderNameRequired,
+        addressVisibility,
+        showStorePaymentField,
+        hideCvcStoredCard,
+        hideCvc,
+        kcpVisibility,
+        socialSecurity,
+      },
+    });
+    navigation.goBack();
+  }, [
+    configuration,
+    save,
+    navigation,
+    holderNameRequired,
+    addressVisibility,
+    showStorePaymentField,
+    hideCvcStoredCard,
+    hideCvc,
+    kcpVisibility,
+    socialSecurity,
+  ]);
+
+  return (
+    <ScrollView style={Styles.page}>
+      <FormToggle
+        title="Holder Name Required"
+        value={holderNameRequired}
+        onValueChange={setHolderNameRequired}
+      />
+      <FormDropdown
+        title="Address Visibility"
+        value={addressVisibility ?? 'none'}
+        options={[...addressModes]}
+        onChange={(v) =>
+          setAddressVisibility(v as CardSettings['addressVisibility'])
+        }
+      />
+      <FormToggle
+        title="Show Store Payment Field"
+        value={showStorePaymentField}
+        onValueChange={setShowStorePaymentField}
+      />
+      <FormToggle
+        title="Hide CVC (Stored Card)"
+        value={hideCvcStoredCard}
+        onValueChange={setHideCvcStoredCard}
+      />
+      <FormToggle title="Hide CVC" value={hideCvc} onValueChange={setHideCvc} />
+      <FormDropdown
+        title="KCP Visibility"
+        value={kcpVisibility ?? 'hide'}
+        options={[...fieldVisibilities]}
+        onChange={(v) => setKcpVisibility(v as CardSettings['kcpVisibility'])}
+      />
+      <FormDropdown
+        title="Social Security"
+        value={socialSecurity ?? 'hide'}
+        options={[...fieldVisibilities]}
+        onChange={(v) => setSocialSecurity(v as CardSettings['socialSecurity'])}
+      />
+      <View style={Styles.formAction}>
+        <Button title="Save" onPress={saveAndGoBack} />
+      </View>
+    </ScrollView>
+  );
+};
+
+export default CardSettingsView;

--- a/example/src/components/Settings/DropInSettingsView.tsx
+++ b/example/src/components/Settings/DropInSettingsView.tsx
@@ -10,7 +10,7 @@ import type { SettingsStackParamList } from './SettingsNavigator';
 type Props = NativeStackScreenProps<SettingsStackParamList, 'DropInSettings'>;
 
 const DropInSettingsView = ({ navigation }: Props) => {
-  const { configuration, save } = useAppContext();
+  const { configuration, update } = useAppContext();
   const existing = configuration.dropInSettings ?? {};
 
   const [showPreselected, setShowPreselected] = useState(
@@ -25,8 +25,7 @@ const DropInSettingsView = ({ navigation }: Props) => {
   const [title, setTitle] = useState(existing.title ?? '');
 
   const saveAndGoBack = useCallback(() => {
-    save({
-      ...configuration,
+    update({
       dropInSettings: {
         showPreselectedStoredPaymentMethod: showPreselected,
         skipListWhenSinglePaymentMethod: skipListWhenSingle,
@@ -36,8 +35,7 @@ const DropInSettingsView = ({ navigation }: Props) => {
     });
     navigation.goBack();
   }, [
-    configuration,
-    save,
+    update,
     navigation,
     showPreselected,
     skipListWhenSingle,

--- a/example/src/components/Settings/DropInSettingsView.tsx
+++ b/example/src/components/Settings/DropInSettingsView.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useState } from 'react';
+import { Button, ScrollView, View } from 'react-native';
+import { useAppContext } from '../../hooks/useAppContext';
+import Styles from '../common/Styles';
+import FormToggle from '../common/FormToggle';
+import FormTextInput from '../common/FormTextInput';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { SettingsStackParamList } from './SettingsNavigator';
+
+type Props = NativeStackScreenProps<SettingsStackParamList, 'DropInSettings'>;
+
+const DropInSettingsView = ({ navigation }: Props) => {
+  const { configuration, save } = useAppContext();
+  const existing = configuration.dropInSettings ?? {};
+
+  const [showPreselected, setShowPreselected] = useState(
+    existing.showPreselectedStoredPaymentMethod ?? true
+  );
+  const [skipListWhenSingle, setSkipListWhenSingle] = useState(
+    existing.skipListWhenSinglePaymentMethod ?? false
+  );
+  const [showRemoveButton, setShowRemoveButton] = useState(
+    existing.showRemovePaymentMethodButton ?? true
+  );
+  const [title, setTitle] = useState(existing.title ?? '');
+
+  const saveAndGoBack = useCallback(() => {
+    save({
+      ...configuration,
+      dropInSettings: {
+        showPreselectedStoredPaymentMethod: showPreselected,
+        skipListWhenSinglePaymentMethod: skipListWhenSingle,
+        showRemovePaymentMethodButton: showRemoveButton,
+        title: title || undefined,
+      },
+    });
+    navigation.goBack();
+  }, [
+    configuration,
+    save,
+    navigation,
+    showPreselected,
+    skipListWhenSingle,
+    showRemoveButton,
+    title,
+  ]);
+
+  return (
+    <ScrollView style={Styles.page}>
+      <FormToggle
+        title="Show Preselected Stored Payment"
+        value={showPreselected}
+        onValueChange={setShowPreselected}
+      />
+      <FormToggle
+        title="Skip List When Single Method"
+        value={skipListWhenSingle}
+        onValueChange={setSkipListWhenSingle}
+      />
+      <FormToggle
+        title="Show Remove Payment Button"
+        value={showRemoveButton}
+        onValueChange={setShowRemoveButton}
+      />
+      <FormTextInput
+        title="Title (iOS only)"
+        value={title}
+        onChangeText={setTitle}
+        placeholder="App name used by default"
+      />
+      <View style={Styles.formAction}>
+        <Button title="Save" onPress={saveAndGoBack} />
+      </View>
+    </ScrollView>
+  );
+};
+
+export default DropInSettingsView;

--- a/example/src/components/Settings/GooglePaySettingsView.tsx
+++ b/example/src/components/Settings/GooglePaySettingsView.tsx
@@ -20,7 +20,7 @@ const totalPriceStatuses = [
 ] as const;
 
 const GooglePaySettingsView = ({ navigation }: Props) => {
-  const { configuration, save } = useAppContext();
+  const { configuration, update } = useAppContext();
   const existing = configuration.googlePaySettings ?? {};
 
   const [allowPrepaidCards, setAllowPrepaidCards] = useState(
@@ -45,8 +45,7 @@ const GooglePaySettingsView = ({ navigation }: Props) => {
   >(existing.totalPriceStatus ?? 'FINAL');
 
   const saveAndGoBack = useCallback(() => {
-    save({
-      ...configuration,
+    update({
       googlePaySettings: {
         allowPrepaidCards,
         allowCreditCards,
@@ -59,8 +58,7 @@ const GooglePaySettingsView = ({ navigation }: Props) => {
     });
     navigation.goBack();
   }, [
-    configuration,
-    save,
+    update,
     navigation,
     allowPrepaidCards,
     allowCreditCards,
@@ -107,9 +105,7 @@ const GooglePaySettingsView = ({ navigation }: Props) => {
         title="Total Price Status"
         value={totalPriceStatus ?? 'FINAL'}
         options={[...totalPriceStatuses]}
-        onChange={(v) =>
-          setTotalPriceStatus(v as GooglePaySettings['totalPriceStatus'])
-        }
+        onChange={setTotalPriceStatus}
       />
       <View style={Styles.formAction}>
         <Button title="Save" onPress={saveAndGoBack} />

--- a/example/src/components/Settings/GooglePaySettingsView.tsx
+++ b/example/src/components/Settings/GooglePaySettingsView.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useState } from 'react';
+import { Button, ScrollView, View } from 'react-native';
+import { useAppContext } from '../../hooks/useAppContext';
+import Styles from '../common/Styles';
+import FormToggle from '../common/FormToggle';
+import FormDropdown from '../common/FormDropdown';
+import type { GooglePaySettings } from '../../api/types';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { SettingsStackParamList } from './SettingsNavigator';
+
+type Props = NativeStackScreenProps<
+  SettingsStackParamList,
+  'GooglePaySettings'
+>;
+
+const totalPriceStatuses = [
+  'NOT_CURRENTLY_KNOWN',
+  'ESTIMATED',
+  'FINAL',
+] as const;
+
+const GooglePaySettingsView = ({ navigation }: Props) => {
+  const { configuration, save } = useAppContext();
+  const existing = configuration.googlePaySettings ?? {};
+
+  const [allowPrepaidCards, setAllowPrepaidCards] = useState(
+    existing.allowPrepaidCards ?? true
+  );
+  const [allowCreditCards, setAllowCreditCards] = useState(
+    existing.allowCreditCards ?? true
+  );
+  const [billingAddressRequired, setBillingAddressRequired] = useState(
+    existing.billingAddressRequired ?? false
+  );
+  const [emailRequired, setEmailRequired] = useState(
+    existing.emailRequired ?? false
+  );
+  const [shippingAddressRequired, setShippingAddressRequired] = useState(
+    existing.shippingAddressRequired ?? false
+  );
+  const [existingPaymentMethodRequired, setExistingPaymentMethodRequired] =
+    useState(existing.existingPaymentMethodRequired ?? false);
+  const [totalPriceStatus, setTotalPriceStatus] = useState<
+    GooglePaySettings['totalPriceStatus']
+  >(existing.totalPriceStatus ?? 'FINAL');
+
+  const saveAndGoBack = useCallback(() => {
+    save({
+      ...configuration,
+      googlePaySettings: {
+        allowPrepaidCards,
+        allowCreditCards,
+        billingAddressRequired,
+        emailRequired,
+        shippingAddressRequired,
+        existingPaymentMethodRequired,
+        totalPriceStatus,
+      },
+    });
+    navigation.goBack();
+  }, [
+    configuration,
+    save,
+    navigation,
+    allowPrepaidCards,
+    allowCreditCards,
+    billingAddressRequired,
+    emailRequired,
+    shippingAddressRequired,
+    existingPaymentMethodRequired,
+    totalPriceStatus,
+  ]);
+
+  return (
+    <ScrollView style={Styles.page}>
+      <FormToggle
+        title="Allow Prepaid Cards"
+        value={allowPrepaidCards}
+        onValueChange={setAllowPrepaidCards}
+      />
+      <FormToggle
+        title="Allow Credit Cards"
+        value={allowCreditCards}
+        onValueChange={setAllowCreditCards}
+      />
+      <FormToggle
+        title="Billing Address Required"
+        value={billingAddressRequired}
+        onValueChange={setBillingAddressRequired}
+      />
+      <FormToggle
+        title="Email Required"
+        value={emailRequired}
+        onValueChange={setEmailRequired}
+      />
+      <FormToggle
+        title="Shipping Address Required"
+        value={shippingAddressRequired}
+        onValueChange={setShippingAddressRequired}
+      />
+      <FormToggle
+        title="Existing Payment Method Required"
+        value={existingPaymentMethodRequired}
+        onValueChange={setExistingPaymentMethodRequired}
+      />
+      <FormDropdown
+        title="Total Price Status"
+        value={totalPriceStatus ?? 'FINAL'}
+        options={[...totalPriceStatuses]}
+        onChange={(v) =>
+          setTotalPriceStatus(v as GooglePaySettings['totalPriceStatus'])
+        }
+      />
+      <View style={Styles.formAction}>
+        <Button title="Save" onPress={saveAndGoBack} />
+      </View>
+    </ScrollView>
+  );
+};
+
+export default GooglePaySettingsView;

--- a/example/src/components/Settings/GooglePaySettingsView.tsx
+++ b/example/src/components/Settings/GooglePaySettingsView.tsx
@@ -4,7 +4,7 @@ import { useAppContext } from '../../hooks/useAppContext';
 import Styles from '../common/Styles';
 import FormToggle from '../common/FormToggle';
 import FormDropdown from '../common/FormDropdown';
-import type { GooglePaySettings } from '../../api/types';
+import type { GooglePaySettings } from '../../settings/types';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { SettingsStackParamList } from './SettingsNavigator';
 
@@ -30,13 +30,13 @@ const GooglePaySettingsView = ({ navigation }: Props) => {
     existing.allowCreditCards ?? true
   );
   const [billingAddressRequired, setBillingAddressRequired] = useState(
-    existing.billingAddressRequired ?? false
+    existing.billingAddressRequired ?? true
   );
   const [emailRequired, setEmailRequired] = useState(
-    existing.emailRequired ?? false
+    existing.emailRequired ?? true
   );
   const [shippingAddressRequired, setShippingAddressRequired] = useState(
-    existing.shippingAddressRequired ?? false
+    existing.shippingAddressRequired ?? true
   );
   const [existingPaymentMethodRequired, setExistingPaymentMethodRequired] =
     useState(existing.existingPaymentMethodRequired ?? false);

--- a/example/src/components/Settings/SettingsNavigator.tsx
+++ b/example/src/components/Settings/SettingsNavigator.tsx
@@ -1,0 +1,50 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import SettingView from './SettingsView';
+import CardSettingsView from './CardSettingsView';
+import DropInSettingsView from './DropInSettingsView';
+import ApplePaySettingsView from './ApplePaySettingsView';
+import GooglePaySettingsView from './GooglePaySettingsView';
+
+export type SettingsStackParamList = {
+  GeneralSettings: undefined;
+  CardSettings: undefined;
+  DropInSettings: undefined;
+  ApplePaySettings: undefined;
+  GooglePaySettings: undefined;
+};
+
+const SettingsStack = createNativeStackNavigator<SettingsStackParamList>();
+
+const SettingsNavigator = () => {
+  return (
+    <SettingsStack.Navigator>
+      <SettingsStack.Screen
+        name="GeneralSettings"
+        component={SettingView}
+        options={{ title: 'Settings' }}
+      />
+      <SettingsStack.Screen
+        name="CardSettings"
+        component={CardSettingsView}
+        options={{ title: 'Card Settings' }}
+      />
+      <SettingsStack.Screen
+        name="DropInSettings"
+        component={DropInSettingsView}
+        options={{ title: 'Drop-In Settings' }}
+      />
+      <SettingsStack.Screen
+        name="ApplePaySettings"
+        component={ApplePaySettingsView}
+        options={{ title: 'Apple Pay Settings' }}
+      />
+      <SettingsStack.Screen
+        name="GooglePaySettings"
+        component={GooglePaySettingsView}
+        options={{ title: 'Google Pay Settings' }}
+      />
+    </SettingsStack.Navigator>
+  );
+};
+
+export default SettingsNavigator;

--- a/example/src/components/Settings/SettingsView.tsx
+++ b/example/src/components/Settings/SettingsView.tsx
@@ -1,10 +1,15 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useAppContext } from '../../hooks/useAppContext';
 import Styles from '../common/Styles';
-import { Button, ScrollView, View } from 'react-native';
+import { Button, ScrollView, TouchableOpacity, View } from 'react-native';
 import FormTextInput from '../common/FormTextInput';
+import AdaptiveText from '../common/AdaptiveText';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { SettingsStackParamList } from './SettingsNavigator';
 
-const SettingView = () => {
+type Props = NativeStackScreenProps<SettingsStackParamList, 'GeneralSettings'>;
+
+const SettingView = ({ navigation }: Props) => {
   const { configuration, save, navigateToRoot } = useAppContext();
 
   const [countryCode, setCountryCode] = useState(configuration.countryCode);
@@ -23,6 +28,7 @@ const SettingView = () => {
 
   const settings = useMemo(
     () => ({
+      ...configuration,
       countryCode: countryCode,
       amount: Number(amount),
       currency: currency,
@@ -32,6 +38,7 @@ const SettingView = () => {
       shopperReference: shopperReference,
     }),
     [
+      configuration,
       countryCode,
       amount,
       currency,
@@ -88,7 +95,44 @@ const SettingView = () => {
         value={shopperReference}
         onChangeText={setShopperReference}
       />
-      <View style={Styles.padded}>
+
+      <AdaptiveText style={Styles.sectionTitle}>
+        Component Settings
+      </AdaptiveText>
+      <TouchableOpacity
+        style={Styles.transparentButton}
+        onPress={() => navigation.navigate('CardSettings')}
+      >
+        <AdaptiveText style={Styles.transparentButtonText}>
+          Card Settings
+        </AdaptiveText>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={Styles.transparentButton}
+        onPress={() => navigation.navigate('DropInSettings')}
+      >
+        <AdaptiveText style={Styles.transparentButtonText}>
+          Drop-In Settings
+        </AdaptiveText>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={Styles.transparentButton}
+        onPress={() => navigation.navigate('ApplePaySettings')}
+      >
+        <AdaptiveText style={Styles.transparentButtonText}>
+          Apple Pay Settings
+        </AdaptiveText>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={Styles.transparentButton}
+        onPress={() => navigation.navigate('GooglePaySettings')}
+      >
+        <AdaptiveText style={Styles.transparentButtonText}>
+          Google Pay Settings
+        </AdaptiveText>
+      </TouchableOpacity>
+
+      <View style={Styles.formAction}>
         <Button title="Save" onPress={saveAndClose} />
       </View>
     </ScrollView>

--- a/example/src/components/Settings/SettingsView.tsx
+++ b/example/src/components/Settings/SettingsView.tsx
@@ -15,7 +15,6 @@ const SettingView = ({ navigation }: Props) => {
   const [countryCode, setCountryCode] = useState(configuration.countryCode);
   const [amount, setAmount] = useState(String(configuration.amount));
   const [currency, setCurrency] = useState(configuration.currency);
-  const [merchantName, setMerchantName] = useState(configuration.merchantName);
   const [merchantAccount, setMerchantAccount] = useState(
     configuration.merchantAccount
   );
@@ -33,7 +32,6 @@ const SettingView = ({ navigation }: Props) => {
       amount: Number(amount),
       currency: currency,
       merchantAccount: merchantAccount,
-      merchantName: merchantName,
       shopperLocale: shopperLocale,
       shopperReference: shopperReference,
     }),
@@ -43,7 +41,6 @@ const SettingView = ({ navigation }: Props) => {
       amount,
       currency,
       merchantAccount,
-      merchantName,
       shopperLocale,
       shopperReference,
     ]
@@ -78,11 +75,6 @@ const SettingView = ({ navigation }: Props) => {
         title="Merchant Account"
         value={merchantAccount}
         onChangeText={setMerchantAccount}
-      />
-      <FormTextInput
-        title="Merchant Name"
-        value={merchantName}
-        onChangeText={setMerchantName}
       />
       <FormTextInput
         title="Shopper locale"

--- a/example/src/components/common/FormDropdown.tsx
+++ b/example/src/components/common/FormDropdown.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import {
+  View,
+  TouchableOpacity,
+  Modal,
+  FlatList,
+  useColorScheme,
+} from 'react-native';
+import Styles from './Styles';
+import AdaptiveText from './AdaptiveText';
+import Colors from './Assets';
+
+type FormDropdownProps<T extends string> = {
+  title: string;
+  value: T;
+  options: T[];
+  onChange: (value: T) => void;
+};
+
+const FormDropdown = <T extends string>({
+  title,
+  value,
+  options,
+  onChange,
+}: FormDropdownProps<T>) => {
+  const [visible, setVisible] = useState(false);
+  const isDarkMode = useColorScheme() === 'dark';
+
+  const backgroundColor = isDarkMode
+    ? Colors.textBackgroundDark
+    : Colors.textBackgroundLight;
+  const textColor = isDarkMode ? Colors.textDark : Colors.textLight;
+
+  return (
+    <View>
+      <AdaptiveText style={Styles.paddedTitle}>{title}</AdaptiveText>
+      <TouchableOpacity
+        style={[Styles.dropdown, { backgroundColor }]}
+        onPress={() => setVisible(true)}
+      >
+        <AdaptiveText style={Styles.dropdownText}>{value}</AdaptiveText>
+      </TouchableOpacity>
+      <Modal visible={visible} transparent animationType="fade">
+        <TouchableOpacity
+          style={Styles.dropdownOverlay}
+          activeOpacity={1}
+          onPress={() => setVisible(false)}
+        >
+          <View style={[Styles.dropdownMenu, { backgroundColor }]}>
+            <FlatList
+              data={options}
+              keyExtractor={(item) => item}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  style={[
+                    Styles.dropdownItem,
+                    item === value && Styles.dropdownItemSelected,
+                  ]}
+                  onPress={() => {
+                    onChange(item);
+                    setVisible(false);
+                  }}
+                >
+                  <AdaptiveText
+                    style={[
+                      Styles.dropdownText,
+                      { color: textColor },
+                      item === value && Styles.dropdownItemSelectedText,
+                    ]}
+                  >
+                    {item}
+                  </AdaptiveText>
+                </TouchableOpacity>
+              )}
+            />
+          </View>
+        </TouchableOpacity>
+      </Modal>
+    </View>
+  );
+};
+
+export default FormDropdown;

--- a/example/src/components/common/FormDropdown.tsx
+++ b/example/src/components/common/FormDropdown.tsx
@@ -40,7 +40,12 @@ const FormDropdown = <T extends string>({
       >
         <AdaptiveText style={Styles.dropdownText}>{value}</AdaptiveText>
       </TouchableOpacity>
-      <Modal visible={visible} transparent animationType="fade">
+      <Modal
+        visible={visible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setVisible(false)}
+      >
         <TouchableOpacity
           style={Styles.dropdownOverlay}
           activeOpacity={1}

--- a/example/src/components/common/FormTextInput.tsx
+++ b/example/src/components/common/FormTextInput.tsx
@@ -9,7 +9,7 @@ export type FormTextInputProps = {
 
 const FormTextInput = (props: FormTextInputProps) => {
   return (
-    <View style={Styles.page}>
+    <View>
       <AdaptiveText style={Styles.paddedTitle}>{props.title}</AdaptiveText>
       <AdaptiveTextInput {...props} style={[props.style, Styles.textInput]} />
     </View>

--- a/example/src/components/common/FormToggle.tsx
+++ b/example/src/components/common/FormToggle.tsx
@@ -1,0 +1,20 @@
+import { View, Switch } from 'react-native';
+import Styles from './Styles';
+import AdaptiveText from './AdaptiveText';
+
+type FormToggleProps = {
+  title: string;
+  value: boolean;
+  onValueChange: (value: boolean) => void;
+};
+
+const FormToggle = ({ title, value, onValueChange }: FormToggleProps) => {
+  return (
+    <View style={Styles.toggleRow}>
+      <AdaptiveText>{title}</AdaptiveText>
+      <Switch value={value} onValueChange={onValueChange} />
+    </View>
+  );
+};
+
+export default FormToggle;

--- a/example/src/components/common/Styles.ts
+++ b/example/src/components/common/Styles.ts
@@ -24,11 +24,15 @@ const Styles = StyleSheet.create({
     paddingTop: 16,
   },
   paddedTitle: {
-    paddingLeft: 8,
-    paddingTop: 8,
+    paddingLeft: 16,
+    paddingTop: 12,
+    paddingBottom: 4,
+    fontSize: 14,
+    color: '#666',
   },
   textInput: {
-    padding: 8,
+    marginHorizontal: 16,
+    padding: 12,
     borderRadius: 8,
     fontSize: 16,
     fontWeight: 'medium',
@@ -110,6 +114,55 @@ const Styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '500',
     textAlign: 'center',
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  sectionTitle: {
+    paddingLeft: 16,
+    paddingTop: 20,
+    paddingBottom: 4,
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  dropdown: {
+    marginHorizontal: 16,
+    padding: 12,
+    borderRadius: 8,
+  },
+  dropdownText: {
+    fontSize: 16,
+  },
+  formAction: {
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+  },
+  dropdownOverlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+  },
+  dropdownMenu: {
+    borderRadius: 12,
+    minWidth: 200,
+    maxHeight: 300,
+    overflow: 'hidden',
+  },
+  dropdownItem: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  dropdownItemSelected: {
+    backgroundColor: 'rgba(0, 122, 255, 0.1)',
+  },
+  dropdownItemSelectedText: {
+    color: '#007AFF',
+    fontWeight: '600',
   },
 });
 

--- a/example/src/hooks/useAppContext.tsx
+++ b/example/src/hooks/useAppContext.tsx
@@ -2,6 +2,7 @@ import {
   useContext,
   useState,
   useMemo,
+  useRef,
   createContext,
   useEffect,
   type PropsWithChildren,
@@ -18,6 +19,7 @@ import { RootStackParamList } from '../router/RootStackNavigator';
 type AppContextType = {
   configuration: AppConfiguration;
   save: (config: AppConfiguration) => void;
+  update: (partial: Partial<AppConfiguration>) => void;
   processResult: (
     result: PaymentResponse,
     nativeComponent: AdyenComponent
@@ -46,6 +48,8 @@ type AppContextProp = {
 
 const AppContextProvider = (props: PropsWithChildren<AppContextProp>) => {
   const [config, setConfig] = useState(props.configuration);
+  const configRef = useRef(config);
+  configRef.current = config;
   const { navigationRef } = props;
 
   useEffect(() => {
@@ -65,6 +69,15 @@ const AppContextProvider = (props: PropsWithChildren<AppContextProp>) => {
       setConfig(newConfig);
     },
     [config]
+  );
+
+  const updateConfiguration = useCallback(
+    async (partial: Partial<AppConfiguration>) => {
+      const merged = { ...configRef.current, ...partial };
+      await AsyncStorage.setItem(storeKey, JSON.stringify(merged));
+      setConfig(merged);
+    },
+    []
   );
 
   const processResult = useCallback(
@@ -97,6 +110,7 @@ const AppContextProvider = (props: PropsWithChildren<AppContextProp>) => {
     () => ({
       configuration: config,
       save: saveConfiguration,
+      update: updateConfiguration,
       processResult,
       navigateToRoot,
       navigateToSettings,
@@ -104,6 +118,7 @@ const AppContextProvider = (props: PropsWithChildren<AppContextProp>) => {
     [
       config,
       saveConfiguration,
+      updateConfiguration,
       processResult,
       navigateToRoot,
       navigateToSettings,

--- a/example/src/hooks/useAppContext.tsx
+++ b/example/src/hooks/useAppContext.tsx
@@ -8,15 +8,16 @@ import {
   useCallback,
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import type { PaymentConfiguration, PaymentResponse } from '../api/types';
+import type { AppConfiguration } from '../settings/types';
+import type { PaymentResponse } from '../api/types';
 import type { NavigationContainerRef } from '@react-navigation/native';
 import type { AdyenComponent } from '@adyen/react-native';
 import { isSuccess } from '../components/utilities/isSuccess';
 import { RootStackParamList } from '../router/RootStackNavigator';
 
 type AppContextType = {
-  configuration: PaymentConfiguration;
-  save: (config: PaymentConfiguration) => void;
+  configuration: AppConfiguration;
+  save: (config: AppConfiguration) => void;
   processResult: (
     result: PaymentResponse,
     nativeComponent: AdyenComponent
@@ -38,7 +39,7 @@ export const useAppContext = () => {
 const storeKey = '@config_storage';
 
 type AppContextProp = {
-  configuration: PaymentConfiguration;
+  configuration: AppConfiguration;
   onError: (error: Error) => void;
   navigationRef: NavigationContainerRef<RootStackParamList>;
 };

--- a/example/src/router/RootStackNavigator.tsx
+++ b/example/src/router/RootStackNavigator.tsx
@@ -8,6 +8,7 @@ import {
 import { ResultCode } from '@adyen/react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { modalScreenOptions } from './modalScreenOptions';
+import SettingsNavigator from '../components/Settings/SettingsNavigator';
 
 // Root stack screens (modals presented from Home)
 export type RootStackParamList = {
@@ -35,8 +36,8 @@ export const RootStackNavigator = () => {
       />
       <RootStack.Screen
         name="Settings"
-        component={Screens.SettingView}
-        options={modalScreenOptions}
+        component={SettingsNavigator}
+        options={{ ...modalScreenOptions, headerShown: false }}
       />
       <RootStack.Screen
         name="Result"

--- a/example/src/settings/checkoutConfiguration.ts
+++ b/example/src/settings/checkoutConfiguration.ts
@@ -6,11 +6,11 @@ import type {
   Configuration,
   StoredPaymentMethod,
 } from '@adyen/react-native';
-import { ENVIRONMENT } from './Configuration';
-import ApiClient from './api/APIClient';
-import type { PaymentConfiguration } from './api/types';
+import { ENVIRONMENT } from '../Configuration';
+import ApiClient from '../api/APIClient';
+import type { AppConfiguration } from './types';
 
-export const checkoutConfiguration = (config: PaymentConfiguration) => {
+export const checkoutConfiguration = (config: AppConfiguration) => {
   const configuration: Configuration = {
     clientKey: ENVIRONMENT.clientKey,
     environment: ENVIRONMENT.environment,
@@ -74,8 +74,7 @@ export const checkoutConfiguration = (config: PaymentConfiguration) => {
     applepay: {
       merchantID:
         config.applePaySettings?.merchantID ?? ENVIRONMENT.applepayMerchantID,
-      merchantName:
-        config.applePaySettings?.merchantName ?? config.merchantName,
+      merchantName: config.applePaySettings?.merchantName,
       allowOnboarding: config.applePaySettings?.allowOnboarding,
       shippingType: config.applePaySettings?.shippingType,
       requiredBillingContactFields: ['phoneticName', 'postalAddress'],

--- a/example/src/settings/checkoutConfiguration.ts
+++ b/example/src/settings/checkoutConfiguration.ts
@@ -74,7 +74,7 @@ export const checkoutConfiguration = (config: AppConfiguration) => {
     applepay: {
       merchantID:
         config.applePaySettings?.merchantID ?? ENVIRONMENT.applepayMerchantID,
-      merchantName: config.applePaySettings?.merchantName,
+      merchantName: config.applePaySettings?.merchantName ?? 'Test Merchant',
       allowOnboarding: config.applePaySettings?.allowOnboarding,
       shippingType: config.applePaySettings?.shippingType,
       requiredBillingContactFields: ['phoneticName', 'postalAddress'],

--- a/example/src/settings/types.ts
+++ b/example/src/settings/types.ts
@@ -1,0 +1,42 @@
+export type CardSettings = {
+  holderNameRequired?: boolean;
+  addressVisibility?: 'full' | 'postalCode' | 'none' | 'lookup';
+  showStorePaymentField?: boolean;
+  hideCvcStoredCard?: boolean;
+  hideCvc?: boolean;
+  kcpVisibility?: 'show' | 'hide';
+  socialSecurity?: 'show' | 'hide';
+};
+
+export type DropInSettings = {
+  showPreselectedStoredPaymentMethod?: boolean;
+  skipListWhenSinglePaymentMethod?: boolean;
+  showRemovePaymentMethodButton?: boolean;
+  title?: string;
+};
+
+export type ApplePaySettings = {
+  merchantID?: string;
+  merchantName?: string;
+  allowOnboarding?: boolean;
+  shippingType?: 'shipping' | 'delivery' | 'storePickup' | 'servicePickup';
+};
+
+export type GooglePaySettings = {
+  allowPrepaidCards?: boolean;
+  allowCreditCards?: boolean;
+  billingAddressRequired?: boolean;
+  emailRequired?: boolean;
+  shippingAddressRequired?: boolean;
+  existingPaymentMethodRequired?: boolean;
+  totalPriceStatus?: 'NOT_CURRENTLY_KNOWN' | 'ESTIMATED' | 'FINAL';
+};
+
+import type { PaymentConfiguration } from '../api/types';
+
+export type AppConfiguration = PaymentConfiguration & {
+  cardSettings?: CardSettings;
+  dropInSettings?: DropInSettings;
+  applePaySettings?: ApplePaySettings;
+  googlePaySettings?: GooglePaySettings;
+};

--- a/example/src/settings/types.ts
+++ b/example/src/settings/types.ts
@@ -1,3 +1,5 @@
+import type { PaymentConfiguration } from '../api/types';
+
 export type CardSettings = {
   holderNameRequired?: boolean;
   addressVisibility?: 'full' | 'postalCode' | 'none' | 'lookup';
@@ -31,8 +33,6 @@ export type GooglePaySettings = {
   existingPaymentMethodRequired?: boolean;
   totalPriceStatus?: 'NOT_CURRENTLY_KNOWN' | 'ESTIMATED' | 'FINAL';
 };
-
-import type { PaymentConfiguration } from '../api/types';
 
 export type AppConfiguration = PaymentConfiguration & {
   cardSettings?: CardSettings;


### PR DESCRIPTION
## Summary

- **Settings UI for Example app**: Added dedicated settings screens for Card, Apple Pay, Google Pay, and Drop-in configuration with a new `SettingsNavigator`. The general settings view was expanded with navigation to each component's settings.
- **New reusable form components**: `FormDropdown` and `FormToggle`, plus expanded shared styles.
- **Type restructuring**: Separated API types from app/settings types — lean `PaymentConfiguration` stays in `api/types.ts`, while component-specific settings (`CardSettings`, `ApplePaySettings`, `GooglePaySettings`, `DropInSettings`) and `AppConfiguration` live in a new `settings/` folder. Moved `checkoutConfiguration.ts` there as well.
- **Removed redundant `merchantName`**: Removed from `AppConfiguration`, `DEFAULT_CONFIGURATION`, and general settings — Apple Pay merchant name is now solely managed in Apple Pay settings.

## Screenshot

<img width="320" alt="Screenshot 2026-03-24 at 15 34 32" src="https://github.com/user-attachments/assets/70cd633c-e931-4b83-a48e-ad61de61898c" />
