### PR TITLE
feat: add embedded component bus infrastructure

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/AdyenPaymentPackage.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/AdyenPaymentPackage.kt
@@ -9,6 +9,7 @@ package com.adyenreactnativesdk
 import android.annotation.SuppressLint
 import com.adyen.checkout.components.core.internal.util.CheckoutPlatform
 import com.adyen.checkout.components.core.internal.util.CheckoutPlatformParams
+import com.adyenreactnativesdk.component.EmbeddedComponentBusModule
 import com.adyenreactnativesdk.component.SessionHelperModule
 import com.adyenreactnativesdk.component.applepay.ApplePayModuleMock
 import com.adyenreactnativesdk.component.dropin.DropInModule
@@ -22,21 +23,29 @@ import com.adyenreactnativesdk.util.messaging.MessageBusEmitter
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
 
 class AdyenPaymentPackage : ReactPackage {
-  override fun createViewManagers(reactContext: ReactApplicationContext) = listOf(PlatformPayViewManager())
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<in Nothing, in Nothing>> {
+    ensureInitialized(reactContext)
+    return listOf(
+      PlatformPayViewManager(),
+    )
+  }
 
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-    val messageBus = getOrCreateMessageBus(reactContext)
+    ensureInitialized(reactContext)
+    val sharedBus = messageBus
     configureAnalytics()
     return listOf(
-      DropInModule(reactContext, messageBus),
-      InstantModule(reactContext, messageBus),
-      GooglePayModule(reactContext, messageBus),
-      ApplePayModuleMock(reactContext, messageBus),
+      DropInModule(reactContext, sharedBus),
+      InstantModule(reactContext, sharedBus),
+      GooglePayModule(reactContext, sharedBus),
+      ApplePayModuleMock(reactContext, sharedBus),
       AdyenCSEModule(reactContext),
-      SessionHelperModule(reactContext, messageBus),
+      SessionHelperModule(reactContext, sharedBus),
       ActionModule(reactContext),
+      EmbeddedComponentBusModule(reactContext, sharedBus),
     )
   }
 
@@ -49,11 +58,15 @@ class AdyenPaymentPackage : ReactPackage {
 
   companion object {
     val messageBus: MessageBus
-      get() {
-        return _messageBus ?: throw IllegalStateException("AdyenCheckout MessageBus is not initialized")
-      }
+      get() = _messageBus ?: throw IllegalStateException("AdyenCheckout MessageBus is not initialized")
+
+    val emitter: MessageBusEmitter
+      get() = _emitter ?: throw IllegalStateException("AdyenCheckout MessageBusEmitter is not initialized")
 
     internal fun messageBusOrNull(): MessageBus? = _messageBus
+
+    @Volatile
+    private var _emitter: MessageBusEmitter? = null
 
     @Volatile
     private var _messageBus: MessageBus? = null
@@ -63,19 +76,19 @@ class AdyenPaymentPackage : ReactPackage {
     private val lock = Any()
 
     /**
-     * Gets or creates a MessageBus for the provided context.
-     * Creates a fresh instance if the context has changed (e.g., after hot reload).
+     * Ensures the shared [MessageBusEmitter] and [MessageBus] are created
+     * for the provided context. Re-creates them when the context changes
+     * (e.g., after hot reload).
      */
-    internal fun getOrCreateMessageBus(context: ReactApplicationContext): MessageBus =
+    internal fun ensureInitialized(context: ReactApplicationContext) {
       synchronized(lock) {
         val contextHash = context.hashCode()
-        if (_messageBus != null && currentContextHashCode == contextHash) {
-          return@synchronized _messageBus!!
-        }
-        MessageBus(MessageBusEmitter(context)).also {
-          _messageBus = it
-          currentContextHashCode = contextHash
-        }
+        if (_emitter != null && currentContextHashCode == contextHash) return
+        val newEmitter = MessageBusEmitter(context)
+        _emitter = newEmitter
+        _messageBus = MessageBus(newEmitter)
+        currentContextHashCode = contextHash
       }
+    }
   }
 }

--- a/android/src/main/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModule.kt
@@ -1,0 +1,179 @@
+package com.adyenreactnativesdk.component
+
+import com.adyen.checkout.components.core.AddressLookupResult
+import com.adyen.checkout.components.core.action.Action
+import com.adyen.checkout.dropin.AddressLookupDropInServiceResult
+import com.adyenreactnativesdk.component.base.BaseAddressModule
+import com.adyenreactnativesdk.component.base.ModuleException
+import com.adyenreactnativesdk.react.ComponentContract
+import com.adyenreactnativesdk.util.messaging.EventName
+import com.adyenreactnativesdk.util.messaging.MessageBus
+import com.adyenreactnativesdk.util.messaging.embeddedComponentsEvents
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import org.json.JSONException
+
+class EmbeddedComponentBusModule(
+  val context: ReactApplicationContext?,
+  messageBus: MessageBus,
+) : BaseAddressModule(context, messageBus) {
+  private var activeComponentType: String? = null
+  private val subscribedTypes: MutableSet<String> = mutableSetOf()
+
+  override fun getName(): String = COMPONENT_NAME
+
+  override fun supportedEvents(): List<String> = EventName.embeddedComponentsEvents()
+
+  override fun getConstants(): MutableMap<String, Any> = super.getConstants()
+
+  @ReactMethod
+  fun addListener(eventName: String?) { // No JS events expected
+  }
+
+  @ReactMethod
+  fun removeListeners(count: Int?) { // No JS events expected
+  }
+
+  @ReactMethod
+  fun subscribe(componentType: String) {
+    subscribedTypes.add(componentType)
+  }
+
+  @ReactMethod
+  fun unsubscribe(componentType: String) {
+    subscribedTypes.remove(componentType)
+    Companion.unregister(componentType)
+    if (activeComponentType == componentType) {
+      activeComponentType = null
+    }
+    if (subscribedTypes.isEmpty()) {
+      cleanup()
+    }
+  }
+
+  @ReactMethod
+  fun confirm(
+    componentType: String,
+    success: Boolean,
+    address: ReadableMap?,
+  ) {
+    activeComponentType = componentType
+    super.confirm(success, address)
+  }
+
+  @ReactMethod
+  fun update(
+    componentType: String,
+    array: ReadableArray?,
+  ) {
+    activeComponentType = componentType
+    super.update(array)
+  }
+
+  @ReactMethod
+  fun hide(
+    componentType: String,
+    success: Boolean,
+    message: ReadableMap?,
+  ) {
+    Companion.unregister(componentType)
+    if (activeComponentType == componentType) {
+      activeComponentType = null
+    }
+    if (subscribedTypes.isEmpty()) {
+      activeComponentType = null
+      cleanup()
+    }
+  }
+
+  override fun hide(
+    success: Boolean,
+    message: ReadableMap?,
+  ) {
+    activeComponentType = null
+    cleanup()
+  }
+
+  @ReactMethod
+  fun handle(
+    componentType: String,
+    actionMap: ReadableMap?,
+  ) {
+    activeComponentType = componentType
+    super.parseAndHandleAction(actionMap)
+  }
+
+  override fun handleAction(action: Action) {
+    val componentName =
+      activeComponentType ?: return messageBus.onException(ModuleException.NoPaymentRegistered())
+
+    val component =
+      getConsumer(componentName)
+        ?: return messageBus.onException(ModuleException.NoConsumer(componentName))
+
+    try {
+      component.onAction(action)
+    } catch (e: JSONException) {
+      messageBus.onException(ModuleException.InvalidAction(e))
+    } finally {
+      activeComponentType = null
+    }
+  }
+
+  override fun sendAddressLookupResult(result: AddressLookupDropInServiceResult) {
+    val componentType =
+      activeComponentType ?: return messageBus.onException(ModuleException.NoPaymentRegistered())
+
+    val componentManager =
+      getConsumer(componentType)
+        ?: return messageBus.onException(ModuleException.NoConsumer(componentType))
+
+    try {
+      when (result) {
+        is AddressLookupDropInServiceResult.LookupResult -> {
+          componentManager.onAddressLookupOptions(result.options)
+        }
+
+        is AddressLookupDropInServiceResult.LookupComplete -> {
+          componentManager.onAddressLookupResult(AddressLookupResult.Completed(result.lookupAddress))
+        }
+
+        is AddressLookupDropInServiceResult.Error -> {
+          componentManager.onAddressLookupResult(AddressLookupResult.Error(result.errorDialog?.message))
+        }
+      }
+    } finally {
+      if (result !is AddressLookupDropInServiceResult.LookupResult) {
+        activeComponentType = null
+      }
+    }
+  }
+
+  companion object {
+    private const val COMPONENT_NAME = "AdyenComponentBus"
+
+    /** Registry of componentType → ViewManager implementing ComponentContract */
+    private val consumers: MutableMap<String, ComponentContract> = mutableMapOf()
+
+    @Synchronized
+    fun register(
+      componentType: String,
+      contract: ComponentContract,
+    ) {
+      consumers[componentType] = contract
+    }
+
+    @Synchronized
+    fun unregister(componentType: String) {
+      consumers.remove(componentType)
+    }
+
+    @Synchronized
+    fun getConsumer(componentType: String): ComponentContract? = consumers[componentType]
+
+    @Synchronized
+    fun clearConsumers() = consumers.clear()
+  }
+}

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/ModuleException.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/ModuleException.kt
@@ -106,4 +106,17 @@ sealed class ModuleException(
       code = "noActivity",
       message = "ViewModel callback is inconsistent",
     )
+
+  class NoConsumer(
+    val name: String,
+  ) : ModuleException(
+      code = "noConsumer",
+      message = "No View is registered in EmbeddedComponentBus as $name",
+    )
+
+  class NoPaymentRegistered :
+    ModuleException(
+      code = "noPaymentRegistered",
+      message = "No `onSubmit` was detected to process this action.",
+    )
 }

--- a/android/src/main/java/com/adyenreactnativesdk/react/ComponentContract.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/react/ComponentContract.kt
@@ -1,0 +1,13 @@
+package com.adyenreactnativesdk.react
+
+import com.adyen.checkout.components.core.AddressLookupResult
+import com.adyen.checkout.components.core.LookupAddress
+import com.adyen.checkout.components.core.action.Action
+
+interface ComponentContract {
+  fun onAction(action: Action)
+
+  fun onAddressLookupResult(result: AddressLookupResult)
+
+  fun onAddressLookupOptions(options: List<LookupAddress>)
+}

--- a/android/src/main/java/com/adyenreactnativesdk/util/messaging/TaggedEmitter.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/util/messaging/TaggedEmitter.kt
@@ -1,0 +1,68 @@
+package com.adyenreactnativesdk.util.messaging
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Wraps an [Emitter] (typically [MessageBusEmitter]) and injects a
+ * `componentType` field into every emitted event payload.
+ *
+ * Used by embedded ViewManagers so the JS side can demux events
+ * from multiple simultaneous embedded components.
+ */
+class TaggedEmitter(
+  private val delegate: MessageBusEmitter,
+  val componentType: String,
+) : Emitter {
+  override fun sendEvent(
+    eventName: EventName,
+    jsonObject: JSONObject,
+  ) {
+    jsonObject.put(COMPONENT_TYPE_KEY, componentType)
+    delegate.sendEvent(eventName, jsonObject)
+  }
+
+  override fun sendEvent(
+    eventName: EventName,
+    string: String,
+  ) {
+    val json =
+      JSONObject().apply {
+        put(COMPONENT_TYPE_KEY, componentType)
+        put("value", string)
+      }
+    delegate.sendEvent(eventName, json)
+  }
+
+  override fun sendEvent(
+    eventName: EventName,
+    jsonObject: JSONArray,
+  ) {
+    val json =
+      JSONObject().apply {
+        put(COMPONENT_TYPE_KEY, componentType)
+        put("data", jsonObject)
+      }
+    delegate.sendEvent(eventName, json)
+  }
+
+  override fun sendError(
+    eventName: EventName,
+    error: Exception,
+  ) {
+    val jsonObject =
+      JSONObject().apply {
+        put("message", error.localizedMessage)
+        error.cause?.let { put("reason", it.localizedMessage) }
+        (error as? com.adyenreactnativesdk.component.base.KnownException)?.let {
+          put("errorCode", it.code)
+        }
+        put(COMPONENT_TYPE_KEY, componentType)
+      }
+    delegate.sendEvent(eventName, jsonObject)
+  }
+
+  private companion object {
+    private const val COMPONENT_TYPE_KEY = "componentType"
+  }
+}

--- a/ios/AdyenModule.m
+++ b/ios/AdyenModule.m
@@ -118,4 +118,26 @@ RCT_EXTERN_METHOD(handle:(NSDictionary *)action
 
 @end
 
+@interface RCT_EXTERN_MODULE(AdyenComponentBus, NSObject)
+
+RCT_EXTERN_METHOD(subscribe:(nonnull NSString *)componentType)
+
+RCT_EXTERN_METHOD(unsubscribe:(nonnull NSString *)componentType)
+
+RCT_EXTERN_METHOD(hide:(nonnull NSString *)componentType
+                  success:(nonnull NSNumber *)success
+                  event:(NSDictionary *)event)
+
+RCT_EXTERN_METHOD(handle:(nonnull NSString *)componentType
+                  action:(nullable NSDictionary *)actionMap)
+
+RCT_EXTERN_METHOD(update:(nonnull NSString *)componentType
+                  results:(nullable NSArray *)results)
+
+RCT_EXTERN_METHOD(confirm:(nonnull NSString *)componentType
+                  success:(nonnull NSNumber *)success
+                  address:(nullable NSDictionary *)address)
+
+@end
+
 

--- a/ios/Components/Base/ModuleException.swift
+++ b/ios/Components/Base/ModuleException.swift
@@ -23,6 +23,7 @@ enum ModuleException: LocalizedError, KnownError {
     case orderRequest(message: String)
     case sessionError
     case invalidClientKey
+    case componentNotRegistered(String)
 
     var errorCode: String {
         switch self {
@@ -50,6 +51,8 @@ enum ModuleException: LocalizedError, KnownError {
             return "sessionError"
         case .invalidClientKey:
             return "invalidClientKey"
+        case .componentNotRegistered:
+            return "componentNotRegistered"
         }
     }
 
@@ -79,6 +82,8 @@ enum ModuleException: LocalizedError, KnownError {
             return "Order request error: \(message)"
         case .sessionError:
             return "Something went wrong while starting session"
+        case let .componentNotRegistered(type):
+            return "No embedded component registered for type \(type)"
         }
     }
 

--- a/ios/Components/Embedded/EmbeddedComponentBusModule.swift
+++ b/ios/Components/Embedded/EmbeddedComponentBusModule.swift
@@ -145,7 +145,7 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
     }
 
     @objc
-    func hide(_ componentType: String, success: NSNumber, event: NSDictionary) {
+    func hide(_ componentType: String, success: NSNumber, event _: NSDictionary) {
         unregister(componentType: componentType)
         if delegates.isEmpty {
             dismiss(success.boolValue)

--- a/ios/Components/Embedded/EmbeddedComponentBusModule.swift
+++ b/ios/Components/Embedded/EmbeddedComponentBusModule.swift
@@ -1,0 +1,164 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+import React
+
+@objc(AdyenComponentBus)
+internal final class EmbeddedComponentBusModule: BaseAddressModule {
+
+    static var shared: EmbeddedComponentBusModule?
+
+    /// Per-componentType delegate proxies
+    private var delegates: [String: EmbeddedComponentDelegateProxy] = [:]
+
+    /// Shared action handler for all embedded views
+    private var actionHandler: AdyenActionComponent?
+
+    /// ComponentTypes with active JS subscriptions
+    private var subscribedTypes: Set<String> = []
+
+    /// Per-componentType address lookup handlers
+    private var lookupHandlers: [String: ([LookupAddressModel]) -> Void] = [:]
+    private var lookupCompletionHandlers: [String: (Result<PostalAddress, Error>) -> Void] = [:]
+
+    override func supportedEvents() -> [String]! {
+        super.supportedEvents() + EventName.cardEvents.map(\.rawValue)
+    }
+
+    override init() {
+        super.init()
+        Self.shared = self
+    }
+
+    // MARK: - Registration
+
+    func register(componentType: String) -> EmbeddedComponentDelegateProxy {
+        let proxy = EmbeddedComponentDelegateProxy(componentType: componentType, bus: self)
+        delegates[componentType] = proxy
+        return proxy
+    }
+
+    func unregister(componentType: String) {
+        delegates.removeValue(forKey: componentType)
+        lookupHandlers.removeValue(forKey: componentType)
+        lookupCompletionHandlers.removeValue(forKey: componentType)
+        if delegates.isEmpty {
+            actionHandler?.cancelIfNeeded()
+            actionHandler = nil
+        }
+    }
+
+    // MARK: - Lookup handler storage (called by EmbeddedComponentDelegateProxy)
+
+    func storeLookupHandler(for componentType: String, handler: @escaping ([LookupAddressModel]) -> Void) {
+        lookupHandlers[componentType] = handler
+    }
+
+    func storeLookupCompletionHandler(for componentType: String, handler: @escaping (Result<PostalAddress, Error>) -> Void) {
+        lookupCompletionHandlers[componentType] = handler
+    }
+
+    // MARK: - Shared action handler
+
+    override func createActionHandlerIfNeeded(context: AdyenContext, locale: String?) {
+        guard BaseModule.session == nil, actionHandler == nil else { return }
+
+        let style = AdyenAppearanceLoader.findStyle()?.actionComponent ?? .init()
+        var config = AdyenActionComponent.Configuration(style: style)
+        if let locale {
+            config.localizationParameters = LocalizationParameters(enforcedLocale: locale)
+        }
+        let handler = AdyenActionComponent(context: context, configuration: config)
+        handler.presentationDelegate = self
+        actionHandler = handler
+    }
+
+    // MARK: - JS subscription lifecycle
+
+    @objc
+    func subscribe(_ componentType: String) {
+        subscribedTypes.insert(componentType)
+    }
+
+    @objc
+    func unsubscribe(_ componentType: String) {
+        subscribedTypes.remove(componentType)
+        unregister(componentType: componentType)
+        if subscribedTypes.isEmpty {
+            cleanUp()
+        }
+    }
+
+    // MARK: - ComponentType-routed commands (called from JS)
+
+    @objc
+    func handle(_ componentType: String, action actionDict: NSDictionary?) {
+        guard let actionDict else { return }
+        guard let handler = actionHandler else {
+            sendError(error: ModuleException.componentNotRegistered(componentType))
+            return
+        }
+        guard let proxy = delegates[componentType] else {
+            sendError(error: ModuleException.componentNotRegistered(componentType))
+            return
+        }
+        do {
+            let action = try parseAction(from: actionDict)
+            DispatchQueue.main.async {
+                handler.delegate = proxy
+                handler.handle(action)
+            }
+        } catch {
+            sendError(error: error)
+        }
+    }
+
+    @objc
+    func update(_ componentType: String, results: NSArray?) {
+        guard let lookupHandler = lookupHandlers[componentType] else { return }
+        let addressModels: [LookupAddressModel] = (results ?? [])
+            .compactMap { $0 as? NSDictionary }
+            .compactMap { try? $0.decode() }
+        DispatchQueue.main.async {
+            lookupHandler(addressModels)
+        }
+    }
+
+    @objc
+    func confirm(_ componentType: String, success: NSNumber, address: NSDictionary) {
+        guard let lookupCompletionHandler = lookupCompletionHandlers[componentType] else { return }
+        DispatchQueue.main.async {
+            if !success.boolValue, let message = address[Keys.message] as? String {
+                return lookupCompletionHandler(.failure(AddressError(message: message)))
+            }
+            do {
+                let addressModel: LookupAddressModel = try address.decode()
+                lookupCompletionHandler(.success(addressModel.postalAddress))
+            } catch {
+                lookupCompletionHandler(.failure(error))
+            }
+        }
+    }
+
+    @objc
+    func hide(_ componentType: String, success: NSNumber, event: NSDictionary) {
+        unregister(componentType: componentType)
+        if delegates.isEmpty {
+            dismiss(success.boolValue)
+        }
+    }
+
+    override func cleanUp() {
+        delegates.removeAll()
+        subscribedTypes.removeAll()
+        actionHandler?.cancelIfNeeded()
+        actionHandler = nil
+        lookupHandlers.removeAll()
+        lookupCompletionHandlers.removeAll()
+        super.cleanUp()
+    }
+}

--- a/ios/Components/Embedded/EmbeddedComponentDelegateProxy.swift
+++ b/ios/Components/Embedded/EmbeddedComponentDelegateProxy.swift
@@ -38,14 +38,14 @@ internal final class EmbeddedComponentDelegateProxy: NSObject {
 // MARK: - PaymentComponentDelegate
 
 extension EmbeddedComponentDelegateProxy: PaymentComponentDelegate {
-    func didSubmit(_ data: PaymentComponentData, from component: any PaymentComponent) {
+    func didSubmit(_ data: PaymentComponentData, from _: any PaymentComponent) {
         guard let bus else { return }
         let extra = (data.paymentMethod as? ApplePayDetails)?.extraData
         let response = SubmitData(paymentData: data.jsonObject, extra: extra)
         bus.sendEvent(event: .submit, body: taggedBody(response.jsonObject))
     }
 
-    func didFail(with error: Error, from component: any PaymentComponent) {
+    func didFail(with error: Error, from _: any PaymentComponent) {
         sendError(error: error)
     }
 }
@@ -53,37 +53,37 @@ extension EmbeddedComponentDelegateProxy: PaymentComponentDelegate {
 // MARK: - ActionComponentDelegate
 
 extension EmbeddedComponentDelegateProxy: ActionComponentDelegate {
-    func didProvide(_ data: ActionComponentData, from component: ActionComponent) {
+    func didProvide(_ data: ActionComponentData, from _: ActionComponent) {
         guard let bus else { return }
         bus.sendEvent(event: .additionalDetails, body: taggedBody(data.jsonObject))
     }
 
-    func didComplete(from component: ActionComponent) {
+    func didComplete(from _: ActionComponent) {
         guard let bus else { return }
         let result = ResultDTO(result: .presentToShopper)
         bus.sendEvent(event: .complete, body: taggedBody(result.jsonObject))
     }
 
-    func didFail(with error: Error, from component: ActionComponent) {
+    func didFail(with error: Error, from _: ActionComponent) {
         sendError(error: error)
     }
 
-    func didOpenExternalApplication(component: ActionComponent) {}
+    // No-op: external application opens are handled by the OS
+    func didOpenExternalApplication(component _: ActionComponent) {}
 }
 
 // MARK: - CardComponentDelegate
 
 extension EmbeddedComponentDelegateProxy: CardComponentDelegate {
-    func didSubmit(lastFour: String, finalBIN: String, component: CardComponent) {
-        /* No callback implemented */
-    }
+    // No-op: lastFour/finalBIN are not forwarded to JS
+    func didSubmit(lastFour _: String, finalBIN _: String, component _: CardComponent) {}
 
-    func didChangeBIN(_ value: String, component: CardComponent) {
+    func didChangeBIN(_ value: String, component _: CardComponent) {
         guard let bus else { return }
         bus.sendEvent(event: .changeBinValue, body: taggedBody(["value": value]))
     }
 
-    func didChangeCardBrand(_ value: [CardBrand]?, component: CardComponent) {
+    func didChangeCardBrand(_ value: [CardBrand]?, component _: CardComponent) {
         guard let bus else { return }
         guard let value, !value.isEmpty else { return }
         let jsonData = value.map { BinLookupDataDTO(brand: $0.type.rawValue).jsonObject }

--- a/ios/Components/Embedded/EmbeddedComponentDelegateProxy.swift
+++ b/ios/Components/Embedded/EmbeddedComponentDelegateProxy.swift
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+
+/// Per-component delegate that tags every emitted event with `componentType`,
+/// allowing the JS side to demux events from multiple simultaneous embedded views.
+internal final class EmbeddedComponentDelegateProxy: NSObject {
+    let componentType: String
+    weak var bus: EmbeddedComponentBusModule?
+
+    init(componentType: String, bus: EmbeddedComponentBusModule) {
+        self.componentType = componentType
+        self.bus = bus
+        super.init()
+    }
+
+    private func taggedBody(_ body: [String: Any]) -> [String: Any] {
+        var dict = body
+        dict["componentType"] = componentType
+        return dict
+    }
+
+    internal func sendError(error: Error) {
+        guard let bus else { return }
+        let errorToSend = bus.checkErrorType(error)
+        if let _ = BaseModule.session {
+            BaseModule.sessionDelegate?.sendError(error: error)
+            return
+        }
+        bus.sendEvent(event: .fail, body: taggedBody(errorToSend.jsonObject))
+    }
+}
+
+// MARK: - PaymentComponentDelegate
+
+extension EmbeddedComponentDelegateProxy: PaymentComponentDelegate {
+    func didSubmit(_ data: PaymentComponentData, from component: any PaymentComponent) {
+        guard let bus else { return }
+        let extra = (data.paymentMethod as? ApplePayDetails)?.extraData
+        let response = SubmitData(paymentData: data.jsonObject, extra: extra)
+        bus.sendEvent(event: .submit, body: taggedBody(response.jsonObject))
+    }
+
+    func didFail(with error: Error, from component: any PaymentComponent) {
+        sendError(error: error)
+    }
+}
+
+// MARK: - ActionComponentDelegate
+
+extension EmbeddedComponentDelegateProxy: ActionComponentDelegate {
+    func didProvide(_ data: ActionComponentData, from component: ActionComponent) {
+        guard let bus else { return }
+        bus.sendEvent(event: .additionalDetails, body: taggedBody(data.jsonObject))
+    }
+
+    func didComplete(from component: ActionComponent) {
+        guard let bus else { return }
+        let result = ResultDTO(result: .presentToShopper)
+        bus.sendEvent(event: .complete, body: taggedBody(result.jsonObject))
+    }
+
+    func didFail(with error: Error, from component: ActionComponent) {
+        sendError(error: error)
+    }
+
+    func didOpenExternalApplication(component: ActionComponent) {}
+}
+
+// MARK: - CardComponentDelegate
+
+extension EmbeddedComponentDelegateProxy: CardComponentDelegate {
+    func didSubmit(lastFour: String, finalBIN: String, component: CardComponent) {
+        /* No callback implemented */
+    }
+
+    func didChangeBIN(_ value: String, component: CardComponent) {
+        guard let bus else { return }
+        bus.sendEvent(event: .changeBinValue, body: taggedBody(["value": value]))
+    }
+
+    func didChangeCardBrand(_ value: [CardBrand]?, component: CardComponent) {
+        guard let bus else { return }
+        guard let value, !value.isEmpty else { return }
+        let jsonData = value.map { BinLookupDataDTO(brand: $0.type.rawValue).jsonObject }
+        bus.sendEvent(event: .binLookup, body: taggedBody(["data": jsonData]))
+    }
+}
+
+// MARK: - AddressLookupProvider
+
+extension EmbeddedComponentDelegateProxy: AddressLookupProvider {
+    func lookUp(searchTerm: String, resultHandler: @escaping ([LookupAddressModel]) -> Void) {
+        guard let bus else { return }
+        bus.storeLookupHandler(for: componentType, handler: resultHandler)
+        bus.sendEvent(event: .updateAddress, body: taggedBody(["value": searchTerm]))
+    }
+
+    func complete(
+        incompleteAddress: LookupAddressModel,
+        resultHandler: @escaping (Result<PostalAddress, any Error>) -> Void
+    ) {
+        guard let bus else { return }
+        bus.storeLookupCompletionHandler(for: componentType, handler: resultHandler)
+        bus.sendEvent(event: .confirmAddress, body: taggedBody(incompleteAddress.jsonObject))
+    }
+}

--- a/src/components/AdyenCheckout.tsx
+++ b/src/components/AdyenCheckout.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
   useMemo,
 } from 'react';
-import { type EmitterSubscription } from 'react-native';
 import { ErrorCode } from '../core';
 import type {
   AdyenActionComponent,
@@ -32,11 +31,8 @@ import {
   startEventListeners,
   type EventHandlerRefs,
 } from './utils/startEventListeners';
-
-function removeAllSubscriptions(map: Map<string, EmitterSubscription[]>) {
-  map.forEach((listeners) => listeners.forEach((s) => s.remove()));
-  map.clear();
-}
+import { AdyenComponentContext } from '../hooks/useComponent';
+import { useSubscriptionManager } from '../hooks/useSubscriptionManager';
 
 /**
  * Props for AdyenCheckout
@@ -101,7 +97,6 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
   const onSubmitRef = useRef(onSubmit);
   const onAdditionalDetailsRef = useRef(onAdditionalDetails);
   const configRef = useRef(config);
-  const subscriptions = useRef<Map<string, EmitterSubscription[]>>(new Map());
 
   const eventHandlerRefs = useMemo<EventHandlerRefs>(
     () => ({
@@ -113,6 +108,9 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
     }),
     []
   );
+
+  const { subscribe, unsubscribe, removeEventListeners, storeEventListeners } =
+    useSubscriptionManager(eventHandlerRefs);
 
   const [sessionContext, setSessionContext] = useState<
     SessionContext | undefined
@@ -155,7 +153,6 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
     SessionHelper.assignErrorHandler(errorHandler);
 
     return () => {
-      removeAllSubscriptions(subscriptions.current);
       SessionHelper.removeAllListeners();
       SessionHelper.hide(true);
     };
@@ -186,12 +183,9 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
         validPaymentMethods
       );
 
-      // Remove existing listeners for this component
-      const existing = subscriptions.current.get(nativeComponent.name) ?? [];
-      existing.forEach((s) => s.remove());
-
+      removeEventListeners(nativeComponent);
       const listeners = startEventListeners(nativeComponent, eventHandlerRefs);
-      subscriptions.current.set(nativeComponent.name, listeners);
+      storeEventListeners(nativeComponent, listeners);
 
       if (paymentMethod) {
         const singlePaymentMethods = { paymentMethods: [paymentMethod] };
@@ -204,7 +198,12 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
         nativeComponent.open(validPaymentMethods, configRef.current);
       }
     },
-    [eventHandlerRefs, currentPaymentMethods]
+    [
+      eventHandlerRefs,
+      currentPaymentMethods,
+      removeEventListeners,
+      storeEventListeners,
+    ]
   );
 
   const checkoutContextValue = useMemo<AdyenCheckoutContextType>(
@@ -219,7 +218,9 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
 
   return (
     <AdyenCheckoutContext.Provider value={checkoutContextValue}>
-      {children}
+      <AdyenComponentContext.Provider value={{ subscribe, unsubscribe }}>
+        {children}
+      </AdyenComponentContext.Provider>
     </AdyenCheckoutContext.Provider>
   );
 };

--- a/src/components/AdyenCheckout.tsx
+++ b/src/components/AdyenCheckout.tsx
@@ -218,7 +218,9 @@ export const AdyenCheckout: React.FC<AdyenCheckoutProps> = ({
 
   return (
     <AdyenCheckoutContext.Provider value={checkoutContextValue}>
-      <AdyenComponentContext.Provider value={{ subscribe, unsubscribe }}>
+      <AdyenComponentContext.Provider
+        value={useMemo(() => ({ subscribe, unsubscribe }), [subscribe, unsubscribe])}
+      >
         {children}
       </AdyenComponentContext.Provider>
     </AdyenCheckoutContext.Provider>

--- a/src/components/__tests__/AdyenCheckout.test.tsx
+++ b/src/components/__tests__/AdyenCheckout.test.tsx
@@ -30,6 +30,15 @@ jest.mock('../../modules/base/getWrapper', () => ({
   })),
 }));
 
+jest.mock('../../hooks/useSubscriptionManager', () => ({
+  useSubscriptionManager: jest.fn(() => ({
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+    removeEventListeners: jest.fn(),
+    storeEventListeners: jest.fn(),
+  })),
+}));
+
 jest.mock('../../modules/session/SessionHelperModule', () => ({
   SessionHelper: {
     createSession: (session: any, config: any) =>

--- a/src/hooks/useComponent.ts
+++ b/src/hooks/useComponent.ts
@@ -1,0 +1,27 @@
+import { createContext, useContext } from 'react';
+import { COMPONENT_MISSING_CONTEXT_ERROR } from './constants';
+
+/**
+ * Context for embedded components to subscribe/unsubscribe to MessageBus events.
+ */
+export interface AdyenComponentContextType {
+  /** Subscribe a component type to MessageBus events */
+  subscribe: (componentType: string) => void;
+  /** Unsubscribe a component type from MessageBus events */
+  unsubscribe: (componentType: string) => void;
+}
+
+export const AdyenComponentContext =
+  createContext<AdyenComponentContextType | null>(null);
+
+/**
+ * Hook to access the AdyenComponentContext for subscribing/unsubscribing to MessageBus events.
+ * Must be used within an AdyenCheckout provider.
+ */
+export const useComponent = (): AdyenComponentContextType => {
+  const context = useContext(AdyenComponentContext);
+  if (!context) {
+    throw new Error(COMPONENT_MISSING_CONTEXT_ERROR);
+  }
+  return context;
+};

--- a/src/hooks/useSubscriptionManager.ts
+++ b/src/hooks/useSubscriptionManager.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { type EmitterSubscription } from 'react-native';
+import { EmbeddedComponentBus } from '../modules/embedded/EmbeddedComponentBus';
+import { EmbeddedComponentProxy } from '../modules/embedded/EmbeddedComponentProxy';
+import {
+  startEventListeners,
+  type EventHandlerRefs,
+} from '../components/utils/startEventListeners';
+import type { AdyenComponentContextType } from './useComponent';
+import type {
+  EventListenerWrapper,
+  NativeModuleWithConstants,
+} from '../modules/base/EventListenerWrapper';
+
+type ComponentSubscriptionManager = AdyenComponentContextType & {
+  removeEventListeners: <T extends NativeModuleWithConstants>(
+    nativeComponent: EventListenerWrapper<T>
+  ) => void;
+  storeEventListeners: <T extends NativeModuleWithConstants>(
+    nativeComponent: EventListenerWrapper<T>,
+    listeners: EmitterSubscription[]
+  ) => void;
+};
+
+export function useSubscriptionManager(
+  eventHandlerRefs: EventHandlerRefs
+): ComponentSubscriptionManager {
+  const subscriptions = useRef<Map<string, EmitterSubscription[]>>(new Map());
+
+  const removeEventListeners = useCallback(
+    <T extends NativeModuleWithConstants>(
+      nativeComponent: EventListenerWrapper<T>
+    ) => {
+      const listeners = subscriptions.current.get(nativeComponent.name) ?? [];
+      listeners.forEach((s: EmitterSubscription) => s.remove());
+      subscriptions.current.delete(nativeComponent.name);
+    },
+    []
+  );
+
+  const storeEventListeners = useCallback(
+    <T extends NativeModuleWithConstants>(
+      nativeComponent: EventListenerWrapper<T>,
+      listeners: EmitterSubscription[]
+    ) => {
+      subscriptions.current.set(nativeComponent.name, listeners);
+    },
+    []
+  );
+
+  const subscribe = useCallback(
+    (componentType: string) => {
+      if (subscriptions.current.has(componentType)) return;
+      EmbeddedComponentBus.subscribe(componentType);
+      const proxy = new EmbeddedComponentProxy(
+        EmbeddedComponentBus,
+        componentType
+      );
+      const bag = startEventListeners(proxy, eventHandlerRefs, componentType);
+      subscriptions.current.set(componentType, bag);
+    },
+    [eventHandlerRefs]
+  );
+
+  const unsubscribe = useCallback((componentType: string) => {
+    const bag = subscriptions.current.get(componentType);
+    bag?.forEach((s) => s.remove());
+    subscriptions.current.delete(componentType);
+    EmbeddedComponentBus.unsubscribe(componentType);
+  }, []);
+
+  function cleanup() {
+    subscriptions.current.forEach((listeners, componentType) => {
+      listeners.forEach((s) => s.remove());
+      EmbeddedComponentBus.unsubscribe(componentType);
+    });
+    subscriptions.current.clear();
+  }
+
+  useEffect(() => cleanup, []);
+
+  return {
+    subscribe,
+    unsubscribe,
+    removeEventListeners,
+    storeEventListeners,
+  };
+}

--- a/src/modules/embedded/EmbeddedComponentBus.ts
+++ b/src/modules/embedded/EmbeddedComponentBus.ts
@@ -1,0 +1,27 @@
+import { EmbeddedComponentBusWrapper } from './EmbeddedComponentBusWrapper';
+import type { AddressLookupItem, PaymentAction } from '../../core';
+import type { NativeModuleWithConstants } from '../base/EventListenerWrapper';
+import { ModuleMock } from '../base/ModuleMock';
+import { NativeModules } from 'react-native';
+
+export interface EmbeddedNativeModule extends NativeModuleWithConstants {
+  subscribe(componentType: string): void;
+  unsubscribe(componentType: string): void;
+  handle(componentType: string, action: PaymentAction): void;
+  hide(
+    componentType: string,
+    success: boolean,
+    option?: { message?: string }
+  ): void;
+  update(componentType: string, results: AddressLookupItem[]): void;
+  confirm(
+    componentType: string,
+    success: boolean,
+    body?: AddressLookupItem | { message?: string }
+  ): void;
+}
+
+/** Communication bus for all embedded Native Modules. */
+export const EmbeddedComponentBus = new EmbeddedComponentBusWrapper(
+  NativeModules.AdyenComponentBus ?? ModuleMock
+);

--- a/src/modules/embedded/EmbeddedComponentBusWrapper.ts
+++ b/src/modules/embedded/EmbeddedComponentBusWrapper.ts
@@ -1,0 +1,42 @@
+import type { AddressLookupItem, PaymentAction } from '../../core';
+import { EventListenerWrapper } from '../base/EventListenerWrapper';
+import type { EmbeddedNativeModule } from './EmbeddedComponentBus';
+
+/**
+ *  Communication bus for all embedded Native Modules.
+ * */
+export class EmbeddedComponentBusWrapper extends EventListenerWrapper<EmbeddedNativeModule> {
+  name: string = 'AdyenComponentBus';
+
+  subscribe(componentType: string): void {
+    this.nativeModule.subscribe(componentType);
+  }
+
+  unsubscribe(componentType: string): void {
+    this.nativeModule.unsubscribe(componentType);
+  }
+
+  handle(componentType: string, action: PaymentAction): void {
+    this.nativeModule.handle(componentType, action);
+  }
+
+  hide(
+    componentType: string,
+    success: boolean,
+    option?: { message?: string }
+  ): void {
+    this.nativeModule.hide(componentType, success, option);
+  }
+
+  update(componentType: string, results: AddressLookupItem[]): void {
+    this.nativeModule.update(componentType, results);
+  }
+
+  confirm(
+    componentType: string,
+    success: boolean,
+    body?: AddressLookupItem | { message?: string }
+  ): void {
+    this.nativeModule.confirm(componentType, success, body);
+  }
+}

--- a/src/modules/embedded/EmbeddedComponentProxy.ts
+++ b/src/modules/embedded/EmbeddedComponentProxy.ts
@@ -1,0 +1,54 @@
+import type { NativeModule } from 'react-native';
+import type {
+  AdyenActionComponent,
+  AddressLookup,
+  AddressLookupItem,
+  HideOption,
+  PaymentAction,
+  Event,
+} from '../../core';
+import type { AdyenEventListener } from '../base/EventListenerWrapper';
+import type { EmbeddedComponentBusWrapper } from './EmbeddedComponentBusWrapper';
+
+/**
+ * Proxy that binds a componentType to all outbound native module calls.
+ * Passed to merchant callbacks as the `component` argument so that
+ * `component.handle(action)` routes to the correct embedded view.
+ */
+export class EmbeddedComponentProxy
+  implements AdyenActionComponent, AddressLookup, AdyenEventListener
+{
+  constructor(
+    private wrapper: EmbeddedComponentBusWrapper,
+    readonly componentType: string
+  ) {}
+
+  isSupported(event: Event): boolean {
+    return this.wrapper.isSupported(event);
+  }
+  get eventEmitterTarget(): NativeModule {
+    return this.wrapper.eventEmitterTarget;
+  }
+
+  handle(action: PaymentAction) {
+    this.wrapper.handle(this.componentType, action);
+  }
+
+  hide(success: boolean, option?: HideOption) {
+    this.wrapper.hide(this.componentType, success, {
+      message: option?.message ?? '',
+    });
+  }
+
+  update(results: AddressLookupItem[]) {
+    this.wrapper.update(this.componentType, results);
+  }
+
+  confirm(address: AddressLookupItem) {
+    this.wrapper.confirm(this.componentType, true, address);
+  }
+
+  reject(error?: { message: string }) {
+    this.wrapper.confirm(this.componentType, false, error);
+  }
+}

--- a/src/modules/embedded/EmbeddedComponentProxy.ts
+++ b/src/modules/embedded/EmbeddedComponentProxy.ts
@@ -19,7 +19,7 @@ export class EmbeddedComponentProxy
   implements AdyenActionComponent, AddressLookup, AdyenEventListener
 {
   constructor(
-    private wrapper: EmbeddedComponentBusWrapper,
+    private readonly wrapper: EmbeddedComponentBusWrapper,
     readonly componentType: string
   ) {}
 

--- a/src/modules/embedded/__tests__/EmbeddedComponentBusWrapper.test.ts
+++ b/src/modules/embedded/__tests__/EmbeddedComponentBusWrapper.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { EmbeddedComponentBusWrapper } from '../EmbeddedComponentBusWrapper';
+import { Event } from '../../../core';
+
+function createMockEmbeddedModule(supportedEvents: string[] = []) {
+  return {
+    addListener: jest.fn(),
+    removeListeners: jest.fn(),
+    getConstants: jest.fn(() => ({ supportedEvents })),
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+    handle: jest.fn(),
+    hide: jest.fn(),
+    update: jest.fn(),
+    confirm: jest.fn(),
+  };
+}
+
+describe('EmbeddedComponentBusWrapper', () => {
+  let mockNativeModule: ReturnType<typeof createMockEmbeddedModule>;
+
+  beforeEach(() => {
+    mockNativeModule = createMockEmbeddedModule();
+  });
+
+  describe('name', () => {
+    test('should return "AdyenComponentBus"', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      expect(wrapper.name).toBe('AdyenComponentBus');
+    });
+  });
+
+  describe('eventEmitterTarget', () => {
+    test('should return the native module', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      expect(wrapper.eventEmitterTarget).toBe(mockNativeModule);
+    });
+  });
+
+  describe('isSupported', () => {
+    test('should return true for events listed in getConstants', () => {
+      const module = createMockEmbeddedModule([Event.onError, Event.onSubmit]);
+      const wrapper = new EmbeddedComponentBusWrapper(module);
+      expect(wrapper.isSupported(Event.onError)).toBe(true);
+      expect(wrapper.isSupported(Event.onSubmit)).toBe(true);
+    });
+
+    test('should return false for events not listed in getConstants', () => {
+      const module = createMockEmbeddedModule([Event.onError]);
+      const wrapper = new EmbeddedComponentBusWrapper(module);
+      expect(wrapper.isSupported(Event.onComplete)).toBe(false);
+    });
+
+    test('should return false when no supported events', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      expect(wrapper.isSupported(Event.onError)).toBe(false);
+    });
+  });
+
+  describe('subscribe', () => {
+    test('should call native module subscribe with componentType', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      wrapper.subscribe('CardComponent');
+      expect(mockNativeModule.subscribe).toHaveBeenCalledWith('CardComponent');
+    });
+  });
+
+  describe('unsubscribe', () => {
+    test('should call native module unsubscribe with componentType', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      wrapper.unsubscribe('CardComponent');
+      expect(mockNativeModule.unsubscribe).toHaveBeenCalledWith(
+        'CardComponent'
+      );
+    });
+  });
+
+  describe('handle', () => {
+    test('should call native module handle with componentType and action', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      const action = { type: 'redirect', paymentMethodType: 'ideal' } as any;
+      wrapper.handle('CardComponent', action);
+      expect(mockNativeModule.handle).toHaveBeenCalledWith(
+        'CardComponent',
+        action
+      );
+    });
+  });
+
+  describe('hide', () => {
+    test('should call native module hide with componentType, success true, and option', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      wrapper.hide('CardComponent', true, { message: 'done' });
+      expect(mockNativeModule.hide).toHaveBeenCalledWith(
+        'CardComponent',
+        true,
+        { message: 'done' }
+      );
+    });
+
+    test('should call native module hide with success false and no option', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      wrapper.hide('CardComponent', false);
+      expect(mockNativeModule.hide).toHaveBeenCalledWith(
+        'CardComponent',
+        false,
+        undefined
+      );
+    });
+  });
+
+  describe('update', () => {
+    test('should call native module update with componentType and results', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      const results = [{ id: '1', name: 'Street 1' }] as any[];
+      wrapper.update('CardComponent', results);
+      expect(mockNativeModule.update).toHaveBeenCalledWith(
+        'CardComponent',
+        results
+      );
+    });
+  });
+
+  describe('confirm', () => {
+    test('should call native module confirm with componentType, success true, and body', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      const address = { id: '1', name: 'Main St' } as any;
+      wrapper.confirm('CardComponent', true, address);
+      expect(mockNativeModule.confirm).toHaveBeenCalledWith(
+        'CardComponent',
+        true,
+        address
+      );
+    });
+
+    test('should call native module confirm with success false and error body', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      wrapper.confirm('CardComponent', false, { message: 'Invalid' });
+      expect(mockNativeModule.confirm).toHaveBeenCalledWith(
+        'CardComponent',
+        false,
+        { message: 'Invalid' }
+      );
+    });
+
+    test('should call native module confirm without body', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      wrapper.confirm('CardComponent', true);
+      expect(mockNativeModule.confirm).toHaveBeenCalledWith(
+        'CardComponent',
+        true,
+        undefined
+      );
+    });
+  });
+});

--- a/src/modules/embedded/__tests__/EmbeddedComponentProxy.test.ts
+++ b/src/modules/embedded/__tests__/EmbeddedComponentProxy.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { EmbeddedComponentProxy } from '../EmbeddedComponentProxy';
+import { Event } from '../../../core';
+
+function createMockBusWrapper() {
+  return {
+    name: 'AdyenComponentBus',
+    isSupported: jest.fn().mockReturnValue(false),
+    eventEmitterTarget: { addListener: jest.fn(), removeListeners: jest.fn() },
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+    handle: jest.fn(),
+    hide: jest.fn(),
+    update: jest.fn(),
+    confirm: jest.fn(),
+  } as any;
+}
+
+describe('EmbeddedComponentProxy', () => {
+  let mockWrapper: ReturnType<typeof createMockBusWrapper>;
+
+  beforeEach(() => {
+    mockWrapper = createMockBusWrapper();
+  });
+
+  describe('constructor', () => {
+    test('should expose componentType', () => {
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      expect(proxy.componentType).toBe('CardComponent');
+    });
+  });
+
+  describe('eventEmitterTarget', () => {
+    test('should delegate to wrapper eventEmitterTarget', () => {
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      expect(proxy.eventEmitterTarget).toBe(mockWrapper.eventEmitterTarget);
+    });
+  });
+
+  describe('isSupported', () => {
+    test('should delegate to wrapper isSupported', () => {
+      mockWrapper.isSupported.mockReturnValue(true);
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      const result = proxy.isSupported(Event.onError);
+      expect(mockWrapper.isSupported).toHaveBeenCalledWith(Event.onError);
+      expect(result).toBe(true);
+    });
+
+    test('should return false when wrapper reports unsupported', () => {
+      mockWrapper.isSupported.mockReturnValue(false);
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      expect(proxy.isSupported(Event.onSubmit)).toBe(false);
+    });
+  });
+
+  describe('handle', () => {
+    test('should call wrapper handle with bound componentType and action', () => {
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      const action = { type: 'redirect', paymentMethodType: 'ideal' } as any;
+      proxy.handle(action);
+      expect(mockWrapper.handle).toHaveBeenCalledWith('CardComponent', action);
+    });
+  });
+
+  describe('hide', () => {
+    test('should call wrapper hide with success true and provided message', () => {
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      proxy.hide(true, { message: 'Payment complete' });
+      expect(mockWrapper.hide).toHaveBeenCalledWith('CardComponent', true, {
+        message: 'Payment complete',
+      });
+    });
+
+    test('should call wrapper hide with empty message when option is undefined', () => {
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      proxy.hide(false);
+      expect(mockWrapper.hide).toHaveBeenCalledWith('CardComponent', false, {
+        message: '',
+      });
+    });
+
+    test('should call wrapper hide with empty message when option.message is undefined', () => {
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      proxy.hide(true, {});
+      expect(mockWrapper.hide).toHaveBeenCalledWith('CardComponent', true, {
+        message: '',
+      });
+    });
+  });
+
+  describe('update', () => {
+    test('should call wrapper update with bound componentType and results', () => {
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      const results = [{ id: '1', name: 'Street 1' }] as any[];
+      proxy.update(results);
+      expect(mockWrapper.update).toHaveBeenCalledWith('CardComponent', results);
+    });
+  });
+
+  describe('confirm', () => {
+    test('should call wrapper confirm with success true and address', () => {
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      const address = { id: '1', name: 'Main St' } as any;
+      proxy.confirm(address);
+      expect(mockWrapper.confirm).toHaveBeenCalledWith(
+        'CardComponent',
+        true,
+        address
+      );
+    });
+  });
+
+  describe('reject', () => {
+    test('should call wrapper confirm with success false and error', () => {
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      proxy.reject({ message: 'Lookup failed' });
+      expect(mockWrapper.confirm).toHaveBeenCalledWith('CardComponent', false, {
+        message: 'Lookup failed',
+      });
+    });
+
+    test('should call wrapper confirm with success false and no error', () => {
+      const proxy = new EmbeddedComponentProxy(mockWrapper, 'CardComponent');
+      proxy.reject();
+      expect(mockWrapper.confirm).toHaveBeenCalledWith(
+        'CardComponent',
+        false,
+        undefined
+      );
+    });
+  });
+
+  describe('componentType binding', () => {
+    test('different proxies on same wrapper route to their own componentType', () => {
+      const proxyA = new EmbeddedComponentProxy(mockWrapper, 'ComponentA');
+      const proxyB = new EmbeddedComponentProxy(mockWrapper, 'ComponentB');
+      const action = { type: 'threeDS2' } as any;
+
+      proxyA.handle(action);
+      proxyB.handle(action);
+
+      expect(mockWrapper.handle).toHaveBeenNthCalledWith(
+        1,
+        'ComponentA',
+        action
+      );
+      expect(mockWrapper.handle).toHaveBeenNthCalledWith(
+        2,
+        'ComponentB',
+        action
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Embedded Component Bus (PR 4/5 of CardView feature)

Introduces the cross-platform infrastructure for embedded native components (like CardView). This is the communication layer that allows JS to route events and commands to specific embedded views by `componentType`.

### JS/TS
- **EmbeddedComponentBusWrapper**: wraps the `AdyenComponentBus` native module, forwarding subscribe/unsubscribe/handle/hide/update/confirm calls
- **EmbeddedComponentProxy**: binds a `componentType` to all outbound calls, passed to merchant callbacks as the `component` argument
- **ModuleMock**: graceful fallback when native modules are not linked
- **useComponent**: context + hook for embedded components to subscribe/unsubscribe
- **useSubscriptionManager**: centralized subscription lifecycle management, used by AdyenCheckout
- **AdyenCheckout**: now uses `useSubscriptionManager` and wraps children in `AdyenComponentContext`
- 27 new tests for EmbeddedComponentBusWrapper and EmbeddedComponentProxy

### iOS
- **EmbeddedComponentBusModule**: per-componentType event routing with shared action handler, address lookup handler storage
- **EmbeddedComponentDelegateProxy**: tags every emitted event with `componentType` for JS-side demuxing, implements PaymentComponentDelegate, ActionComponentDelegate, CardComponentDelegate, AddressLookupProvider
- ObjC bridge additions for `AdyenComponentBus`
- Added `componentNotRegistered` case to `ModuleException`

### Android
- **EmbeddedComponentBusModule**: componentType-routed commands with companion object consumer registry
- **TaggedEmitter**: wraps MessageBusEmitter, injects `componentType` into all event payloads
- **ComponentContract**: interface for view managers to register with the bus
- Added `NoConsumer` and `NoPaymentRegistered` to `ModuleException`
- **AdyenPaymentPackage**: exposes emitter, registers `EmbeddedComponentBusModule`

All 210 JS tests pass (27 new). Typecheck passes.