### PR TITLE
refactor: migrate configuration parsers to property-based DSL

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/configuration/CardConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/CardConfigurationParser.kt
@@ -57,7 +57,7 @@ class CardConfigurationParser(
   }
 
   fun applyConfiguration(builder: BcmcConfiguration.Builder) {
-    showStorePaymentField?.let { builder.isStorePaymentFieldVisible = it }
+    showStorePaymentField?.let { builder.showStorePaymentField = it }
     holderNameRequired?.let { builder.isHolderNameRequired = it }
   }
 

--- a/android/src/main/java/com/adyenreactnativesdk/configuration/CardConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/CardConfigurationParser.kt
@@ -46,19 +46,19 @@ class CardConfigurationParser(
   }
 
   fun applyConfiguration(builder: CardConfiguration.Builder) {
-    supportedCardTypes?.let { builder.setSupportedCardTypes(*it.toTypedArray()) }
-    showStorePaymentField?.let { builder.setShowStorePaymentField(it) }
-    hideCvcStoredCard?.let { builder.setHideCvcStoredCard(it) }
-    hideCvc?.let { builder.setHideCvc(it) }
-    holderNameRequired?.let { builder.setHolderNameRequired(it) }
-    addressVisibility?.let { builder.setAddressConfiguration(it) }
-    kcpVisibility?.let { builder.setKcpAuthVisibility(it) }
-    socialSecurityNumberVisibility?.let { builder.setSocialSecurityNumberVisibility(it) }
+    supportedCardTypes?.let { builder.supportedCardBrands = it.toList() }
+    showStorePaymentField?.let { builder.isStorePaymentFieldVisible = it }
+    hideCvcStoredCard?.let { builder.isHideCvcStoredCard = it }
+    hideCvc?.let { builder.isHideCvc = it }
+    holderNameRequired?.let { builder.isHolderNameRequired = it }
+    addressVisibility?.let { builder.addressConfiguration = it }
+    kcpVisibility?.let { builder.kcpAuthVisibility = it }
+    socialSecurityNumberVisibility?.let { builder.socialSecurityNumberVisibility = it }
   }
 
   fun applyConfiguration(builder: BcmcConfiguration.Builder) {
-    showStorePaymentField?.let { builder.setShowStorePaymentField(it) }
-    holderNameRequired?.let { builder.setHolderNameRequired(it) }
+    showStorePaymentField?.let { builder.isStorePaymentFieldVisible = it }
+    holderNameRequired?.let { builder.isHolderNameRequired = it }
   }
 
   private val showStorePaymentField: Boolean?

--- a/android/src/main/java/com/adyenreactnativesdk/configuration/CardConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/CardConfigurationParser.kt
@@ -46,7 +46,7 @@ class CardConfigurationParser(
   }
 
   fun applyConfiguration(builder: CardConfiguration.Builder) {
-    supportedCardTypes?.let { builder.supportedCardBrands = it.toList() }
+    supportedCardTypes?.let { builder.supportedCardBrands = it }
     showStorePaymentField?.let { builder.isStorePaymentFieldVisible = it }
     hideCvcStoredCard?.let { builder.isHideCvcStoredCard = it }
     hideCvc?.let { builder.isHideCvc = it }

--- a/android/src/main/java/com/adyenreactnativesdk/configuration/DropInConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/DropInConfigurationParser.kt
@@ -55,8 +55,8 @@ class DropInConfigurationParser(
       }
 
   fun applyConfiguration(builder: DropInConfiguration.Builder) {
-    showPreselectedStoredPaymentMethod?.let { builder.isShowPreselectedStoredPaymentMethod = it }
-    skipListWhenSinglePaymentMethod?.let { builder.isSkipListWhenSinglePaymentMethod = it }
-    setEnableRemovingStoredPaymentMethods?.let { builder.isEnableRemovingStoredPaymentMethods = it }
+    showPreselectedStoredPaymentMethod?.let { builder.showPreselectedStoredPaymentMethod = it }
+    skipListWhenSinglePaymentMethod?.let { builder.skipListWhenSinglePaymentMethod = it }
+    setEnableRemovingStoredPaymentMethods?.let { builder.isRemovingStoredPaymentMethodsEnabled = it }
   }
 }

--- a/android/src/main/java/com/adyenreactnativesdk/configuration/DropInConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/DropInConfigurationParser.kt
@@ -55,8 +55,8 @@ class DropInConfigurationParser(
       }
 
   fun applyConfiguration(builder: DropInConfiguration.Builder) {
-    showPreselectedStoredPaymentMethod?.let { builder.setShowPreselectedStoredPaymentMethod(it) }
-    skipListWhenSinglePaymentMethod?.let { builder.setSkipListWhenSinglePaymentMethod(it) }
-    setEnableRemovingStoredPaymentMethods?.let { builder.setEnableRemovingStoredPaymentMethods(it) }
+    showPreselectedStoredPaymentMethod?.let { builder.isShowPreselectedStoredPaymentMethod = it }
+    skipListWhenSinglePaymentMethod?.let { builder.isSkipListWhenSinglePaymentMethod = it }
+    setEnableRemovingStoredPaymentMethods?.let { builder.isEnableRemovingStoredPaymentMethods = it }
   }
 }

--- a/android/src/main/java/com/adyenreactnativesdk/configuration/GooglePayConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/GooglePayConfigurationParser.kt
@@ -86,44 +86,43 @@ class GooglePayConfigurationParser(
 
   fun applyConfiguration(builder: GooglePayConfiguration.Builder) {
     if (config.hasKey(ALLOWED_AUTH_METHODS_KEY)) {
-      builder.setAllowedAuthMethods(allowedAuthMethods)
+      builder.allowedAuthMethods = allowedAuthMethods
     }
     if (config.hasKey(ALLOWED_CARD_NETWORKS_KEY)) {
-      builder.setAllowedCardNetworks(allowedCardNetworks)
+      builder.allowedCardNetworks = allowedCardNetworks
     }
     if (config.hasKey(ALLOW_PREPAID_CARDS_KEY)) {
-      builder.setAllowPrepaidCards(config.getBoolean(ALLOW_PREPAID_CARDS_KEY))
+      builder.isAllowPrepaidCards = config.getBoolean(ALLOW_PREPAID_CARDS_KEY)
     }
     if (config.hasKey(ALLOW_CREDIT_CARDS_KEY)) {
-      builder.setAllowCreditCards(config.getBoolean(ALLOW_CREDIT_CARDS_KEY))
+      builder.isAllowCreditCards = config.getBoolean(ALLOW_CREDIT_CARDS_KEY)
     }
     if (config.hasKey(BILLING_ADDRESS_REQUIRED_KEY)) {
-      builder.setBillingAddressRequired(config.getBoolean(BILLING_ADDRESS_REQUIRED_KEY))
+      builder.isBillingAddressRequired = config.getBoolean(BILLING_ADDRESS_REQUIRED_KEY)
     }
     if (config.hasKey(EMAIL_REQUIRED_KEY)) {
-      builder.setEmailRequired(config.getBoolean(EMAIL_REQUIRED_KEY))
+      builder.isEmailRequired = config.getBoolean(EMAIL_REQUIRED_KEY)
     }
     if (config.hasKey(SHIPPING_ADDRESS_REQUIRED_KEY)) {
-      builder.setShippingAddressRequired(config.getBoolean(SHIPPING_ADDRESS_REQUIRED_KEY))
+      builder.isShippingAddressRequired = config.getBoolean(SHIPPING_ADDRESS_REQUIRED_KEY)
     }
     if (config.hasKey(EXISTING_PAYMENT_METHOD_REQUIRED_KEY)) {
-      builder.setExistingPaymentMethodRequired(
+      builder.isExistingPaymentMethodRequired =
         config.getBoolean(
           EXISTING_PAYMENT_METHOD_REQUIRED_KEY,
-        ),
-      )
+        )
     }
     if (config.hasKey(MERCHANT_ACCOUNT_KEY)) {
-      config.getString(MERCHANT_ACCOUNT_KEY)?.let { builder.setMerchantAccount(it) }
+      config.getString(MERCHANT_ACCOUNT_KEY)?.let { builder.merchantAccount = it }
     }
     if (config.hasKey(TOTAL_PRICE_STATUS_KEY)) {
-      config.getString(TOTAL_PRICE_STATUS_KEY)?.let { builder.setTotalPriceStatus(it) }
+      config.getString(TOTAL_PRICE_STATUS_KEY)?.let { builder.totalPriceStatus = it }
     }
     if (config.hasKey(BILLING_ADDRESS_PARAMETERS_KEY)) {
-      builder.setBillingAddressParameters(billingAddressParameters)
+      builder.billingAddressParameters = billingAddressParameters
     }
     if (config.hasKey(SHIPPING_ADDRESS_PARAMETERS_KEY)) {
-      builder.setShippingAddressParameters(shippingAddressParameters)
+      builder.shippingAddressParameters = shippingAddressParameters
     }
   }
 }

--- a/android/src/main/java/com/adyenreactnativesdk/configuration/ThreeDSConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/ThreeDSConfigurationParser.kt
@@ -31,6 +31,6 @@ class ThreeDSConfigurationParser(
       }
 
   fun applyConfiguration(builder: Adyen3DS2Configuration.Builder) {
-    requestorAppUrl?.let { builder.setThreeDSRequestorAppURL(it) }
+    requestorAppUrl?.let { builder.threeDSRequestorAppURL = it }
   }
 }

--- a/android/src/test/java/com/adyenreactnativesdk/configuration/CardConfigurationParserTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/configuration/CardConfigurationParserTest.kt
@@ -135,21 +135,19 @@ class CardConfigurationParserTest {
     val mockBuilder = mock(CardConfiguration.Builder::class.java)
     sut.applyConfiguration(mockBuilder)
 
-    verify(mockBuilder, times(1)).setShowStorePaymentField(false)
-    verify(mockBuilder, times(1)).setHolderNameRequired(true)
-    verify(mockBuilder, times(1)).setHideCvc(true)
-    verify(mockBuilder, times(1)).setHideCvcStoredCard(true)
-    verify(mockBuilder, times(1)).setKcpAuthVisibility(KCPAuthVisibility.SHOW)
-    verify(mockBuilder, times(1)).setAddressConfiguration(any())
-    verify(mockBuilder, times(1)).setSocialSecurityNumberVisibility(
-      SocialSecurityNumberVisibility.SHOW,
-    )
-    verify(mockBuilder, times(1)).setSupportedCardTypes(
-      *arrayOf(
+    verify(mockBuilder, times(1)).isStorePaymentFieldVisible = false
+    verify(mockBuilder, times(1)).isHolderNameRequired = true
+    verify(mockBuilder, times(1)).isHideCvc = true
+    verify(mockBuilder, times(1)).isHideCvcStoredCard = true
+    verify(mockBuilder, times(1)).kcpAuthVisibility = KCPAuthVisibility.SHOW
+    verify(mockBuilder, times(1)).addressConfiguration = any()
+    verify(mockBuilder, times(1)).socialSecurityNumberVisibility =
+      SocialSecurityNumberVisibility.SHOW
+    verify(mockBuilder, times(1)).supportedCardBrands =
+      listOf(
         CardBrand("mc"),
         CardBrand("visa"),
         CardBrand("maestro"),
-      ),
-    )
+      )
   }
 }

--- a/android/src/test/java/com/adyenreactnativesdk/configuration/DropInConfigurationParserTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/configuration/DropInConfigurationParserTest.kt
@@ -27,9 +27,9 @@ class DropInConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(0)).isSkipListWhenSinglePaymentMethod = any()
-    verify(mockBuilder, times(0)).isShowPreselectedStoredPaymentMethod = any()
-    verify(mockBuilder, times(0)).isEnableRemovingStoredPaymentMethods = any()
+    verify(mockBuilder, times(0)).skipListWhenSinglePaymentMethod = any()
+    verify(mockBuilder, times(0)).showPreselectedStoredPaymentMethod = any()
+    verify(mockBuilder, times(0)).isRemovingStoredPaymentMethodsEnabled = any()
   }
 
   @Test
@@ -44,7 +44,7 @@ class DropInConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).isSkipListWhenSinglePaymentMethod = false
+    verify(mockBuilder, times(1)).skipListWhenSinglePaymentMethod = false
   }
 
   @Test
@@ -59,7 +59,7 @@ class DropInConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).isShowPreselectedStoredPaymentMethod = false
+    verify(mockBuilder, times(1)).showPreselectedStoredPaymentMethod = false
   }
 
   @Test
@@ -74,6 +74,6 @@ class DropInConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).isEnableRemovingStoredPaymentMethods = true
+    verify(mockBuilder, times(1)).isRemovingStoredPaymentMethodsEnabled = true
   }
 }

--- a/android/src/test/java/com/adyenreactnativesdk/configuration/DropInConfigurationParserTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/configuration/DropInConfigurationParserTest.kt
@@ -27,9 +27,9 @@ class DropInConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(0)).setSkipListWhenSinglePaymentMethod(any())
-    verify(mockBuilder, times(0)).setShowPreselectedStoredPaymentMethod(any())
-    verify(mockBuilder, times(0)).setEnableRemovingStoredPaymentMethods(any())
+    verify(mockBuilder, times(0)).isSkipListWhenSinglePaymentMethod = any()
+    verify(mockBuilder, times(0)).isShowPreselectedStoredPaymentMethod = any()
+    verify(mockBuilder, times(0)).isEnableRemovingStoredPaymentMethods = any()
   }
 
   @Test
@@ -44,7 +44,7 @@ class DropInConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setSkipListWhenSinglePaymentMethod(false)
+    verify(mockBuilder, times(1)).isSkipListWhenSinglePaymentMethod = false
   }
 
   @Test
@@ -59,7 +59,7 @@ class DropInConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setShowPreselectedStoredPaymentMethod(false)
+    verify(mockBuilder, times(1)).isShowPreselectedStoredPaymentMethod = false
   }
 
   @Test
@@ -74,6 +74,6 @@ class DropInConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setEnableRemovingStoredPaymentMethods(true)
+    verify(mockBuilder, times(1)).isEnableRemovingStoredPaymentMethods = true
   }
 }

--- a/android/src/test/java/com/adyenreactnativesdk/configuration/GooglePayConfigurationParserTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/configuration/GooglePayConfigurationParserTest.kt
@@ -32,15 +32,15 @@ class GooglePayConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(0)).setAllowedAuthMethods(any())
-    verify(mockBuilder, times(0)).setAllowedCardNetworks(any())
-    verify(mockBuilder, times(0)).setAllowCreditCards(any())
-    verify(mockBuilder, times(0)).setAllowPrepaidCards(any())
-    verify(mockBuilder, times(0)).setEmailRequired(any())
-    verify(mockBuilder, times(0)).setShippingAddressRequired(any())
-    verify(mockBuilder, times(0)).setBillingAddressRequired(any())
-    verify(mockBuilder, times(0)).setTotalPriceStatus(any())
-    verify(mockBuilder, times(0)).setMerchantAccount(any())
+    verify(mockBuilder, times(0)).allowedAuthMethods = any()
+    verify(mockBuilder, times(0)).allowedCardNetworks = any()
+    verify(mockBuilder, times(0)).isAllowCreditCards = any()
+    verify(mockBuilder, times(0)).isAllowPrepaidCards = any()
+    verify(mockBuilder, times(0)).isEmailRequired = any()
+    verify(mockBuilder, times(0)).isShippingAddressRequired = any()
+    verify(mockBuilder, times(0)).isBillingAddressRequired = any()
+    verify(mockBuilder, times(0)).totalPriceStatus = any()
+    verify(mockBuilder, times(0)).merchantAccount = any()
   }
 
   @Test
@@ -55,7 +55,7 @@ class GooglePayConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setAllowCreditCards(true)
+    verify(mockBuilder, times(1)).isAllowCreditCards = true
   }
 
   @Test
@@ -70,7 +70,7 @@ class GooglePayConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setAllowPrepaidCards(true)
+    verify(mockBuilder, times(1)).isAllowPrepaidCards = true
   }
 
   @Test
@@ -85,7 +85,7 @@ class GooglePayConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setEmailRequired(true)
+    verify(mockBuilder, times(1)).isEmailRequired = true
   }
 
   @Test
@@ -100,7 +100,7 @@ class GooglePayConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setShippingAddressRequired(true)
+    verify(mockBuilder, times(1)).isShippingAddressRequired = true
   }
 
   @Test
@@ -115,7 +115,7 @@ class GooglePayConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setBillingAddressRequired(true)
+    verify(mockBuilder, times(1)).isBillingAddressRequired = true
   }
 
   @Test
@@ -130,7 +130,7 @@ class GooglePayConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setTotalPriceStatus("FINAL")
+    verify(mockBuilder, times(1)).totalPriceStatus = "FINAL"
   }
 
   @Test
@@ -145,7 +145,7 @@ class GooglePayConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setMerchantAccount("Merchant_account")
+    verify(mockBuilder, times(1)).merchantAccount = "Merchant_account"
   }
 
   @Test
@@ -163,9 +163,8 @@ class GooglePayConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setAllowedAuthMethods(
-      arrayListOf("PAN_ONLY", "CRYPTOGRAM_3DS"),
-    )
+    verify(mockBuilder, times(1)).allowedAuthMethods =
+      arrayListOf("PAN_ONLY", "CRYPTOGRAM_3DS")
   }
 
   @Test
@@ -185,8 +184,7 @@ class GooglePayConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setAllowedCardNetworks(
-      arrayListOf("MASTERCARD", "VISA", "amex", "wrong_value"),
-    )
+    verify(mockBuilder, times(1)).allowedCardNetworks =
+      arrayListOf("MASTERCARD", "VISA", "amex", "wrong_value")
   }
 }

--- a/android/src/test/java/com/adyenreactnativesdk/configuration/ThreeDSConfigurationParserTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/configuration/ThreeDSConfigurationParserTest.kt
@@ -41,7 +41,7 @@ class ThreeDSConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(0)).setThreeDSRequestorAppURL(any())
+    verify(mockBuilder, times(0)).threeDSRequestorAppURL = any()
   }
 
   @Test
@@ -75,7 +75,7 @@ class ThreeDSConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
-    verify(mockBuilder, times(1)).setThreeDSRequestorAppURL("https://testing.com")
+    verify(mockBuilder, times(1)).threeDSRequestorAppURL = "https://testing.com"
   }
 
   @Test


### PR DESCRIPTION
## Summary
This PR migrates all Android configuration parsers from the deprecated builder setter pattern (`builder.setXXX()`) to the new property-based DSL syntax (`builder.XXX = value`).

## Changes
- **CardConfigurationParser**: Updated all builder methods to use property assignment
  - `setSupportedCardTypes()` → `supportedCardBrands`
  - `setShowStorePaymentField()` → `isStorePaymentFieldVisible`
  - `setHideCvc()`, `setHideCvcStoredCard()` → `isHideCvc`, `isHideCvcStoredCard`
  - etc.

- **GooglePayConfigurationParser**: Updated all configuration setters
  - `setAllowedAuthMethods()` → `allowedAuthMethods`
  - `setAllowCreditCards()` → `isAllowCreditCards`
  - etc.

- **DropInConfigurationParser**: Updated builder methods
  - `setShowPreselectedStoredPaymentMethod()` → `isShowPreselectedStoredPaymentMethod`
  - etc.

- **ThreeDSConfigurationParser**: Updated 3DS configuration
  - `setThreeDSRequestorAppURL()` → `threeDSRequestorAppURL`

- **All tests updated** to verify property assignments instead of method calls

## Benefits
- Aligns with modern Adyen Android SDK 5.17+ builder patterns
- Prepares codebase for upcoming features that require the new DSL syntax
- More idiomatic Kotlin code

## Testing
- ✅ All existing unit tests pass
- ✅ Code formatted with ktlint
- ✅ No functional changes, purely refactoring

## Breaking Changes
None - this is an internal refactoring that doesn't affect the public API.