### PR TITLE
refactor: extract startEventListeners and use callback refs in AdyenCheckout

### DIFF
--- a/src/components/AdyenCheckout.tsx
+++ b/src/components/AdyenCheckout.tsx
@@ -6,33 +6,37 @@ import React, {
   useState,
   useMemo,
 } from 'react';
-import { type EmitterSubscription, NativeEventEmitter } from 'react-native';
+import { type EmitterSubscription } from 'react-native';
+import { ErrorCode } from '../core';
 import type {
-  AddressLookup,
-  AddressLookupItem,
   AdyenActionComponent,
   AdyenComponent,
   AdyenError,
   Configuration,
-  Order,
-  PartialPaymentComponent,
   PaymentDetailsData,
   PaymentMethodData,
   PaymentMethodsResponse,
   SessionConfiguration,
   SessionsResult,
-  StoredPaymentMethod,
-  SubmitModel,
 } from '../core';
-import { Event, ErrorCode } from '../core';
-import { AdyenCheckoutContext } from '../hooks/useAdyenCheckout';
+import {
+  AdyenCheckoutContext,
+  type AdyenCheckoutContextType,
+} from '../hooks/useAdyenCheckout';
 import { getWrapper } from '../modules/base/getWrapper';
 import { SessionHelper } from '../modules/session/SessionHelperModule';
 import type { SessionContext } from '../modules/session/types';
-import { checkPaymentMethodsResponse } from './utils/checkPaymentMethodsResponse';
 import { checkConfiguration } from './utils/checkConfiguration';
-import type { RemovesStoredPayment } from '../modules/dropin/DropInWrapper';
-import type { PaymentComponentWrapper } from '../modules/base/PaymentComponentWrapper';
+import { checkPaymentMethodsResponse } from './utils/checkPaymentMethodsResponse';
+import {
+  startEventListeners,
+  type EventHandlerRefs,
+} from './utils/startEventListeners';
+
+function removeAllSubscriptions(map: Map<string, EmitterSubscription[]>) {
+  map.forEach((listeners) => listeners.forEach((s) => s.remove()));
+  map.clear();
+}
 
 /**
  * Props for AdyenCheckout
@@ -92,9 +96,24 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
   onComplete,
   children,
 }) => {
-  const subscriptions = useRef<EmitterSubscription[]>([]);
   const onCompleteRef = useRef(onComplete);
   const onErrorRef = useRef(onError);
+  const onSubmitRef = useRef(onSubmit);
+  const onAdditionalDetailsRef = useRef(onAdditionalDetails);
+  const configRef = useRef(config);
+  const subscriptions = useRef<Map<string, EmitterSubscription[]>>(new Map());
+
+  const eventHandlerRefs = useMemo<EventHandlerRefs>(
+    () => ({
+      onSubmit: onSubmitRef,
+      onError: onErrorRef,
+      onComplete: onCompleteRef,
+      onAdditionalDetails: onAdditionalDetailsRef,
+      config: configRef,
+    }),
+    []
+  );
+
   const [sessionContext, setSessionContext] = useState<
     SessionContext | undefined
   >(undefined);
@@ -105,9 +124,10 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
     return paymentMethods ?? sessionContext?.paymentMethods;
   }, [paymentMethods, sessionContext]);
 
-  function removeEventListeners() {
-    subscriptions.current.forEach((s: EmitterSubscription) => s.remove());
-  }
+  useEffect(() => {
+    checkConfiguration(config);
+    configRef.current = config;
+  }, [config]);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
@@ -118,8 +138,14 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
   }, [onError]);
 
   useEffect(() => {
-    SessionHelper.removeAllListeners();
+    onSubmitRef.current = onSubmit;
+  }, [onSubmit]);
 
+  useEffect(() => {
+    onAdditionalDetailsRef.current = onAdditionalDetails;
+  }, [onAdditionalDetails]);
+
+  useEffect(() => {
     const completeHandler = (result: any) =>
       onCompleteRef.current?.(result, SessionHelper);
     const errorHandler = (error: any) =>
@@ -129,7 +155,7 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
     SessionHelper.assignErrorHandler(errorHandler);
 
     return () => {
-      removeEventListeners();
+      removeAllSubscriptions(subscriptions.current);
       SessionHelper.removeAllListeners();
       SessionHelper.hide(true);
     };
@@ -137,7 +163,7 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
 
   useEffect(() => {
     if (session && !sessionContext) {
-      SessionHelper.createSession(session, config)
+      SessionHelper.createSession(session, configRef.current)
         .then((sessionResponse) => setSessionContext(sessionResponse))
         .catch((error) => {
           const errorDTO: AdyenError = {
@@ -147,125 +173,7 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
           onErrorRef.current?.(errorDTO, SessionHelper);
         });
     }
-  }, [session, sessionContext, config, setSessionContext]);
-
-  const startEventListeners = useCallback(
-    (nativeComponent: PaymentComponentWrapper & AdyenActionComponent) => {
-      removeEventListeners();
-      const eventEmitter = new NativeEventEmitter(
-        nativeComponent.eventEmitterTarget
-      );
-      subscriptions.current = [];
-
-      /** Subscribe to an event if supported by native module */
-      function subscribeIfSupported<T>(
-        event: Event,
-        handler: (data: T) => void
-      ): void {
-        if (nativeComponent.isSupported(event)) {
-          subscriptions.current.push(eventEmitter.addListener(event, handler));
-        }
-      }
-
-      function submitPayment(data: PaymentMethodData, extra: any) {
-        const payload = {
-          ...data,
-          returnUrl: data.returnUrl ?? config.returnUrl,
-        };
-        onSubmit?.(payload, nativeComponent, extra);
-      }
-
-      // Core events
-      subscribeIfSupported<SubmitModel>(Event.onSubmit, (response) =>
-        submitPayment(response.paymentData, response.extra)
-      );
-      subscribeIfSupported<AdyenError>(Event.onError, (error) =>
-        onError?.(error, nativeComponent)
-      );
-      subscribeIfSupported<SessionsResult>(Event.onComplete, (data) =>
-        onComplete?.(data, nativeComponent)
-      );
-      subscribeIfSupported<PaymentDetailsData>(
-        Event.onAdditionalDetails,
-        (data) => onAdditionalDetails?.(data, nativeComponent)
-      );
-
-      // Stored payment method removal
-      const onDisableStoredPaymentMethodCallback =
-        config.dropin?.onDisableStoredPaymentMethod;
-      if (onDisableStoredPaymentMethodCallback) {
-        const nativeModule = nativeComponent as unknown as RemovesStoredPayment;
-        subscribeIfSupported<StoredPaymentMethod>(
-          Event.onDisableStoredPaymentMethod,
-          (data) =>
-            onDisableStoredPaymentMethodCallback(
-              data,
-              () => nativeModule.removeStored(true),
-              () => nativeModule.removeStored(false)
-            )
-        );
-      }
-
-      // Address lookup
-      const onUpdateAddressCallback = config.card?.onUpdateAddress;
-      const onConfirmAddressCallback = config.card?.onConfirmAddress;
-      if (onUpdateAddressCallback && onConfirmAddressCallback) {
-        const nativeModule = nativeComponent as unknown as AddressLookup;
-        subscribeIfSupported(Event.onAddressUpdate, async (prompt: string) =>
-          onUpdateAddressCallback(prompt, nativeModule)
-        );
-        subscribeIfSupported(
-          Event.onAddressConfirm,
-          (address: AddressLookupItem) =>
-            onConfirmAddressCallback(address, nativeModule)
-        );
-      }
-
-      // Partial payments
-      const onBalanceCheckCallback = config.partialPayment?.onBalanceCheck;
-      const onOrderRequestCallback = config.partialPayment?.onOrderRequest;
-      const onOrderCancelCallback = config.partialPayment?.onOrderCancel;
-      if (
-        onBalanceCheckCallback &&
-        onOrderRequestCallback &&
-        onOrderCancelCallback
-      ) {
-        const component = nativeComponent as unknown as PartialPaymentComponent;
-        subscribeIfSupported(
-          Event.onCheckBalance,
-          async (paymentData: PaymentMethodData) =>
-            onBalanceCheckCallback(
-              paymentData,
-              (balance) => component.provideBalance(true, balance, undefined),
-              (error) => component.provideBalance(false, undefined, error)
-            )
-        );
-        subscribeIfSupported(Event.onRequestOrder, () => {
-          onOrderRequestCallback(
-            (order: Order) => component.provideOrder(true, order, undefined),
-            (error: Error) => component.provideOrder(false, undefined, error)
-          );
-        });
-        subscribeIfSupported(
-          Event.onCancelOrder,
-          ({ order, shouldUpdatePaymentMethods }: any) =>
-            onOrderCancelCallback(order, shouldUpdatePaymentMethods, component)
-        );
-      }
-
-      // BIN lookup and value
-      const onBinLookupCallback = config.card?.onBinLookup;
-      if (onBinLookupCallback) {
-        subscribeIfSupported(Event.onBinLookup, onBinLookupCallback);
-      }
-
-      const onBinValueCallback = config.card?.onBinValue;
-      if (onBinValueCallback) {
-        subscribeIfSupported(Event.onBinValue, onBinValueCallback);
-      }
-    },
-    [onSubmit, onAdditionalDetails, onComplete, onError, config]
-  );
+  }, [session, sessionContext]);
 
   const start = useCallback(
     (typeName: string) => {
@@ -278,32 +186,39 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
         validPaymentMethods
       );
 
-      checkConfiguration(config);
-      startEventListeners(nativeComponent);
+      // Remove existing listeners for this component
+      const existing = subscriptions.current.get(nativeComponent.name) ?? [];
+      existing.forEach((s) => s.remove());
+
+      const listeners = startEventListeners(nativeComponent, eventHandlerRefs);
+      subscriptions.current.set(nativeComponent.name, listeners);
 
       if (paymentMethod) {
         const singlePaymentMethods = { paymentMethods: [paymentMethod] };
         const singlePaymentConfig = {
-          ...config,
+          ...configRef.current,
           dropin: { skipListWhenSinglePaymentMethod: true },
         };
         nativeComponent.open(singlePaymentMethods, singlePaymentConfig);
       } else {
-        nativeComponent.open(validPaymentMethods, config);
+        nativeComponent.open(validPaymentMethods, configRef.current);
       }
     },
-    [config, currentPaymentMethods, startEventListeners]
+    [eventHandlerRefs, currentPaymentMethods]
+  );
+
+  const checkoutContextValue = useMemo<AdyenCheckoutContextType>(
+    () => ({
+      start,
+      config,
+      paymentMethods: currentPaymentMethods,
+      isReady: currentPaymentMethods !== undefined,
+    }),
+    [currentPaymentMethods, start, config]
   );
 
   return (
-    <AdyenCheckoutContext.Provider
-      value={{
-        start,
-        config,
-        paymentMethods: currentPaymentMethods,
-        isReady: currentPaymentMethods !== undefined,
-      }}
-    >
+    <AdyenCheckoutContext.Provider value={checkoutContextValue}>
       {children}
     </AdyenCheckoutContext.Provider>
   );

--- a/src/components/utils/startEventListeners.ts
+++ b/src/components/utils/startEventListeners.ts
@@ -1,0 +1,162 @@
+import { type EmitterSubscription, NativeEventEmitter } from 'react-native';
+import type {
+  AddressLookup,
+  AddressLookupItem,
+  AdyenActionComponent,
+  AdyenError,
+  Configuration,
+  Order,
+  PartialPaymentComponent,
+  PaymentDetailsData,
+  PaymentMethodData,
+  SessionsResult,
+  StoredPaymentMethod,
+  SubmitModel,
+} from '../../core';
+import { Event } from '../../core';
+import type { RemovesStoredPayment } from '../../modules/dropin/DropInWrapper';
+import type { AdyenEventListener } from '../../modules/base/EventListenerWrapper';
+
+export type EventHandlerRefs = {
+  onSubmit: React.RefObject<
+    | ((
+        data: PaymentMethodData,
+        component: AdyenActionComponent,
+        extra?: any
+      ) => void)
+    | undefined
+  >;
+  onError: React.RefObject<
+    (error: AdyenError, component: AdyenActionComponent) => void
+  >;
+  onComplete: React.RefObject<
+    ((result: SessionsResult, component: AdyenActionComponent) => void) | undefined
+  >;
+  onAdditionalDetails: React.RefObject<
+    | ((data: PaymentDetailsData, component: AdyenActionComponent) => void)
+    | undefined
+  >;
+  config: React.RefObject<Configuration>;
+};
+
+/**
+ * Start event listeners on a native component.
+ *
+ * @param nativeComponent - The native wrapper used for event subscription.
+ * @param refs - Callback refs for event handlers.
+ * @param componentType - When set, events are filtered by `data.componentType` (embedded component mode).
+ */
+export function startEventListeners(
+  nativeComponent: AdyenEventListener & AdyenActionComponent,
+  refs: EventHandlerRefs,
+  componentType?: string
+): EmitterSubscription[] {
+  const eventEmitter = new NativeEventEmitter(
+    nativeComponent.eventEmitterTarget
+  );
+  const eventSubscriptions: EmitterSubscription[] = [];
+
+  function subscribeIfSupported<T>(
+    event: Event,
+    handler: (data: T) => void
+  ): void {
+    if (nativeComponent.isSupported(event)) {
+      eventSubscriptions.push(
+        eventEmitter.addListener(event, (rawData: any) => {
+          if (componentType) {
+            if (rawData?.componentType !== componentType) return;
+          }
+          handler(rawData as T);
+        })
+      );
+    }
+  }
+
+  function submitPayment(data: PaymentMethodData, extra: any) {
+    const payload = {
+      ...data,
+      returnUrl: data.returnUrl ?? refs.config.current.returnUrl,
+    };
+    refs.onSubmit.current?.(payload, nativeComponent, extra);
+  }
+
+  // Core events
+  subscribeIfSupported<SubmitModel>(Event.onSubmit, (response) =>
+    submitPayment(response.paymentData, response.extra)
+  );
+  subscribeIfSupported<AdyenError>(Event.onError, (error) =>
+    refs.onError.current?.(error, nativeComponent)
+  );
+  subscribeIfSupported<SessionsResult>(Event.onComplete, (data) =>
+    refs.onComplete.current?.(data, nativeComponent)
+  );
+  subscribeIfSupported<PaymentDetailsData>(Event.onAdditionalDetails, (data) =>
+    refs.onAdditionalDetails.current?.(data, nativeComponent)
+  );
+
+  // Address lookup
+  const lookupModule = nativeComponent as unknown as AddressLookup;
+  subscribeIfSupported(Event.onAddressUpdate, async (data: any) => {
+    const prompt = componentType && typeof data === 'object' ? data.value : data;
+    refs.config.current.card?.onUpdateAddress?.(prompt, lookupModule);
+  });
+  subscribeIfSupported(Event.onAddressConfirm, (address: AddressLookupItem) =>
+    refs.config.current.card?.onConfirmAddress?.(address, lookupModule)
+  );
+
+  // BIN lookup and value
+  subscribeIfSupported(Event.onBinLookup, (data: any) => {
+    const lookupData =
+      componentType && !Array.isArray(data) && typeof data === 'object' ? data.data : data;
+    refs.config.current.card?.onBinLookup?.(lookupData);
+  });
+
+  subscribeIfSupported(Event.onBinValue, (data: any) => {
+    const value =
+      componentType && typeof data === 'object' ? data.value : data;
+    refs.config.current.card?.onBinValue?.(value);
+  });
+
+  // Stored payment method removal (Drop-in only)
+  const nativeModule = nativeComponent as unknown as RemovesStoredPayment;
+  subscribeIfSupported<StoredPaymentMethod>(
+    Event.onDisableStoredPaymentMethod,
+    (data) =>
+      refs.config.current.dropin?.onDisableStoredPaymentMethod?.(
+        data,
+        () => nativeModule.removeStored(true),
+        () => nativeModule.removeStored(false)
+      )
+  );
+
+  // Partial payments (Drop-in only)
+  const partialComponent =
+    nativeComponent as unknown as PartialPaymentComponent;
+  subscribeIfSupported(
+    Event.onCheckBalance,
+    async (paymentData: PaymentMethodData) =>
+      refs.config.current.partialPayment?.onBalanceCheck?.(
+        paymentData,
+        (balance) =>
+          partialComponent.provideBalance(true, balance, undefined),
+        (error) => partialComponent.provideBalance(false, undefined, error)
+      )
+  );
+  subscribeIfSupported(Event.onRequestOrder, () => {
+    refs.config.current.partialPayment?.onOrderRequest?.(
+      (order: Order) => partialComponent.provideOrder(true, order, undefined),
+      (error: Error) => partialComponent.provideOrder(false, undefined, error)
+    );
+  });
+  subscribeIfSupported(
+    Event.onCancelOrder,
+    ({ order, shouldUpdatePaymentMethods }: any) =>
+      refs.config.current.partialPayment?.onOrderCancel?.(
+        order,
+        shouldUpdatePaymentMethods,
+        partialComponent
+      )
+  );
+
+  return eventSubscriptions;
+}

--- a/src/hooks/constants.ts
+++ b/src/hooks/constants.ts
@@ -1,0 +1,5 @@
+export const MISSING_CONTEXT_ERROR =
+  'useAdyenCheckout must be used within an AdyenCheckout';
+
+export const COMPONENT_MISSING_CONTEXT_ERROR =
+  'useCheckout must be used within an AdyenCheckout';

--- a/src/hooks/useAdyenCheckout.ts
+++ b/src/hooks/useAdyenCheckout.ts
@@ -1,5 +1,6 @@
 import { createContext, useContext } from 'react';
 import type { PaymentMethodsResponse, Configuration } from '../core';
+import { MISSING_CONTEXT_ERROR } from './constants';
 
 /**
  * Shape of the AdyenCheckout context value.
@@ -31,6 +32,3 @@ export const useAdyenCheckout = (): AdyenCheckoutContextType => {
   }
   throw new Error(MISSING_CONTEXT_ERROR);
 };
-
-const MISSING_CONTEXT_ERROR =
-  'useAdyenCheckout must be used within an AdyenCheckout';


### PR DESCRIPTION
## Extract Event Listeners (PR 3/5 of CardView feature)

Extracts the event listener setup from `AdyenCheckout` into a standalone utility and refactors callback management to use React refs. This prepares the codebase for embedded components that will share the same event subscription pattern.

### Changes

**New: `src/components/utils/startEventListeners.ts`**
- Extracted from `AdyenCheckout.tsx` — sets up all event subscriptions (core, address lookup, BIN, partial payments, stored payment removal)
- Uses callback refs instead of direct prop values, preventing stale closures
- Accepts optional `componentType` parameter for future embedded component event filtering
- Returns subscription array for cleanup

**New: `src/hooks/constants.ts`**
- Shared error message constants (`MISSING_CONTEXT_ERROR`, `COMPONENT_MISSING_CONTEXT_ERROR`)

**Refactored: `src/components/AdyenCheckout.tsx`**
- All callback props (`onSubmit`, `onError`, `onComplete`, `onAdditionalDetails`, `config`) stored in refs
- Subscriptions managed per-component via `Map<string, EmitterSubscription[]>` instead of flat array
- `checkConfiguration` runs on config change via `useEffect` instead of on every `start()` call
- Session creation uses `configRef.current` to avoid unnecessary re-renders
- Context value memoized via `useMemo`

**Updated: `src/hooks/useAdyenCheckout.ts`**
- Uses shared constant from `hooks/constants.ts`

All 183 JS tests pass. Typecheck passes.