### PR TITLE
fix: trigger React root layout update after Google Pay button loads

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/react/platformpay/PlatformPayView.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/react/platformpay/PlatformPayView.kt
@@ -2,6 +2,7 @@ package com.adyenreactnativesdk.react.platformpay
 
 import android.annotation.SuppressLint
 import android.widget.FrameLayout
+import com.facebook.react.uimanager.RootViewUtil
 import com.facebook.react.uimanager.ThemedReactContext
 import com.google.android.gms.wallet.button.ButtonConstants
 import com.google.android.gms.wallet.button.ButtonOptions
@@ -52,6 +53,9 @@ class PlatformPayView(
     removeView(googlePayButton)
     scheduleUpdate()
     addView(googlePayButton)
+    postDelayed(2000) {
+      (RootViewUtil.getRootView(this) as? FrameLayout)?.requestLayout()
+    }
   }
 
   private fun scheduleUpdate() {

--- a/android/src/main/java/com/adyenreactnativesdk/react/platformpay/PlatformPayView.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/react/platformpay/PlatformPayView.kt
@@ -2,6 +2,7 @@ package com.adyenreactnativesdk.react.platformpay
 
 import android.annotation.SuppressLint
 import android.widget.FrameLayout
+import androidx.core.view.postDelayed
 import com.facebook.react.uimanager.RootViewUtil
 import com.facebook.react.uimanager.ThemedReactContext
 import com.google.android.gms.wallet.button.ButtonConstants


### PR DESCRIPTION
## Summary
Fixes an issue where the Google Pay button on Android would not display properly after fetching card data from Google Pay servers.

## Changes
- Added a delayed React root view layout refresh in `PlatformPayView.kt`
- The 2-second delay gives the Google Pay button time to fetch card data and update its UI
- Uses `RootViewUtil.getRootView()` to access the React Native root view and trigger a layout update

## Issue
The Google Pay button fetches card data asynchronously and changes its visibility/appearance internally, but these changes don't trigger React Native's layout system. As a result, the button remains invisible until the screen is rotated or manually refreshed.

## Solution
After adding the Google Pay button to the view hierarchy, we schedule a delayed layout update on the React root view. This ensures that React Native re-renders the component tree after the button has finished loading its card data.

## Testing
- Verify Google Pay button displays correctly on initial load
- Verify button updates are reflected without requiring screen rotation