### PR TITLE
refactor: slim base classes, extend action/address hierarchy to all Android modules

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModule.kt
@@ -1,8 +1,7 @@
 package com.adyenreactnativesdk.component
 
+import android.util.Log
 import com.adyen.checkout.components.core.AddressLookupResult
-import com.adyen.checkout.components.core.action.Action
-import com.adyen.checkout.dropin.AddressLookupDropInServiceResult
 import com.adyenreactnativesdk.component.base.BaseAddressModule
 import com.adyenreactnativesdk.component.base.ModuleException
 import com.adyenreactnativesdk.react.ComponentContract
@@ -13,13 +12,11 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import org.json.JSONException
 
 class EmbeddedComponentBusModule(
   val context: ReactApplicationContext?,
   messageBus: MessageBus,
 ) : BaseAddressModule(context, messageBus) {
-  private var activeViewId: String? = null
   private val subscribedViews: MutableSet<String> = mutableSetOf()
 
   override fun getName(): String = COMPONENT_NAME
@@ -51,13 +48,23 @@ class EmbeddedComponentBusModule(
   }
 
   @ReactMethod
-  fun confirm(
+  fun handle(
     viewId: String,
-    success: Boolean,
-    address: ReadableMap?,
+    actionMap: ReadableMap?,
   ) {
-    activeViewId = viewId
-    super.confirm(success, address)
+    val action =
+      try {
+        parseActionFromMap(actionMap)
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to parse action", e)
+        return sendError(ModuleException.InvalidAction(e))
+      }
+
+    val consumer =
+      getConsumer(viewId)
+        ?: return sendError(ModuleException.NoConsumer(viewId))
+
+    consumer.onAction(action)
   }
 
   @ReactMethod
@@ -65,8 +72,33 @@ class EmbeddedComponentBusModule(
     viewId: String,
     array: ReadableArray?,
   ) {
-    activeViewId = viewId
-    super.update(array)
+    val consumer =
+      getConsumer(viewId)
+        ?: return sendError(ModuleException.NoConsumer(viewId))
+
+    consumer.onAddressLookupOptions(parseAddressOptions(array))
+  }
+
+  @ReactMethod
+  fun confirm(
+    viewId: String,
+    success: Boolean,
+    address: ReadableMap?,
+  ) {
+    val consumer =
+      getConsumer(viewId)
+        ?: return sendError(ModuleException.NoConsumer(viewId))
+
+    if (success) {
+      try {
+        consumer.onAddressLookupResult(AddressLookupResult.Completed(parseLookupAddress(address)))
+      } catch (e: Throwable) {
+        Log.w(TAG, "Failed to parse address lookup confirmation", e)
+        consumer.onAddressLookupResult(AddressLookupResult.Error(e.localizedMessage))
+      }
+    } else {
+      consumer.onAddressLookupResult(AddressLookupResult.Error(address?.getString("message")))
+    }
   }
 
   @ReactMethod
@@ -85,67 +117,12 @@ class EmbeddedComponentBusModule(
     success: Boolean,
     message: ReadableMap?,
   ) {
-    activeViewId = null
     cleanup()
-  }
-
-  @ReactMethod
-  fun handle(
-    viewId: String,
-    actionMap: ReadableMap?,
-  ) {
-    activeViewId = viewId
-    super.parseAndHandleAction(actionMap)
-  }
-
-  override fun handleAction(action: Action) {
-    val viewId =
-      activeViewId ?: return messageBus.onException(ModuleException.NoPaymentRegistered())
-
-    val component =
-      getConsumer(viewId)
-        ?: return messageBus.onException(ModuleException.NoConsumer(viewId))
-
-    try {
-      component.onAction(action)
-    } catch (e: JSONException) {
-      messageBus.onException(ModuleException.InvalidAction(e))
-    } finally {
-      activeViewId = null
-    }
-  }
-
-  override fun sendAddressLookupResult(result: AddressLookupDropInServiceResult) {
-    val viewId =
-      activeViewId ?: return messageBus.onException(ModuleException.NoPaymentRegistered())
-
-    val contract =
-      getConsumer(viewId)
-        ?: return messageBus.onException(ModuleException.NoConsumer(viewId))
-
-    try {
-      when (result) {
-        is AddressLookupDropInServiceResult.LookupResult -> {
-          contract.onAddressLookupOptions(result.options)
-        }
-
-        is AddressLookupDropInServiceResult.LookupComplete -> {
-          contract.onAddressLookupResult(AddressLookupResult.Completed(result.lookupAddress))
-        }
-
-        is AddressLookupDropInServiceResult.Error -> {
-          contract.onAddressLookupResult(AddressLookupResult.Error(result.errorDialog?.message))
-        }
-      }
-    } finally {
-      if (result !is AddressLookupDropInServiceResult.LookupResult) {
-        activeViewId = null
-      }
-    }
   }
 
   companion object {
     private const val COMPONENT_NAME = "AdyenComponentBus"
+    private const val TAG = "EmbeddedComponentBusModule"
 
     /** Registry of viewId (reactTag) → ViewState implementing ComponentContract */
     private val consumers: MutableMap<String, ComponentContract> = mutableMapOf()

--- a/android/src/main/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModule.kt
@@ -57,7 +57,7 @@ class EmbeddedComponentBusModule(
         parseActionFromMap(actionMap)
       } catch (e: Exception) {
         Log.w(TAG, "Failed to parse action", e)
-        return sendError(ModuleException.InvalidAction(e))
+        return sendError(e)
       }
 
     val consumer =
@@ -92,7 +92,7 @@ class EmbeddedComponentBusModule(
     if (success) {
       try {
         consumer.onAddressLookupResult(AddressLookupResult.Completed(parseLookupAddress(address)))
-      } catch (e: Throwable) {
+      } catch (e: Exception) {
         Log.w(TAG, "Failed to parse address lookup confirmation", e)
         consumer.onAddressLookupResult(AddressLookupResult.Error(e.localizedMessage))
       }

--- a/android/src/main/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModule.kt
@@ -7,7 +7,7 @@ import com.adyenreactnativesdk.component.base.ModuleException
 import com.adyenreactnativesdk.react.ComponentContract
 import com.adyenreactnativesdk.util.messaging.EventName
 import com.adyenreactnativesdk.util.messaging.MessageBus
-import com.adyenreactnativesdk.util.messaging.embeddedComponentsEvents
+import com.adyenreactnativesdk.util.messaging.cardEvents
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
@@ -21,7 +21,7 @@ class EmbeddedComponentBusModule(
 
   override fun getName(): String = COMPONENT_NAME
 
-  override fun supportedEvents(): List<String> = EventName.embeddedComponentsEvents()
+  override fun supportedEvents(): List<String> = super.supportedEvents() + EventName.cardEvents()
 
   override fun getConstants(): MutableMap<String, Any> = super.getConstants()
 

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/BaseActionModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/BaseActionModule.kt
@@ -14,7 +14,7 @@ import com.adyenreactnativesdk.util.messaging.mainEvents
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 
-open class BaseActionModule(
+abstract class BaseActionModule(
   reactContext: ReactApplicationContext?,
   messageBus: MessageBus,
 ) : BaseModule(reactContext, messageBus) {

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/BaseActionModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/BaseActionModule.kt
@@ -10,7 +10,7 @@ import com.adyen.checkout.components.core.action.Action
 import com.adyenreactnativesdk.util.ReactNativeJson
 import com.adyenreactnativesdk.util.messaging.EventName
 import com.adyenreactnativesdk.util.messaging.MessageBus
-import com.adyenreactnativesdk.util.messaging.mainEvents
+import com.adyenreactnativesdk.util.messaging.coreEvents
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 
@@ -18,7 +18,7 @@ abstract class BaseActionModule(
   reactContext: ReactApplicationContext?,
   messageBus: MessageBus,
 ) : BaseModule(reactContext, messageBus) {
-  override fun supportedEvents(): List<String> = EventName.mainEvents()
+  override fun supportedEvents(): List<String> = EventName.coreEvents()
 
   protected fun parseActionFromMap(actionMap: ReadableMap?): Action =
     try {

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/BaseActionModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/BaseActionModule.kt
@@ -6,8 +6,6 @@
 
 package com.adyenreactnativesdk.component.base
 
-import android.util.Log
-import com.adyen.checkout.components.core.ActionComponentData
 import com.adyen.checkout.components.core.action.Action
 import com.adyenreactnativesdk.util.ReactNativeJson
 import com.adyenreactnativesdk.util.messaging.EventName
@@ -17,21 +15,11 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import org.json.JSONException
 
-abstract class BaseActionModule(
+open class BaseActionModule(
   reactContext: ReactApplicationContext?,
   messageBus: MessageBus,
 ) : BaseModule(reactContext, messageBus) {
   override fun supportedEvents(): List<String> = EventName.mainEvents()
-
-  protected fun parseAndHandleAction(actionMap: ReadableMap?) {
-    try {
-      val action = parseActionFromMap(actionMap)
-      handleAction(action)
-    } catch (e: Exception) {
-      Log.w(TAG, "Failed to parse and handle action", e)
-      sendError(ModuleException.InvalidAction(e))
-    }
-  }
 
   protected fun parseActionFromMap(actionMap: ReadableMap?): Action =
     try {
@@ -40,28 +28,4 @@ abstract class BaseActionModule(
     } catch (e: JSONException) {
       throw ModuleException.InvalidAction(e)
     }
-
-  protected abstract fun handleAction(action: Action)
-
-  protected fun sendAdditionalDetailsEvent(actionComponentData: ActionComponentData) {
-    try {
-      messageBus.onAdditionalDetails(actionComponentData)
-    } catch (e: Exception) {
-      Log.w(TAG, "Failed to send additional details event", e)
-      sendError(e)
-    }
-  }
-
-  protected fun sendCompleteEvent() {
-    try {
-      messageBus.onFinished()
-    } catch (e: Exception) {
-      Log.w(TAG, "Failed to send complete event", e)
-      sendError(e)
-    }
-  }
-
-  private companion object {
-    private const val TAG = "BaseActionModule"
-  }
 }

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/BaseActionModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/BaseActionModule.kt
@@ -13,7 +13,6 @@ import com.adyenreactnativesdk.util.messaging.MessageBus
 import com.adyenreactnativesdk.util.messaging.mainEvents
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
-import org.json.JSONException
 
 open class BaseActionModule(
   reactContext: ReactApplicationContext?,
@@ -25,7 +24,7 @@ open class BaseActionModule(
     try {
       val jsonObject = ReactNativeJson.convertMapToJson(actionMap)
       Action.SERIALIZER.deserialize(jsonObject)
-    } catch (e: JSONException) {
+    } catch (e: Exception) {
       throw ModuleException.InvalidAction(e)
     }
 }

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/BaseAddressModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/BaseAddressModule.kt
@@ -1,9 +1,13 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ */
+
 package com.adyenreactnativesdk.component.base
 
 import android.util.Log
 import com.adyen.checkout.components.core.LookupAddress
-import com.adyen.checkout.dropin.AddressLookupDropInServiceResult
-import com.adyen.checkout.dropin.ErrorDialog
 import com.adyenreactnativesdk.component.model.fromJsonObject
 import com.adyenreactnativesdk.util.ReactNativeJson
 import com.adyenreactnativesdk.util.map
@@ -14,52 +18,25 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 
-abstract class BaseAddressModule(
+open class BaseAddressModule(
   reactContext: ReactApplicationContext?,
   messageBus: MessageBus,
 ) : BaseActionModule(reactContext, messageBus) {
   override fun supportedEvents(): List<String> = super.supportedEvents() + EventName.addressLookupEvents()
 
-  open fun update(array: ReadableArray?) {
-    val result =
-      try {
-        val jsonArray = ReactNativeJson.convertArrayToJson(array)
-        val addresses = jsonArray.map { LookupAddress::class.fromJsonObject(it) }
-        AddressLookupDropInServiceResult.LookupResult(addresses.toList())
-      } catch (error: Throwable) {
-        Log.w(TAG, error)
-        AddressLookupDropInServiceResult.LookupResult(arrayListOf())
-      }
-    sendAddressLookupResult(result)
+  protected fun parseAddressOptions(array: ReadableArray?): List<LookupAddress> =
+    try {
+      val jsonArray = ReactNativeJson.convertArrayToJson(array)
+      jsonArray.map { LookupAddress::class.fromJsonObject(it) }
+    } catch (e: Throwable) {
+      Log.w(TAG, "Failed to parse address options", e)
+      emptyList()
+    }
+
+  protected fun parseLookupAddress(address: ReadableMap?): LookupAddress {
+    val jsonObject = ReactNativeJson.convertMapToJson(address)
+    return LookupAddress::class.fromJsonObject(jsonObject)
   }
-
-  open fun confirm(
-    success: Boolean,
-    address: ReadableMap?,
-  ) {
-    val result =
-      if (success) {
-        try {
-          val jsonObject = ReactNativeJson.convertMapToJson(address)
-          val lookupAddress = LookupAddress::class.fromJsonObject(jsonObject)
-          AddressLookupDropInServiceResult.LookupComplete(lookupAddress)
-        } catch (error: Throwable) {
-          lookupError(error.localizedMessage)
-        }
-      } else {
-        lookupError(address?.getString("message"))
-      }
-    sendAddressLookupResult(result)
-  }
-
-  private fun lookupError(message: String?): AddressLookupDropInServiceResult.Error =
-    AddressLookupDropInServiceResult.Error(
-      message?.let { ErrorDialog(message = it) },
-      null,
-      false,
-    )
-
-  abstract fun sendAddressLookupResult(result: AddressLookupDropInServiceResult)
 
   private companion object {
     private const val TAG = "BaseAddressModule"

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/BaseAddressModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/BaseAddressModule.kt
@@ -28,15 +28,18 @@ open class BaseAddressModule(
     try {
       val jsonArray = ReactNativeJson.convertArrayToJson(array)
       jsonArray.map { LookupAddress::class.fromJsonObject(it) }
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
       Log.w(TAG, "Failed to parse address options", e)
       emptyList()
     }
 
-  protected fun parseLookupAddress(address: ReadableMap?): LookupAddress {
-    val jsonObject = ReactNativeJson.convertMapToJson(address)
-    return LookupAddress::class.fromJsonObject(jsonObject)
-  }
+  protected fun parseLookupAddress(address: ReadableMap?): LookupAddress =
+    try {
+      val jsonObject = ReactNativeJson.convertMapToJson(address)
+      LookupAddress::class.fromJsonObject(jsonObject)
+    } catch (e: Exception) {
+      throw ModuleException.InvalidAction(e)
+    }
 
   private companion object {
     private const val TAG = "BaseAddressModule"

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/BaseAddressModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/BaseAddressModule.kt
@@ -18,7 +18,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 
-open class BaseAddressModule(
+abstract class BaseAddressModule(
   reactContext: ReactApplicationContext?,
   messageBus: MessageBus,
 ) : BaseActionModule(reactContext, messageBus) {

--- a/android/src/main/java/com/adyenreactnativesdk/component/dropin/DropInModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/dropin/DropInModule.kt
@@ -11,10 +11,8 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import com.adyen.checkout.components.core.BalanceResult
 import com.adyen.checkout.components.core.CheckoutConfiguration
-import com.adyen.checkout.components.core.LookupAddress
 import com.adyen.checkout.components.core.OrderResponse
 import com.adyen.checkout.components.core.PaymentMethodsApiResponse
-import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.dropin.AddressLookupDropInServiceResult
 import com.adyen.checkout.dropin.BalanceDropInServiceResult
 import com.adyen.checkout.dropin.BaseDropInServiceContract
@@ -30,13 +28,11 @@ import com.adyen.checkout.dropin.internal.ui.model.DropInResultContractParams
 import com.adyen.checkout.dropin.internal.ui.model.SessionDropInResultContractParams
 import com.adyen.checkout.redirect.RedirectComponent
 import com.adyenreactnativesdk.AdyenPaymentPackage
-import com.adyenreactnativesdk.component.base.BaseModule
+import com.adyenreactnativesdk.component.base.BaseAddressModule
 import com.adyenreactnativesdk.component.base.ModuleException
-import com.adyenreactnativesdk.component.model.fromJsonObject
 import com.adyenreactnativesdk.configuration.CheckoutConfigurationFactory
 import com.adyenreactnativesdk.util.AdyenConstants
 import com.adyenreactnativesdk.util.ReactNativeJson
-import com.adyenreactnativesdk.util.map
 import com.adyenreactnativesdk.util.messaging.EventName
 import com.adyenreactnativesdk.util.messaging.MessageBus
 import com.facebook.react.bridge.Arguments
@@ -51,7 +47,7 @@ import com.facebook.react.jstasks.HeadlessJsTaskContext
 class DropInModule(
   reactContext: ReactApplicationContext?,
   messageBus: MessageBus,
-) : BaseModule(reactContext, messageBus) {
+) : BaseAddressModule(reactContext, messageBus) {
   private var taskId: Int? = null
 
   private val integration: String
@@ -121,8 +117,7 @@ class DropInModule(
   @ReactMethod
   fun handle(actionMap: ReadableMap?) {
     try {
-      val jsonObject = ReactNativeJson.convertMapToJson(actionMap)
-      val action = Action.SERIALIZER.deserialize(jsonObject)
+      val action = parseActionFromMap(actionMap)
       service.sendResult(DropInServiceResult.Action(action))
     } catch (e: Exception) {
       sendError(ModuleException.InvalidAction(e))
@@ -144,16 +139,7 @@ class DropInModule(
 
   @ReactMethod
   fun update(array: ReadableArray?) {
-    val result =
-      try {
-        val jsonArray = ReactNativeJson.convertArrayToJson(array)
-        val addresses = jsonArray.map { LookupAddress::class.fromJsonObject(it) }
-        AddressLookupDropInServiceResult.LookupResult(addresses.toList())
-      } catch (error: Throwable) {
-        Log.w(TAG, error)
-        AddressLookupDropInServiceResult.LookupResult(arrayListOf())
-      }
-    service.sendAddressLookupResult(result)
+    service.sendAddressLookupResult(AddressLookupDropInServiceResult.LookupResult(parseAddressOptions(array)))
   }
 
   @ReactMethod
@@ -164,25 +150,13 @@ class DropInModule(
     val result =
       if (success) {
         try {
-          val jsonObject = ReactNativeJson.convertMapToJson(address)
-          val lookupAddress = LookupAddress::class.fromJsonObject(jsonObject)
-          AddressLookupDropInServiceResult.LookupComplete(lookupAddress)
-        } catch (error: Throwable) {
-          AddressLookupDropInServiceResult.Error(
-            ErrorDialog(
-              message = error.localizedMessage,
-            ),
-            null,
-            false,
-          )
+          AddressLookupDropInServiceResult.LookupComplete(parseLookupAddress(address))
+        } catch (e: Throwable) {
+          AddressLookupDropInServiceResult.Error(ErrorDialog(message = e.localizedMessage), null, false)
         }
       } else {
         val error = address?.getString("message")?.let { ErrorDialog(message = it) }
-        AddressLookupDropInServiceResult.Error(
-          error,
-          null,
-          false,
-        )
+        AddressLookupDropInServiceResult.Error(error, null, false)
       }
     service.sendAddressLookupResult(result)
   }

--- a/android/src/main/java/com/adyenreactnativesdk/component/dropin/DropInModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/dropin/DropInModule.kt
@@ -35,6 +35,8 @@ import com.adyenreactnativesdk.util.AdyenConstants
 import com.adyenreactnativesdk.util.ReactNativeJson
 import com.adyenreactnativesdk.util.messaging.EventName
 import com.adyenreactnativesdk.util.messaging.MessageBus
+import com.adyenreactnativesdk.util.messaging.cardEvents
+import com.adyenreactnativesdk.util.messaging.dropInEvents
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -64,8 +66,6 @@ class DropInModule(
   fun removeListeners(count: Int?) { // No JS events expected
   }
 
-  override fun getConstants(): MutableMap<String, Any> = mutableMapOf("supportedEvents" to supportedEvents())
-
   @ReactMethod
   fun getReturnURL(promise: Promise) {
     promise.resolve(RedirectComponent.getReturnUrl(reactApplicationContext))
@@ -73,7 +73,7 @@ class DropInModule(
 
   override fun getName(): String = COMPONENT_NAME
 
-  override fun supportedEvents(): List<String> = EventName.entries.map { it.value }
+  override fun supportedEvents(): List<String> = super.supportedEvents() + EventName.cardEvents() + EventName.dropInEvents()
 
   @ReactMethod
   fun open(

--- a/android/src/main/java/com/adyenreactnativesdk/component/dropin/DropInModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/dropin/DropInModule.kt
@@ -120,7 +120,7 @@ class DropInModule(
       val action = parseActionFromMap(actionMap)
       service.sendResult(DropInServiceResult.Action(action))
     } catch (e: Exception) {
-      sendError(ModuleException.InvalidAction(e))
+      sendError(e)
     }
   }
 

--- a/android/src/main/java/com/adyenreactnativesdk/component/dropin/DropInModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/dropin/DropInModule.kt
@@ -58,6 +58,8 @@ class DropInModule(
   private val service: BaseDropInServiceContract
     get() = (if (session != null) sessionService else advancedService) ?: throw ModuleException.NoModuleListener(integration)
 
+  override fun getConstants(): MutableMap<String, Any> = mutableMapOf("supportedEvents" to supportedEvents())
+
   @ReactMethod
   fun addListener(eventName: String?) { // No JS events expected
   }

--- a/android/src/main/java/com/adyenreactnativesdk/component/dropin/DropInModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/dropin/DropInModule.kt
@@ -153,7 +153,7 @@ class DropInModule(
       if (success) {
         try {
           AddressLookupDropInServiceResult.LookupComplete(parseLookupAddress(address))
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
           AddressLookupDropInServiceResult.Error(ErrorDialog(message = e.localizedMessage), null, false)
         }
       } else {

--- a/android/src/main/java/com/adyenreactnativesdk/component/googlepay/GooglePayModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/googlepay/GooglePayModule.kt
@@ -90,7 +90,7 @@ class GooglePayModule(
       val action = parseActionFromMap(actionMap)
       GooglePayFragment.handle(appCompatActivity.supportFragmentManager, action)
     } catch (e: Exception) {
-      sendError(ModuleException.InvalidAction(e))
+      sendError(e)
     }
   }
 

--- a/android/src/main/java/com/adyenreactnativesdk/component/googlepay/GooglePayModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/googlepay/GooglePayModule.kt
@@ -28,6 +28,8 @@ class GooglePayModule(
 ) : BaseActionModule(context, messageBus) {
   override fun getName(): String = COMPONENT_NAME
 
+  override fun getConstants(): MutableMap<String, Any> = mutableMapOf("supportedEvents" to supportedEvents())
+
   @ReactMethod
   fun addListener(eventName: String?) { // No JS events expected
   }

--- a/android/src/main/java/com/adyenreactnativesdk/component/googlepay/GooglePayModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/googlepay/GooglePayModule.kt
@@ -10,29 +10,23 @@ import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.ComponentAvailableCallback
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.PaymentMethodsApiResponse
-import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.googlepay.GooglePayComponent
-import com.adyenreactnativesdk.component.base.BaseModule
+import com.adyenreactnativesdk.component.base.BaseActionModule
 import com.adyenreactnativesdk.component.base.KnownException
 import com.adyenreactnativesdk.component.base.ModuleException
 import com.adyenreactnativesdk.configuration.CheckoutConfigurationFactory
 import com.adyenreactnativesdk.util.ReactNativeJson
-import com.adyenreactnativesdk.util.messaging.EventName
 import com.adyenreactnativesdk.util.messaging.MessageBus
-import com.adyenreactnativesdk.util.messaging.mainEvents
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import org.json.JSONException
 
 class GooglePayModule(
   context: ReactApplicationContext?,
   messageBus: MessageBus,
-) : BaseModule(context, messageBus) {
+) : BaseActionModule(context, messageBus) {
   override fun getName(): String = COMPONENT_NAME
-
-  override fun supportedEvents(): List<String> = EventName.mainEvents()
 
   @ReactMethod
   fun addListener(eventName: String?) { // No JS events expected
@@ -41,8 +35,6 @@ class GooglePayModule(
   @ReactMethod
   fun removeListeners(count: Int?) { // No JS events expected
   }
-
-  override fun getConstants(): MutableMap<String, Any> = mutableMapOf("supportedEvents" to supportedEvents())
 
   @ReactMethod
   fun open(
@@ -95,10 +87,9 @@ class GooglePayModule(
   @ReactMethod
   fun handle(actionMap: ReadableMap?) {
     try {
-      val jsonObject = ReactNativeJson.convertMapToJson(actionMap)
-      val action = Action.SERIALIZER.deserialize(jsonObject)
+      val action = parseActionFromMap(actionMap)
       GooglePayFragment.handle(appCompatActivity.supportFragmentManager, action)
-    } catch (e: JSONException) {
+    } catch (e: Exception) {
       sendError(ModuleException.InvalidAction(e))
     }
   }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
@@ -9,30 +9,23 @@ package com.adyenreactnativesdk.component.instant
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.PaymentMethodTypes
-import com.adyen.checkout.components.core.action.Action
-import com.adyenreactnativesdk.component.base.BaseModule
+import com.adyenreactnativesdk.component.base.BaseActionModule
 import com.adyenreactnativesdk.component.base.ModuleException
 import com.adyenreactnativesdk.component.base.instant.IInstantFragment
 import com.adyenreactnativesdk.component.instant.fragment.IdealFragment
 import com.adyenreactnativesdk.component.instant.fragment.InstantFragment
 import com.adyenreactnativesdk.component.instant.fragment.TwintFragment
 import com.adyenreactnativesdk.configuration.CheckoutConfigurationFactory
-import com.adyenreactnativesdk.util.ReactNativeJson
-import com.adyenreactnativesdk.util.messaging.EventName
 import com.adyenreactnativesdk.util.messaging.MessageBus
-import com.adyenreactnativesdk.util.messaging.mainEvents
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import org.json.JSONException
 
 class InstantModule(
   context: ReactApplicationContext?,
   messageBus: MessageBus,
-) : BaseModule(context, messageBus) {
+) : BaseActionModule(context, messageBus) {
   override fun getName(): String = COMPONENT_NAME
-
-  override fun supportedEvents(): List<String> = EventName.mainEvents()
 
   @ReactMethod
   fun addListener(eventName: String?) { // No JS events expected
@@ -41,8 +34,6 @@ class InstantModule(
   @ReactMethod
   fun removeListeners(count: Int?) { // No JS events expected
   }
-
-  override fun getConstants(): MutableMap<String, Any> = mutableMapOf("supportedEvents" to supportedEvents())
 
   @ReactMethod
   fun open(
@@ -79,10 +70,9 @@ class InstantModule(
   @ReactMethod
   fun handle(actionMap: ReadableMap?) {
     try {
-      val jsonObject = ReactNativeJson.convertMapToJson(actionMap)
-      val action = Action.SERIALIZER.deserialize(jsonObject)
+      val action = parseActionFromMap(actionMap)
       fragment?.handle(appCompatActivity.supportFragmentManager, action)
-    } catch (e: JSONException) {
+    } catch (e: Exception) {
       sendError(ModuleException.InvalidAction(e))
     }
   }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
@@ -73,7 +73,7 @@ class InstantModule(
       val action = parseActionFromMap(actionMap)
       fragment?.handle(appCompatActivity.supportFragmentManager, action)
     } catch (e: Exception) {
-      sendError(ModuleException.InvalidAction(e))
+      sendError(e)
     }
   }
 

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
@@ -27,6 +27,8 @@ class InstantModule(
 ) : BaseActionModule(context, messageBus) {
   override fun getName(): String = COMPONENT_NAME
 
+  override fun getConstants(): MutableMap<String, Any> = mutableMapOf("supportedEvents" to supportedEvents())
+
   @ReactMethod
   fun addListener(eventName: String?) { // No JS events expected
   }

--- a/android/src/main/java/com/adyenreactnativesdk/util/messaging/EventName.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/util/messaging/EventName.kt
@@ -21,7 +21,7 @@ enum class EventName(
   companion object
 }
 
-fun EventName.Companion.mainEvents() =
+fun EventName.Companion.coreEvents() =
   listOf(
     EventName.SUBMIT.value,
     EventName.ERROR.value,
@@ -41,19 +41,16 @@ fun EventName.Companion.addressLookupEvents() =
     EventName.CONFIRM_ADDRESS.value,
   )
 
-fun EventName.Companion.cardComponentEvents() =
+fun EventName.Companion.cardEvents() =
   listOf(
     EventName.BIN_LOOKUP.value,
     EventName.CHANGE_BIN_VALUE.value,
   )
 
-fun EventName.Companion.dropinEvents() =
-  embeddedComponentsEvents() +
-    listOf(
-      EventName.DISABLE_STORED_PAYMENT_METHOD.value,
-      EventName.CHECK_BALANCE.value,
-      EventName.REQUEST_ORDER.value,
-      EventName.CANCEL_ORDER.value,
-    )
-
-fun EventName.Companion.embeddedComponentsEvents() = mainEvents() + addressLookupEvents() + cardComponentEvents()
+fun EventName.Companion.dropInEvents() =
+  listOf(
+    EventName.DISABLE_STORED_PAYMENT_METHOD.value,
+    EventName.CHECK_BALANCE.value,
+    EventName.REQUEST_ORDER.value,
+    EventName.CANCEL_ORDER.value,
+  )

--- a/android/src/test/java/com/adyenreactnativesdk/util/messaging/EventNameTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/util/messaging/EventNameTest.kt
@@ -12,16 +12,16 @@ import org.junit.Test
 
 class EventNameTest {
   @Test
-  fun `mainEvents returns correct event values`() {
+  fun `coreEvents returns correct event values`() {
     // WHEN
-    val mainEvents = EventName.mainEvents()
+    val coreEvents = EventName.coreEvents()
 
     // THEN
-    assertEquals(4, mainEvents.size)
-    assertTrue(mainEvents.contains(EventName.SUBMIT.value))
-    assertTrue(mainEvents.contains(EventName.ERROR.value))
-    assertTrue(mainEvents.contains(EventName.COMPLETE_VOUCHER.value))
-    assertTrue(mainEvents.contains(EventName.ADDITIONAL_DETAILS.value))
+    assertEquals(4, coreEvents.size)
+    assertTrue(coreEvents.contains(EventName.SUBMIT.value))
+    assertTrue(coreEvents.contains(EventName.ERROR.value))
+    assertTrue(coreEvents.contains(EventName.COMPLETE_VOUCHER.value))
+    assertTrue(coreEvents.contains(EventName.ADDITIONAL_DETAILS.value))
   }
 
   @Test

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -316,30 +316,32 @@ BaseModule                                           # Base class for payment mo
     │       - createSession(sessionModel, config)
     │       - hide() delegates to currentModule
     │
-    ├──► GooglePayModule                             # Google Pay component
-    │       - open(paymentMethods, config)
-    │       - handle(action)
-    │       - isAvailable(paymentMethods, config)
-    │
-    ├──► InstantModule                               # Instant/redirect payments
-    │       - open(paymentMethods, config)
-    │       - handle(action)
-    │
-    └──► DropInModule                                # Drop-in component
-            - open(paymentMethods, config)
-            - handle(action)
-            - removeStored(success)
-            - getReturnURL()
-            - update/confirm (address lookup)
-            - provideBalance/Order/PaymentMethods
-
-BaseAddressModule(BaseActionModule(BaseModule))      # Extended base for address + action support
-    │
-    └──► EmbeddedComponentBusModule                  # Embedded component bus
-            - consumers: Map<String, ComponentContract> (companion, keyed by reactTag)
-            - subscribe/unsubscribe (JS lifecycle)
-            - register/unregister (native view lifecycle)
-            - handle/update/confirm/hide (JS → native routing)
+    └──► BaseActionModule                            # Adds parseActionFromMap() + mainEvents()
+            │
+            ├──► GooglePayModule                     # Google Pay component
+            │       - open(paymentMethods, config)
+            │       - handle(action)
+            │       - isAvailable(paymentMethods, config)
+            │
+            ├──► InstantModule                       # Instant/redirect payments
+            │       - open(paymentMethods, config)
+            │       - handle(action)
+            │
+            └──► BaseAddressModule                   # Adds parseAddressOptions/parseLookupAddress() + addressLookupEvents()
+                    │
+                    ├──► DropInModule                # Drop-in component
+                    │       - open(paymentMethods, config)
+                    │       - handle(action)
+                    │       - removeStored(success)
+                    │       - getReturnURL()
+                    │       - update/confirm (address lookup)
+                    │       - provideBalance/Order/PaymentMethods
+                    │
+                    └──► EmbeddedComponentBusModule  # Embedded component bus
+                            - consumers: Map<String, ComponentContract> (companion, keyed by reactTag)
+                            - subscribe/unsubscribe (JS lifecycle)
+                            - register/unregister (native view lifecycle)
+                            - handle/update/confirm/hide (JS → native routing)
 ```
 
 ### Embedded Views (Fabric Native Components)


### PR DESCRIPTION
## Summary

Converts `BaseActionModule` and `BaseAddressModule` from abstract template-method classes into lean open classes with shared parsing helpers, and extends the hierarchy to all modules that perform action/address parsing.

### Changes

**`BaseActionModule`**:
- Remove `parseAndHandleAction()` / `abstract handleAction()` template pattern
- Remove dead helpers `sendAdditionalDetailsEvent()` / `sendCompleteEvent()`
- Keep `parseActionFromMap()` and `supportedEvents()` chain

**`BaseAddressModule`**:
- Remove `abstract sendAddressLookupResult()` and template `update()` / `confirm()`
- Add `parseAddressOptions()` and `parseLookupAddress()` helpers
- Keep `supportedEvents()` chain

**`GooglePayModule`** and **`InstantModule`**: now extend `BaseActionModule`; use `parseActionFromMap()` in `handle()`, drop redundant `supportedEvents()` and `getConstants()` overrides

**`DropInModule`**: now extends `BaseAddressModule`; uses `parseActionFromMap()`, `parseAddressOptions()`, `parseLookupAddress()` in `handle`/`update`/`confirm`

**`EmbeddedComponentBusModule`**: now extends `BaseAddressModule`; removes the `activeViewId` field entirely by passing `viewId` directly into each `@ReactMethod`; uses inherited parsing helpers

**`Architecture.md`**: updated Android class hierarchy diagram

### Why

All four modules were duplicating the same action-parsing boilerplate. The previous abstract template-method design forced `EmbeddedComponentBusModule` to stash `activeViewId` as a field to work around routing-unaware base class callbacks. Inlining `viewId` as a direct method parameter makes each `@ReactMethod` self-contained and removes the shared mutable state.