### PR TITLE
fix: resolve SonarCloud maintainability issues in TypeScript code

### DIFF
--- a/src/core/configurations/ApplePayConfiguration.ts
+++ b/src/core/configurations/ApplePayConfiguration.ts
@@ -45,7 +45,7 @@ export interface ApplePaySummaryItem {
   /** A short, localized description of the summary item. */
   label: string;
   /** The amount associated with the summary item. */
-  amount: Number | string;
+  amount: number | string;
   /** The summary item’s type that indicates whether the amount is final. */
   type?: 'pending' | 'final';
 }
@@ -116,7 +116,7 @@ export interface ApplePayRecurringSummaryItem extends ApplePaySummaryItem {
   /** The interval at which payments will be taken (daily, weekly, monthly, yearly, etc.). The default value is NSCalendarUnitMonth. */
   intervalUnit?: ApplePayCalendarUnit;
   /** The number of intervals between payments. Default is 1. */
-  intervalCount?: Number;
+  intervalCount?: number;
   /**The timestamp in ISO 8601 date format (ex. 2025-04-21) which the recurring payments will end. The default value is null which specifies no end date. */
   endDate?: string;
 }

--- a/src/core/configurations/PartialPaymentConfiguration.ts
+++ b/src/core/configurations/PartialPaymentConfiguration.ts
@@ -44,7 +44,7 @@ export interface PartialPaymentConfiguration {
    */
   onOrderCancel(
     order: Order,
-    shouldUpdatePaymentMethods: Boolean,
+    shouldUpdatePaymentMethods: boolean,
     component: PartialPaymentComponent
   ): void;
 }

--- a/src/modules/session/SessionWrapper.ts
+++ b/src/modules/session/SessionWrapper.ts
@@ -24,9 +24,9 @@ interface SessionNativeModule extends NativeModule, AdyenComponent {
 }
 
 export class SessionWrapper implements SessionHelperModule {
-  private nativeModule: SessionNativeModule;
-  private eventEmitter: NativeEventEmitter;
-  private subscriptions: Map<string, EmitterSubscription> = new Map();
+  private readonly nativeModule: SessionNativeModule;
+  private readonly eventEmitter: NativeEventEmitter;
+  private readonly subscriptions: Map<string, EmitterSubscription> = new Map();
 
   constructor(nativeModule: SessionNativeModule) {
     this.nativeModule = nativeModule;

--- a/src/plugin/setAppTheme.ts
+++ b/src/plugin/setAppTheme.ts
@@ -15,18 +15,17 @@ export function setAppTheme(androidStyles: any) {
     resources.style = styles;
   }
 
-  let appTheme = styles.find((item: any) => item.$.name === defaultTheme);
-  if (!appTheme) {
-    console.log(
-      `Default theme is not '${defaultTheme}'. Please set your theme parent as descendent of 'Theme.MaterialComponents'`
-    );
-  } else {
-    var parentTheme = 'Theme.MaterialComponents.Light.NoActionBar';
-    const oldParent = appTheme.$.parent;
-    if (oldParent && oldParent.includes('DayNight')) {
+  const appTheme = styles.find((item: any) => item.$.name === defaultTheme);
+  if (appTheme) {
+    let parentTheme = 'Theme.MaterialComponents.Light.NoActionBar';
+    if (appTheme.$.parent?.includes('DayNight')) {
       parentTheme = 'Theme.MaterialComponents.DayNight.NoActionBar';
     }
     appTheme.$ = { name: defaultTheme, parent: parentTheme };
+  } else {
+    console.log(
+      `Default theme is not '${defaultTheme}'. Please set your theme parent as descendent of 'Theme.MaterialComponents'`
+    );
   }
 
   let unwantedAppTheme = styles.findLast(

--- a/src/plugin/withAdyenIos.ts
+++ b/src/plugin/withAdyenIos.ts
@@ -17,7 +17,7 @@ export const withAdyenIos: ConfigPlugin<AdyenPluginProps> = (
   { merchantIdentifier, useFrameworks }
 ) => {
   config = withAppDelegate(config, (newConfig) => {
-    var appDelegate = newConfig.modResults.contents;
+    const appDelegate = newConfig.modResults.contents;
     if (
       appDelegate.includes('ADYRedirectComponent') ||
       appDelegate.includes('import Adyen')

--- a/src/plugin/withAdyenIos.ts
+++ b/src/plugin/withAdyenIos.ts
@@ -17,7 +17,7 @@ export const withAdyenIos: ConfigPlugin<AdyenPluginProps> = (
   { merchantIdentifier, useFrameworks }
 ) => {
   config = withAppDelegate(config, (newConfig) => {
-    const appDelegate = newConfig.modResults.contents;
+    let appDelegate = newConfig.modResults.contents;
     if (
       appDelegate.includes('ADYRedirectComponent') ||
       appDelegate.includes('import Adyen')


### PR DESCRIPTION
## Summary

Fixes 10 open SonarCloud maintainability issues in TypeScript/JS code.

### Changes
- **S2933** (readonly members): Mark `nativeModule`, `eventEmitter`, `subscriptions` as `readonly` in `SessionWrapper`
- **S3504** (`var` → `let/const`): Replace `var` with `let` in `setAppTheme.ts` and `withAdyenIos.ts` (kept as `let` where reassignment occurs)
- **S6582** (optional chaining): Use `?.includes()` instead of `x && x.includes()` in `setAppTheme.ts`
- **S7735** (negated condition): Invert the `if (!appTheme)` condition for better readability in `setAppTheme.ts`
- **S1533** (wrapper types): Replace `Number` wrapper with primitive `number` in `ApplePayConfiguration`; `Boolean` with `boolean` in `PartialPaymentConfiguration`

### Testing
- All 228 JS tests pass
- Lint and typecheck clean
