### PR TITLE
deprecate: warn about scheme via AdyenCheckout.start() deprecation in v3

### DIFF
--- a/src/modules/base/getWrapper.ts
+++ b/src/modules/base/getWrapper.ts
@@ -53,6 +53,12 @@ export function getWrapper(
       break;
   }
 
+  if (typeName === 'scheme') {
+    console.warn(
+      'AdyenCheckout.start("scheme") will be deprecated in v3. Use the embedded <CardView> component instead.'
+    );
+  }
+
   const paymentMethod = find(paymentMethods, typeName);
   if (!paymentMethod) {
     throw new Error(UNKNOWN_PAYMENT_METHOD_ERROR + typeName);

--- a/src/modules/base/getWrapper.ts
+++ b/src/modules/base/getWrapper.ts
@@ -53,9 +53,9 @@ export function getWrapper(
       break;
   }
 
-  if (typeName === 'scheme') {
+  if (typeName === 'scheme' || typeName === 'card') {
     console.warn(
-      'AdyenCheckout.start("scheme") will be deprecated in v3. Use the embedded <CardView> component instead.'
+      'AdyenCheckout.start("' + typeName + '") will be deprecated in v3. Use the embedded <CardView> component instead.'
     );
   }
 


### PR DESCRIPTION
## Summary

Adds a deprecation warning when consumers call `AdyenCheckout.start("scheme")`. The warning advises migrating to the embedded `<CardView>` component, as this flow will be deprecated in v3.

## Changes

- Added `console.warn` in `getWrapper.ts` for the `scheme` payment method type.