### PR TITLE
fix: address SonarCloud security hotspots for cleartext traffic and backup

### DIFF
--- a/src/plugin/setAppTheme.ts
+++ b/src/plugin/setAppTheme.ts
@@ -4,7 +4,7 @@ export function setAppTheme(androidStyles: any) {
   let resources = androidStyles.resources;
   if (!resources) {
     resources = {
-      $: { 'xmlns:tools': 'http://schemas.android.com/tools' },
+      $: { 'xmlns:tools': 'http://schemas.android.com/tools' }, // NOSONAR: this is an XML namespace URI, not a network call
     };
     androidStyles.resources = resources;
   }


### PR DESCRIPTION
## Summary

Addresses 3 SonarCloud security hotspots (all LOW probability):

- **`android/src/main/AndroidManifest.xml`**: Explicitly set `android:usesCleartextTraffic="false"` and `android:allowBackup="false"` on the `<application>` element. As a payment SDK, cleartext HTTP traffic should never be used, and sensitive data should not be backed up.
- **`src/plugin/setAppTheme.ts`**: Added `// NOSONAR` comment to suppress false positive — `http://schemas.android.com/tools` is an XML namespace URI identifier, not an actual HTTP network call. Android tooling requires this exact URI.

## Ticket

COSDK-1214

## Testing

No functional changes. Lint and typecheck pass.