### PR TITLE
Use "Trusted publishing" for npm packages

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -3,6 +3,7 @@
 
 name: Publish Package
 permissions:
+  id-token: write
   contents: read
 
 on:
@@ -21,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ inputs.version == '' && github.ref_name || inputs.version }}
-      NODE-VERSION: 20
+      NODE-VERSION: 22
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -31,10 +32,7 @@ jobs:
       - name: Update version in package.json
         run: |
           sed -i 's/"version":.*$/"version": "${{ env.VERSION }}",/g' package.json
-      - name: Build and publish to npm
+      - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - name: Upload artifacts
+      - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ADYEN_REACT_NATIVE_TOKEN }}
-          CI: true

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ inputs.version == '' && github.ref_name || inputs.version }}
-      NODE-VERSION: 22
+      NODE-VERSION: 24
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
# Changes

* Use Trusted publishing for npm packages instead of a static token