### PR TITLE
Add NEA environment support

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/configuration/RootConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/RootConfigurationParser.kt
@@ -75,6 +75,7 @@ class RootConfigurationParser(
           "live-us" -> Environment.UNITED_STATES
           "live-apse" -> Environment.APSE
           "live-in" -> Environment.INDIA
+          "live-nea" -> Environment.NEA
           else -> Environment.TEST
         }
       } else {

--- a/android/src/test/java/com/adyenreactnativesdk/configuration/RootConfigurationParserTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/configuration/RootConfigurationParserTest.kt
@@ -131,6 +131,19 @@ class RootConfigurationParserTest {
   }
 
   @Test
+  fun test_environment_returnsLiveNea_whenConfiguredWithLiveNEA() {
+    // GIVEN
+    val map = WritableMapMock()
+    map.putString(RootConfigurationParser.ENVIRONMENT_KEY, "live-nea")
+
+    // WHEN
+    val sut = RootConfigurationParser(map)
+
+    // THEN
+    assertEquals(Environment.NEA, sut.environment)
+  }
+
+  @Test
   fun test_environment_returnsTest_whenConfiguredWithInvalidValue() {
     // GIVEN
     val map = WritableMapMock()

--- a/example/ios/AdyenExampleTests/RootConfigurationtParserTests.swift
+++ b/example/ios/AdyenExampleTests/RootConfigurationtParserTests.swift
@@ -80,6 +80,17 @@ class RootParserTests: XCTestCase {
         XCTAssertEqual(sut.environment, .liveApse)
     }
 
+    func test_environment_returnsLiveNea_whenConfiguredWithLiveNEA() {
+        // GIVEN
+        let configDict: NSDictionary = ["environment": "live-nea"]
+
+        // WHEN
+        let sut = RootConfigurationParser(configuration: configDict)
+        
+        // THEN
+        XCTAssertEqual(sut.environment, .liveNea)
+    }
+
     func test_clientKey_returnsConfiguredValue_whenProvided() {
         // GIVEN
         let configDict: NSDictionary = ["clientKey": "client-key"]

--- a/ios/Helpers/Environment.swift
+++ b/ios/Helpers/Environment.swift
@@ -16,6 +16,7 @@ extension Environment {
         case "live-us": return .liveUnitedStates
         case "live-in": return .liveIndia
         case "live-apse": return .liveApse
+        case "live-nea": return .liveNea
         default:
             return .test
         }

--- a/src/core/configurations/Configuration.ts
+++ b/src/core/configurations/Configuration.ts
@@ -13,7 +13,8 @@ export type Environment =
   | 'live-us'
   | 'live-au'
   | 'live-apse'
-  | 'live-in';
+  | 'live-in'
+  | 'live-nea';
 
 /** Environment configuration */
 export interface EnvironmentConfiguration {


### PR DESCRIPTION
## Summary
Adds support for the new `live-nea` environment region in the React Native SDK.

### Changes
- **TypeScript**: Added `'live-nea'` to the `Environment` type union
- **Android**: Added `"live-nea" -> Environment.NEA` mapping in `RootConfigurationParser`
- **iOS**: Added `"live-nea" -> .liveNea` mapping in `Environment.parse()`
- **Tests**: Added Android and iOS unit test for NEA environment parsing

**Ticket:** COSDK-871