### PR TITLE
chore: replace xcpretty with xcbeautify in CI workflows

### DIFF
--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -74,7 +74,7 @@ jobs:
             -enableCodeCoverage YES \
             -allowProvisioningUpdates 2>&1 \
             | tee ${{ env.buildLogPath }} \
-            | xcpretty --utf --color \
+            | xcbeautify --renderer github-actions \
             && exit ${PIPESTATUS[0]}
 
       - name: Upload Xcodebuild Log

--- a/e2e-tests/scripts/build-ios.sh
+++ b/e2e-tests/scripts/build-ios.sh
@@ -34,7 +34,7 @@ UDID=$(bash ./resolve_ios_simulator.sh "$device_name")
 echo "::group::Build iOS [$(date '+%H:%M:%S')]"
 if ! command -v xcbeautify &> /dev/null; then
   echo "Installing xcbeautify..."
-  brew install xcbeautify
+  HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify
 fi
 
 XCODEBUILD_LOG="xcodebuild.log"

--- a/e2e-tests/scripts/build-ios.sh
+++ b/e2e-tests/scripts/build-ios.sh
@@ -32,9 +32,9 @@ echo "Using workspace: $WORKSPACE with scheme: $SCHEME"
 UDID=$(bash ./resolve_ios_simulator.sh "$device_name")
 
 echo "::group::Build iOS [$(date '+%H:%M:%S')]"
-if ! command -v xcpretty &> /dev/null; then
-  echo "Installing xcpretty..."
-  gem install xcpretty
+if ! command -v xcbeautify &> /dev/null; then
+  echo "Installing xcbeautify..."
+  brew install xcbeautify
 fi
 
 XCODEBUILD_LOG="xcodebuild.log"
@@ -44,7 +44,7 @@ xcodebuild -workspace "ios/$SCHEME.xcworkspace" \
   -sdk iphonesimulator \
   -destination "platform=iOS Simulator,id=$UDID" \
   -derivedDataPath build \
-  2>&1 | tee "$XCODEBUILD_LOG" | xcpretty --utf --color
+  2>&1 | tee "$XCODEBUILD_LOG" | xcbeautify --renderer github-actions
 echo "::endgroup::"
 
 echo "::group::Start Metro [$(date '+%H:%M:%S')]"


### PR DESCRIPTION
## Summary

Replaces `xcpretty` with `xcbeautify --renderer github-actions` in:
- `.github/workflows/ios_tests.yml`
- `e2e-tests/scripts/build-ios.sh`

The `--renderer github-actions` flag emits GitHub Actions annotations (`::error::`, `::warning::`) for inline PR diff annotations and Actions summary page.

The install fallback in `build-ios.sh` is updated from `gem install xcpretty` to `brew install xcbeautify`.