### PR TITLE
feat: add card validation methods to CSE module

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/cse/AdyenCSEModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/cse/AdyenCSEModule.kt
@@ -9,6 +9,14 @@ package com.adyenreactnativesdk.cse
 import com.adyen.checkout.cse.CardEncrypter
 import com.adyen.checkout.cse.EncryptionException
 import com.adyen.checkout.cse.UnencryptedCard
+import com.adyen.checkout.core.CardBrand
+import com.adyen.checkout.core.ui.model.ExpiryDate
+import com.adyen.checkout.core.ui.validation.CardExpiryDateValidationResult
+import com.adyen.checkout.core.ui.validation.CardExpiryDateValidator
+import com.adyen.checkout.core.ui.validation.CardNumberValidationResult
+import com.adyen.checkout.core.ui.validation.CardNumberValidator
+import com.adyen.checkout.core.ui.validation.CardSecurityCodeValidationResult
+import com.adyen.checkout.core.ui.validation.CardSecurityCodeValidator
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -70,6 +78,45 @@ class AdyenCSEModule(
     } catch (e: EncryptionException) {
       promise.reject(ERROR_MESSAGE, e)
     }
+  }
+
+  @ReactMethod
+  fun validateCardNumber(
+    cardNumber: String,
+    enableLuhnCheck: Boolean,
+    promise: Promise,
+  ) {
+    val validationResult = CardNumberValidator.validateCardNumber(cardNumber, enableLuhnCheck)
+    promise.resolve(validationResult is CardNumberValidationResult.Valid)
+  }
+
+  @ReactMethod
+  fun validateCardExpiryDate(
+    expiryMonth: String,
+    expiryYear: String,
+    promise: Promise,
+  ) {
+    val expireMonth = expiryMonth.toIntOrNull()
+    val expireYear = expiryYear.toIntOrNull()
+    if (expireMonth == null || expireYear == null) {
+      promise.resolve(false)
+      return
+    }
+
+    val expiryDate = ExpiryDate(expireMonth, expireYear)
+    val validationResult = CardExpiryDateValidator.validateExpiryDate(expiryDate)
+    promise.resolve(validationResult is CardExpiryDateValidationResult.Valid)
+  }
+
+  @ReactMethod
+  fun validateCardSecurityCode(
+    securityCode: String,
+    cardBrand: String?,
+    promise: Promise,
+  ) {
+    val cardType = cardBrand?.let { CardBrand(it) }
+    val validationResult = CardSecurityCodeValidator.validateSecurityCode(securityCode, cardType)
+    promise.resolve(validationResult is CardSecurityCodeValidationResult.Valid)
   }
 
   companion object {

--- a/android/src/main/java/com/adyenreactnativesdk/cse/AdyenCSEModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/cse/AdyenCSEModule.kt
@@ -6,9 +6,6 @@
 
 package com.adyenreactnativesdk.cse
 
-import com.adyen.checkout.cse.CardEncrypter
-import com.adyen.checkout.cse.EncryptionException
-import com.adyen.checkout.cse.UnencryptedCard
 import com.adyen.checkout.core.CardBrand
 import com.adyen.checkout.core.ui.model.ExpiryDate
 import com.adyen.checkout.core.ui.validation.CardExpiryDateValidationResult
@@ -17,6 +14,9 @@ import com.adyen.checkout.core.ui.validation.CardNumberValidationResult
 import com.adyen.checkout.core.ui.validation.CardNumberValidator
 import com.adyen.checkout.core.ui.validation.CardSecurityCodeValidationResult
 import com.adyen.checkout.core.ui.validation.CardSecurityCodeValidator
+import com.adyen.checkout.cse.CardEncrypter
+import com.adyen.checkout.cse.EncryptionException
+import com.adyen.checkout.cse.UnencryptedCard
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule

--- a/example/src/components/CustomCard/CseView.tsx
+++ b/example/src/components/CustomCard/CseView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Button, View, Alert, ScrollView } from 'react-native';
-import { AdyenAction } from '@adyen/react-native';
+import { AdyenAction, AdyenCSE } from '@adyen/react-native';
 import Styles from '../common/Styles';
 import { payWithCard } from './utils/payWithCard';
 import { useAppContext } from '../../hooks/useAppContext';
@@ -10,6 +10,8 @@ import ExpiryDateInput from './components/ExpiryDateInput';
 import SecureCodeInput from './components/SecureCodeInput';
 import { formatMinorUnits } from '../utilities/formatMinorUnits';
 
+const CARD_VALIDATION_ERROR_TITLE = 'Invalid card details';
+
 const CseView = () => {
   const { configuration, processResult } = useAppContext();
   const [number, setNumber] = useState('');
@@ -18,26 +20,58 @@ const CseView = () => {
 
   const unencryptedCard = useMemo(() => {
     const parts = expiryDate.split('/');
-    const expiryMonth = parts[0];
-    const expiryYear = parts[1];
+    const expiryMonth = parts[0] ?? '';
+    const expiryYear = parts[1] ? '20' + parts[1] : '';
     return {
       number: number.replace(/\s+/g, ''),
       expiryMonth,
-      expiryYear: '20' + expiryYear,
+      expiryYear,
       cvv,
     };
   }, [expiryDate, number, cvv]);
 
+  const validateCardData = useCallback(async (): Promise<string | null> => {
+    const isCardNumberValid = await AdyenCSE.validateCardNumber(
+      unencryptedCard.number ?? '',
+      true
+    );
+    if (!isCardNumberValid) {
+      return 'Please provide a valid card number.';
+    }
+
+    const isExpiryDateValid = await AdyenCSE.validateCardExpiryDate(
+      unencryptedCard.expiryMonth ?? '',
+      unencryptedCard.expiryYear ?? ''
+    );
+    if (!isExpiryDateValid) {
+      return 'Please provide a valid expiry date.';
+    }
+
+    const isSecurityCodeValid = await AdyenCSE.validateCardSecurityCode(
+      unencryptedCard.cvv ?? ''
+    );
+    if (!isSecurityCodeValid) {
+      return 'Please provide a valid security code.';
+    }
+
+    return null;
+  }, [unencryptedCard]);
+
   const tryEncryptCard = useCallback(async () => {
     let result: PaymentResponse;
     try {
+      const validationError = await validateCardData();
+      if (validationError) {
+        Alert.alert(CARD_VALIDATION_ERROR_TITLE, validationError);
+        return;
+      }
       result = await payWithCard(unencryptedCard, configuration);
       processResult(result, AdyenAction);
     } catch (e) {
       Alert.alert('Error', String(e));
       return;
     }
-  }, [configuration, unencryptedCard, processResult]);
+  }, [configuration, unencryptedCard, processResult, validateCardData]);
 
   const amountLabel = useMemo(() => {
     return formatMinorUnits(

--- a/ios/AdyenModule.m
+++ b/ios/AdyenModule.m
@@ -93,6 +93,21 @@ RCT_EXTERN_METHOD(encryptBin:(NSString *)bin
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(validateCardNumber:(NSString *)cardNumber
+                  enableLuhnCheck:(BOOL)enableLuhnCheck
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(validateCardExpiryDate:(NSString *)expiryMonth
+                  expiryYear:(NSString *)expiryYear
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(validateCardSecurityCode:(NSString *)securityCode
+                  cardBrand:(nullable NSString *)cardBrand
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end
 
 @interface RCT_EXTERN_MODULE(SessionHelper, NSObject)

--- a/ios/CSE/AdyenCSEModule.swift
+++ b/ios/CSE/AdyenCSEModule.swift
@@ -61,8 +61,14 @@ internal final class AdyenCSEModule: NSObject {
                                 expiryYear: NSString,
                                 resolver: RCTPromiseResolveBlock,
                                 rejecter: RCTPromiseRejectBlock) {
-        let lastTwoYearChars = String((expiryYear as String).suffix(2))
-        let isValid = CardExpiryDateValidator().isValid("\(expiryMonth)\(lastTwoYearChars)")
+        let yearString = expiryYear as String
+        let isValid: Bool
+        if yearString.count == 2 || yearString.count == 4 {
+            let lastTwoYearChars = String(yearString.suffix(2))
+            isValid = CardExpiryDateValidator().isValid("\(expiryMonth)\(lastTwoYearChars)")
+        } else {
+            isValid = false
+        }
         resolver(isValid)
     }
 

--- a/ios/CSE/AdyenCSEModule.swift
+++ b/ios/CSE/AdyenCSEModule.swift
@@ -5,6 +5,9 @@
 //
 
 import Adyen
+#if canImport(AdyenCard)
+import AdyenCard
+#endif
 import Foundation
 import React
 
@@ -42,6 +45,53 @@ internal final class AdyenCSEModule: NSObject {
         } catch {
             rejecter("AdyenCSE", Constant.errorMessage, error)
         }
+    }
+
+    @objc
+    func validateCardNumber(_ cardNumber: NSString,
+                            enableLuhnCheck: Bool,
+                            resolver: RCTPromiseResolveBlock,
+                            rejecter: RCTPromiseRejectBlock) {
+#if canImport(AdyenCard)
+        let isValid = CardNumberValidator(
+            isLuhnCheckEnabled: enableLuhnCheck,
+            isEnteredBrandSupported: true
+        ).isValid(cardNumber as String)
+        resolver(isValid)
+#else
+        resolver(false)
+#endif
+    }
+
+    @objc
+    func validateCardExpiryDate(_ expiryMonth: NSString,
+                                expiryYear: NSString,
+                                resolver: RCTPromiseResolveBlock,
+                                rejecter: RCTPromiseRejectBlock) {
+#if canImport(AdyenCard)
+        let lastTwoYearChars = String((expiryYear as String).suffix(2))
+        let isValid = CardExpiryDateValidator().isValid("\(expiryMonth)\(lastTwoYearChars)")
+        resolver(isValid)
+#else
+        resolver(false)
+#endif
+    }
+
+    @objc
+    func validateCardSecurityCode(_ securityCode: NSString,
+                                  cardBrand: NSString?,
+                                  resolver: RCTPromiseResolveBlock,
+                                  rejecter: RCTPromiseRejectBlock) {
+#if canImport(AdyenCard)
+        if let cardBrand = cardBrand as String? {
+            let cardType = CardType(rawValue: cardBrand)
+            resolver(CardSecurityCodeValidator(cardType: cardType).isValid(securityCode as String))
+        } else {
+            resolver(CardSecurityCodeValidator().isValid(securityCode as String))
+        }
+#else
+        resolver(false)
+#endif
     }
 
     private enum Constant {

--- a/ios/CSE/AdyenCSEModule.swift
+++ b/ios/CSE/AdyenCSEModule.swift
@@ -5,7 +5,6 @@
 //
 
 import Adyen
-import AdyenCard
 import Foundation
 import React
 

--- a/ios/CSE/AdyenCSEModule.swift
+++ b/ios/CSE/AdyenCSEModule.swift
@@ -5,9 +5,7 @@
 //
 
 import Adyen
-#if canImport(AdyenCard)
 import AdyenCard
-#endif
 import Foundation
 import React
 
@@ -52,15 +50,11 @@ internal final class AdyenCSEModule: NSObject {
                             enableLuhnCheck: Bool,
                             resolver: RCTPromiseResolveBlock,
                             rejecter: RCTPromiseRejectBlock) {
-#if canImport(AdyenCard)
         let isValid = CardNumberValidator(
             isLuhnCheckEnabled: enableLuhnCheck,
             isEnteredBrandSupported: true
         ).isValid(cardNumber as String)
         resolver(isValid)
-#else
-        resolver(false)
-#endif
     }
 
     @objc
@@ -68,13 +62,9 @@ internal final class AdyenCSEModule: NSObject {
                                 expiryYear: NSString,
                                 resolver: RCTPromiseResolveBlock,
                                 rejecter: RCTPromiseRejectBlock) {
-#if canImport(AdyenCard)
         let lastTwoYearChars = String((expiryYear as String).suffix(2))
         let isValid = CardExpiryDateValidator().isValid("\(expiryMonth)\(lastTwoYearChars)")
         resolver(isValid)
-#else
-        resolver(false)
-#endif
     }
 
     @objc
@@ -82,16 +72,12 @@ internal final class AdyenCSEModule: NSObject {
                                   cardBrand: NSString?,
                                   resolver: RCTPromiseResolveBlock,
                                   rejecter: RCTPromiseRejectBlock) {
-#if canImport(AdyenCard)
         if let cardBrand = cardBrand as String? {
             let cardType = CardType(rawValue: cardBrand)
             resolver(CardSecurityCodeValidator(cardType: cardType).isValid(securityCode as String))
         } else {
             resolver(CardSecurityCodeValidator().isValid(securityCode as String))
         }
-#else
-        resolver(false)
-#endif
     }
 
     private enum Constant {

--- a/src/modules/cse/AdyenCSEModule.ts
+++ b/src/modules/cse/AdyenCSEModule.ts
@@ -10,6 +10,24 @@ export interface AdyenCSEModule {
 
   /** Method to encrypt BIN(first 6-11 digits of the card). */
   encryptBin(payload: string, publicKey: string): Promise<string>;
+
+  /** Method to validate card number. */
+  validateCardNumber(
+    cardNumber: string,
+    enableLuhnCheck: boolean
+  ): Promise<boolean>;
+
+  /** Method to validate card expiry date. */
+  validateCardExpiryDate(
+    expiryMonth: string,
+    expiryYear: string
+  ): Promise<boolean>;
+
+  /** Method to validate card security code. */
+  validateCardSecurityCode(
+    securityCode: string,
+    cardBrand?: string
+  ): Promise<boolean>;
 }
 
 /** Encryption helper. */

--- a/src/modules/cse/AdyenCSEModuleWrapper.ts
+++ b/src/modules/cse/AdyenCSEModuleWrapper.ts
@@ -21,4 +21,28 @@ export class AdyenCSEWrapper implements AdyenCSEModule {
   encryptBin(payload: string, publicKey: string): Promise<string> {
     return this.nativeModule.encryptBin(payload, publicKey);
   }
+
+  /** Method to validate card number. */
+  validateCardNumber(
+    cardNumber: string,
+    enableLuhnCheck: boolean
+  ): Promise<boolean> {
+    return this.nativeModule.validateCardNumber(cardNumber, enableLuhnCheck);
+  }
+
+  /** Method to validate card expiry date. */
+  validateCardExpiryDate(
+    expiryMonth: string,
+    expiryYear: string
+  ): Promise<boolean> {
+    return this.nativeModule.validateCardExpiryDate(expiryMonth, expiryYear);
+  }
+
+  /** Method to validate card security code. */
+  validateCardSecurityCode(
+    securityCode: string,
+    cardBrand?: string
+  ): Promise<boolean> {
+    return this.nativeModule.validateCardSecurityCode(securityCode, cardBrand);
+  }
 }

--- a/src/modules/cse/__tests__/AdyenCSEModuleWrapper.test.ts
+++ b/src/modules/cse/__tests__/AdyenCSEModuleWrapper.test.ts
@@ -15,6 +15,15 @@ function createMockCSEModule() {
     encryptBin: jest
       .fn<() => Promise<string>>()
       .mockResolvedValue('adyenjs_bin_...'),
+    validateCardNumber: jest
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(true),
+    validateCardExpiryDate: jest
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(true),
+    validateCardSecurityCode: jest
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(true),
   } as any;
 }
 
@@ -145,6 +154,98 @@ describe('AdyenCSEModuleWrapper', () => {
     test('should implement encryptBin method', () => {
       const wrapper = new AdyenCSEWrapper(mockNativeModule);
       expect(typeof wrapper.encryptBin).toBe('function');
+    });
+
+    test('should implement validateCardNumber method', () => {
+      const wrapper = new AdyenCSEWrapper(mockNativeModule);
+      expect(typeof wrapper.validateCardNumber).toBe('function');
+    });
+
+    test('should implement validateCardExpiryDate method', () => {
+      const wrapper = new AdyenCSEWrapper(mockNativeModule);
+      expect(typeof wrapper.validateCardExpiryDate).toBe('function');
+    });
+
+    test('should implement validateCardSecurityCode method', () => {
+      const wrapper = new AdyenCSEWrapper(mockNativeModule);
+      expect(typeof wrapper.validateCardSecurityCode).toBe('function');
+    });
+  });
+
+  describe('validateCardNumber', () => {
+    test('should call native module validateCardNumber with value and luhn check flag', async () => {
+      const wrapper = new AdyenCSEWrapper(mockNativeModule);
+
+      await wrapper.validateCardNumber('4111111111111111', true);
+
+      expect(mockNativeModule.validateCardNumber).toHaveBeenCalledWith(
+        '4111111111111111',
+        true
+      );
+    });
+
+    test('should return validation result', async () => {
+      mockNativeModule.validateCardNumber.mockResolvedValue(false);
+      const wrapper = new AdyenCSEWrapper(mockNativeModule);
+
+      const result = await wrapper.validateCardNumber('1234', true);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('validateCardExpiryDate', () => {
+    test('should call native module validateCardExpiryDate with month and year', async () => {
+      const wrapper = new AdyenCSEWrapper(mockNativeModule);
+
+      await wrapper.validateCardExpiryDate('03', '2030');
+
+      expect(mockNativeModule.validateCardExpiryDate).toHaveBeenCalledWith(
+        '03',
+        '2030'
+      );
+    });
+
+    test('should return validation result', async () => {
+      mockNativeModule.validateCardExpiryDate.mockResolvedValue(false);
+      const wrapper = new AdyenCSEWrapper(mockNativeModule);
+
+      const result = await wrapper.validateCardExpiryDate('13', '2030');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('validateCardSecurityCode', () => {
+    test('should call native module validateCardSecurityCode with code and optional brand', async () => {
+      const wrapper = new AdyenCSEWrapper(mockNativeModule);
+
+      await wrapper.validateCardSecurityCode('737', 'visa');
+
+      expect(mockNativeModule.validateCardSecurityCode).toHaveBeenCalledWith(
+        '737',
+        'visa'
+      );
+    });
+
+    test('should call native module validateCardSecurityCode without brand', async () => {
+      const wrapper = new AdyenCSEWrapper(mockNativeModule);
+
+      await wrapper.validateCardSecurityCode('737');
+
+      expect(mockNativeModule.validateCardSecurityCode).toHaveBeenCalledWith(
+        '737',
+        undefined
+      );
+    });
+
+    test('should return validation result', async () => {
+      mockNativeModule.validateCardSecurityCode.mockResolvedValue(false);
+      const wrapper = new AdyenCSEWrapper(mockNativeModule);
+
+      const result = await wrapper.validateCardSecurityCode('12');
+
+      expect(result).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add `validateCardNumber`, `validateCardExpiryDate`, and `validateCardSecurityCode` to AdyenCSE module
- expose methods in TypeScript wrapper and iOS/Android native modules
- add wrapper tests for new methods