### PR TITLE
feat: add ApplePay delegate callbacks for shipping, coupon code, and authorization

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -92,7 +92,7 @@
 | `onShippingContactChange(contact, resolve) => {}` | Called when the shopper selects or updates a shipping contact. Call `resolve({ paymentSummaryItems, shippingMethods, errors })` to update the sheet. Omit fields to keep current values.                                                                                                                                                                                   | No                                      |
 | `onShippingMethodChange(shippingMethod, resolve) => {}` | Called when the shopper selects a shipping method. Call `resolve({ paymentSummaryItems, errors })` to update the sheet.                                                                                                                                                                                                                                               | No                                      |
 | `onCouponCodeChange(couponCode, resolve) => {}` | Called when the shopper enters or updates a coupon code. Call `resolve({ paymentSummaryItems, shippingMethods, errors })` to update the sheet. Requires `supportsCouponCode: true` and iOS 15+.                                                                                                                                                                        | No                                      |
-| `onAuthorization(payment, resolve) => {}` | Called after the shopper authorizes the payment, before it is submitted to Adyen. Call `resolve({ status: 'success' })` to proceed or `resolve({ status: 'failure', errors })` to show validation errors and keep the sheet open.                                                                                                                                      | No                                      |
+| `onAuthorize(payment, resolve) => {}` | Called after the shopper authorizes the payment, before it is submitted to Adyen. Call `resolve({ status: 'success' })` to proceed or `resolve({ status: 'failure', errors })` to show validation errors and keep the sheet open.                                                                                                                                      | No                                      |
 
 #### ApplePay Recurring payment
 
@@ -274,7 +274,7 @@ const configuration = {
         resolve({});
       }
     },
-    onAuthorization: (payment, resolve) => {
+    onAuthorize: (payment, resolve) => {
       // Optionally validate billing/shipping address before submission.
       resolve({ status: 'success' });
     },

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -87,6 +87,12 @@
 | `supportedCountries`            | A list of two-letter country codes for limiting payment to cards from specific countries or regions. When provided will filter the selectable payment passes to those issued in the supported countries.                                                                                                                                                                                    | No                                      |
 | `shippingMethods`               | The list of shipping methods available for a payment request. Corresponds to [ApplePayShippingMethod](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest/1916121-shippingmethods).                                                                                                                                                                       | No                                      |
 | `recurringPaymentRequest`       | A class that represents a request to set up a recurring payment, typically a subscription. Corresponds to [PKRecurringPaymentRequest](#applepay-recurring-payment).                                                                                                                                                                                                                         | No                                      |
+| `supportsCouponCode`            | When **true**, the Apple Pay sheet displays a coupon code field. Requires iOS 15+. Defaults to **false**.                                                                                                                                                                                                                                                                                   | No                                      |
+| `couponCode`                    | Pre-fills the coupon code field in the Apple Pay sheet. Requires iOS 15+.                                                                                                                                                                                                                                                                                                                   | No                                      |
+| `onShippingContactChange(contact, resolve) => {}` | Called when the shopper selects or updates a shipping contact. Call `resolve({ paymentSummaryItems, shippingMethods, errors })` to update the sheet. Omit fields to keep current values.                                                                                                                                                                                   | No                                      |
+| `onShippingMethodChange(shippingMethod, resolve) => {}` | Called when the shopper selects a shipping method. Call `resolve({ paymentSummaryItems, errors })` to update the sheet.                                                                                                                                                                                                                                               | No                                      |
+| `onCouponCodeChange(couponCode, resolve) => {}` | Called when the shopper enters or updates a coupon code. Call `resolve({ paymentSummaryItems, shippingMethods, errors })` to update the sheet. Requires `supportsCouponCode: true` and iOS 15+.                                                                                                                                                                        | No                                      |
+| `onAuthorization(payment, resolve) => {}` | Called after the shopper authorizes the payment, before it is submitted to Adyen. Call `resolve({ status: 'success' })` to proceed or `resolve({ status: 'failure', errors })` to show validation errors and keep the sheet open.                                                                                                                                      | No                                      |
 
 #### ApplePay Recurring payment
 
@@ -239,6 +245,39 @@ const configuration = {
     ],
     requiredBillingContactFields: ['phoneticName', 'postalAddress'],
     requiredShippingContactFields: ['name', 'phone', 'email', 'postalAddress'],
+    supportsCouponCode: true,
+    onShippingContactChange: (contact, resolve) => {
+      resolve({
+        shippingMethods: [
+          { label: 'Standard', amount: 5, identifier: 'standard', detail: '5–7 days' },
+          { label: 'Express', amount: 15, identifier: 'express', detail: '1–2 days' },
+        ],
+        paymentSummaryItems: [
+          { label: 'Shipping', amount: 5 },
+          { label: '{YOUR_MERCHANT_NAME}', amount: 103 },
+        ],
+      });
+    },
+    onShippingMethodChange: (shippingMethod, resolve) => {
+      const shippingCost = shippingMethod.identifier === 'express' ? 15 : 5;
+      resolve({
+        paymentSummaryItems: [
+          { label: shippingMethod.label, amount: shippingCost },
+          { label: '{YOUR_MERCHANT_NAME}', amount: 98 + shippingCost },
+        ],
+      });
+    },
+    onCouponCodeChange: (couponCode, resolve) => {
+      if (couponCode === 'INVALID') {
+        resolve({ errors: [{ type: 'couponCode', message: 'This coupon code is not valid.' }] });
+      } else {
+        resolve({});
+      }
+    },
+    onAuthorization: (payment, resolve) => {
+      // Optionally validate billing/shipping address before submission.
+      resolve({ status: 'success' });
+    },
     recurringPaymentRequest: {
             description: 'My Subscription',
             regularBilling: {

--- a/example/ios/AdyenExampleTests/Modules/ApplePayModuleTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/ApplePayModuleTests.swift
@@ -175,6 +175,92 @@ final class ApplePayModuleTests: XCTestCase {
         XCTAssertTrue(canMakePayments)
     }
 
+    func test_provideShippingContactUpdate_callsHandler() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler should be called")
+        var receivedUpdate: PKPaymentRequestShippingContactUpdate?
+        sut.shippingContactHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+
+        // WHEN
+        sut.provideShippingContactUpdate([:])
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertNotNil(receivedUpdate)
+        XCTAssertNil(sut.shippingContactHandler)
+    }
+
+    func test_provideShippingMethodUpdate_callsHandler() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler should be called")
+        var receivedUpdate: PKPaymentRequestShippingMethodUpdate?
+        sut.shippingMethodHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+
+        // WHEN
+        sut.provideShippingMethodUpdate([:])
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertNotNil(receivedUpdate)
+        XCTAssertNil(sut.shippingMethodHandler)
+    }
+
+    func test_provideAuthorizationResult_callsHandlerWithSuccess() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler should be called")
+        var receivedResult: PKPaymentAuthorizationResult?
+        sut.authorizationHandler = { result in
+            receivedResult = result
+            expectation.fulfill()
+        }
+
+        // WHEN
+        sut.provideAuthorizationResult(["status": "success"])
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedResult?.status, .success)
+        XCTAssertNil(sut.authorizationHandler)
+    }
+
+    func test_provideAuthorizationResult_callsHandlerWithFailure() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler should be called")
+        var receivedResult: PKPaymentAuthorizationResult?
+        sut.authorizationHandler = { result in
+            receivedResult = result
+            expectation.fulfill()
+        }
+
+        // WHEN
+        sut.provideAuthorizationResult(["status": "failure"])
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedResult?.status, .failure)
+    }
+
+    func test_cleanUp_clearsAllHandlers() {
+        // GIVEN
+        sut.shippingContactHandler = { _ in }
+        sut.shippingMethodHandler = { _ in }
+        sut.authorizationHandler = { _ in }
+
+        // WHEN
+        sut.cleanUp()
+
+        // THEN
+        XCTAssertNil(sut.shippingContactHandler)
+        XCTAssertNil(sut.shippingMethodHandler)
+        XCTAssertNil(sut.authorizationHandler)
+    }
+
     func test_hide_callsDismiss() {
         // GIVEN
         let expectation = self.expectation(description: "dismiss should be called")

--- a/example/ios/AdyenExampleTests/Modules/ApplePayModuleTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/ApplePayModuleTests.swift
@@ -261,6 +261,305 @@ final class ApplePayModuleTests: XCTestCase {
         XCTAssertNil(sut.authorizationHandler)
     }
 
+    // MARK: - provideShippingContactUpdate
+
+    func test_provideShippingContactUpdate_doesNothing_whenNoHandler() {
+        // GIVEN — no handler set
+        var called = false
+        sut.shippingContactHandler = nil
+
+        // WHEN
+        sut.provideShippingContactUpdate([:])
+
+        // THEN — no crash, no call
+        XCTAssertFalse(called)
+        _ = called // suppress warning
+    }
+
+    func test_provideShippingContactUpdate_usesSummaryItemsFromDict() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestShippingContactUpdate?
+        sut.shippingContactHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+        let update: NSDictionary = [
+            "paymentSummaryItems": [["label": "Total", "amount": "20"]]
+        ]
+
+        // WHEN
+        sut.provideShippingContactUpdate(update)
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedUpdate?.paymentSummaryItems.first?.label, "Total")
+    }
+
+    func test_provideShippingContactUpdate_fallsBackToCurrentPaymentSummaryItems() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestShippingContactUpdate?
+        sut.currentApplePayPayment = try! ApplePayPayment(
+            countryCode: "US",
+            currencyCode: "USD",
+            summaryItems: [PKPaymentSummaryItem(label: "Fallback", amount: 10)]
+        )
+        sut.shippingContactHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+
+        // WHEN — no paymentSummaryItems in dict
+        sut.provideShippingContactUpdate([:])
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedUpdate?.paymentSummaryItems.first?.label, "Fallback")
+    }
+
+    func test_provideShippingContactUpdate_usesShippingMethodsFromDict() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestShippingContactUpdate?
+        sut.shippingContactHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+        let update: NSDictionary = [
+            "paymentSummaryItems": [["label": "Total", "amount": "5"]],
+            "shippingMethods": [["label": "Express", "amount": "15", "identifier": "express"]]
+        ]
+
+        // WHEN
+        sut.provideShippingContactUpdate(update)
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedUpdate?.shippingMethods.first?.identifier, "express")
+    }
+
+    func test_provideShippingContactUpdate_fallsBackToCurrentShippingMethods() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestShippingContactUpdate?
+        let fallbackMethod = PKShippingMethod(label: "Standard", amount: 5)
+        fallbackMethod.identifier = "standard"
+        sut.currentShippingMethods = [fallbackMethod]
+        sut.shippingContactHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+
+        // WHEN — no shippingMethods in dict
+        sut.provideShippingContactUpdate([:])
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedUpdate?.shippingMethods.first?.identifier, "standard")
+    }
+
+    func test_provideShippingContactUpdate_parsesErrors() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestShippingContactUpdate?
+        sut.shippingContactHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+        let update: NSDictionary = [
+            "paymentSummaryItems": [["label": "Total", "amount": "5"]],
+            "errors": [["type": "shippingAddress", "field": "postalCode", "message": "Invalid postal code"]]
+        ]
+
+        // WHEN
+        sut.provideShippingContactUpdate(update)
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedUpdate?.errors?.count, 1)
+    }
+
+    // MARK: - provideShippingMethodUpdate
+
+    func test_provideShippingMethodUpdate_doesNothing_whenNoHandler() {
+        // GIVEN
+        sut.shippingMethodHandler = nil
+
+        // WHEN / THEN — no crash
+        sut.provideShippingMethodUpdate([:])
+    }
+
+    func test_provideShippingMethodUpdate_usesSummaryItemsFromDict() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestShippingMethodUpdate?
+        sut.shippingMethodHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+        let update: NSDictionary = [
+            "paymentSummaryItems": [["label": "Express Total", "amount": "25"]]
+        ]
+
+        // WHEN
+        sut.provideShippingMethodUpdate(update)
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedUpdate?.paymentSummaryItems.first?.label, "Express Total")
+    }
+
+    func test_provideShippingMethodUpdate_fallsBackToCurrentPaymentSummaryItems() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestShippingMethodUpdate?
+        sut.currentApplePayPayment = try! ApplePayPayment(
+            countryCode: "US",
+            currencyCode: "USD",
+            summaryItems: [PKPaymentSummaryItem(label: "Fallback Total", amount: 10)]
+        )
+        sut.shippingMethodHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+
+        // WHEN
+        sut.provideShippingMethodUpdate([:])
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedUpdate?.paymentSummaryItems.first?.label, "Fallback Total")
+    }
+
+    // MARK: - provideCouponCodeUpdate
+
+    @available(iOS 15.0, *)
+    func test_provideCouponCodeUpdate_callsHandler() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestCouponCodeUpdate?
+        sut.couponCodeHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+
+        // WHEN
+        sut.provideCouponCodeUpdate([:])
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertNotNil(receivedUpdate)
+        XCTAssertNil(sut.couponCodeHandler)
+    }
+
+    @available(iOS 15.0, *)
+    func test_provideCouponCodeUpdate_doesNothing_whenNoHandler() {
+        // GIVEN
+        sut.couponCodeHandler = nil
+
+        // WHEN / THEN — no crash
+        sut.provideCouponCodeUpdate([:])
+    }
+
+    @available(iOS 15.0, *)
+    func test_provideCouponCodeUpdate_usesSummaryItemsAndShippingMethodsFromDict() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestCouponCodeUpdate?
+        sut.couponCodeHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+        let update: NSDictionary = [
+            "paymentSummaryItems": [["label": "Discounted Total", "amount": "80"]],
+            "shippingMethods": [["label": "Standard", "amount": "5", "identifier": "std"]]
+        ]
+
+        // WHEN
+        sut.provideCouponCodeUpdate(update)
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedUpdate?.paymentSummaryItems.first?.label, "Discounted Total")
+        XCTAssertEqual(receivedUpdate?.shippingMethods.first?.identifier, "std")
+    }
+
+    @available(iOS 15.0, *)
+    func test_provideCouponCodeUpdate_fallsBackToCurrentShippingMethods() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestCouponCodeUpdate?
+        let fallback = PKShippingMethod(label: "Fallback", amount: 0)
+        fallback.identifier = "fallback"
+        sut.currentShippingMethods = [fallback]
+        sut.couponCodeHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+
+        // WHEN — no shippingMethods in dict
+        sut.provideCouponCodeUpdate([:])
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedUpdate?.shippingMethods.first?.identifier, "fallback")
+    }
+
+    @available(iOS 15.0, *)
+    func test_provideCouponCodeUpdate_parsesErrors() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedUpdate: PKPaymentRequestCouponCodeUpdate?
+        sut.couponCodeHandler = { update in
+            receivedUpdate = update
+            expectation.fulfill()
+        }
+        let update: NSDictionary = [
+            "paymentSummaryItems": [["label": "Total", "amount": "10"]],
+            "errors": [["type": "couponCode", "message": "Invalid coupon"]]
+        ]
+
+        // WHEN
+        sut.provideCouponCodeUpdate(update)
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedUpdate?.errors?.count, 1)
+    }
+
+    // MARK: - provideAuthorizationResult
+
+    func test_provideAuthorizationResult_doesNothing_whenNoHandler() {
+        // GIVEN
+        sut.authorizationHandler = nil
+
+        // WHEN / THEN — no crash
+        sut.provideAuthorizationResult(["status": "success"])
+    }
+
+    func test_provideAuthorizationResult_withErrors_passesThemThrough() {
+        // GIVEN
+        let expectation = self.expectation(description: "handler called")
+        var receivedResult: PKPaymentAuthorizationResult?
+        sut.authorizationHandler = { result in
+            receivedResult = result
+            expectation.fulfill()
+        }
+        let result: NSDictionary = [
+            "status": "failure",
+            "errors": [["type": "shippingAddress", "field": "postalCode", "message": "Bad zip"]]
+        ]
+
+        // WHEN
+        sut.provideAuthorizationResult(result)
+
+        // THEN
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedResult?.status, .failure)
+        XCTAssertEqual(receivedResult?.errors?.count, 1)
+    }
+
     func test_hide_callsDismiss() {
         // GIVEN
         let expectation = self.expectation(description: "dismiss should be called")
@@ -277,6 +576,177 @@ final class ApplePayModuleTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1.0)
+    }
+}
+
+final class ApplePayModuleUtilitiesTests: XCTestCase {
+
+    // MARK: - PKShippingMethod.jsonObject
+
+    func test_pkShippingMethod_jsonObject_containsRequiredFields() {
+        // GIVEN
+        let method = PKShippingMethod(label: "Standard", amount: 5.00)
+        method.identifier = "standard"
+        method.detail = "5–7 days"
+
+        // WHEN
+        let json = method.jsonObject
+
+        // THEN
+        XCTAssertEqual(json["label"] as? String, "Standard")
+        XCTAssertEqual(json["amount"] as? String, "5")
+        XCTAssertEqual(json["identifier"] as? String, "standard")
+        XCTAssertEqual(json["detail"] as? String, "5–7 days")
+    }
+
+    func test_pkShippingMethod_jsonObject_typeIsPending() {
+        // GIVEN
+        let method = PKShippingMethod(label: "TBD", amount: 0, type: .pending)
+
+        // WHEN
+        let json = method.jsonObject
+
+        // THEN
+        XCTAssertEqual(json["type"] as? String, "pending")
+    }
+
+    func test_pkShippingMethod_jsonObject_typeIsFinal() {
+        // GIVEN
+        let method = PKShippingMethod(label: "Express", amount: 15, type: .final)
+
+        // WHEN
+        let json = method.jsonObject
+
+        // THEN
+        XCTAssertEqual(json["type"] as? String, "final")
+    }
+
+    func test_pkShippingMethod_jsonObject_omitsNilIdentifierAndDetail() {
+        // GIVEN
+        let method = PKShippingMethod(label: "Free", amount: 0)
+
+        // WHEN
+        let json = method.jsonObject
+
+        // THEN
+        XCTAssertNil(json["identifier"])
+        XCTAssertNil(json["detail"])
+    }
+
+    // MARK: - PKContact.jsonObject (field assertions)
+
+    func test_pkContact_jsonObject_containsAllFields() {
+        // GIVEN
+        let contact = PKContact()
+        contact.emailAddress = "test@example.com"
+        contact.phoneNumber = CNPhoneNumber(stringValue: "+1234567890")
+
+        var name = PersonNameComponents()
+        name.givenName = "John"
+        name.familyName = "Doe"
+        name.phoneticRepresentation = PersonNameComponents()
+        name.phoneticRepresentation?.givenName = "Jon"
+        name.phoneticRepresentation?.familyName = "Doh"
+        contact.name = name
+
+        let address = CNMutablePostalAddress()
+        address.street = "123 Main St"
+        address.city = "Springfield"
+        address.state = "IL"
+        address.postalCode = "62701"
+        address.country = "United States"
+        address.isoCountryCode = "US"
+        address.subLocality = "Downtown"
+        address.subAdministrativeArea = "Sangamon"
+        contact.postalAddress = address
+
+        // WHEN
+        let json = contact.jsonObject
+
+        // THEN
+        XCTAssertEqual(json["emailAddress"] as? String, "test@example.com")
+        XCTAssertEqual(json["phoneNumber"] as? String, "+1234567890")
+        XCTAssertEqual(json["givenName"] as? String, "John")
+        XCTAssertEqual(json["familyName"] as? String, "Doe")
+        XCTAssertEqual(json["phoneticGivenName"] as? String, "Jon")
+        XCTAssertEqual(json["phoneticFamilyName"] as? String, "Doh")
+        XCTAssertEqual(json["addressLines"] as? String, "123 Main St")
+        XCTAssertEqual(json["locality"] as? String, "Springfield")
+        XCTAssertEqual(json["administrativeArea"] as? String, "IL")
+        XCTAssertEqual(json["postalCode"] as? String, "62701")
+        XCTAssertEqual(json["country"] as? String, "United States")
+        XCTAssertEqual(json["countryCode"] as? String, "US")
+        XCTAssertEqual(json["subLocality"] as? String, "Downtown")
+        XCTAssertEqual(json["subAdministrativeArea"] as? String, "Sangamon")
+    }
+
+    // MARK: - applePayError(from:)
+
+    func test_applePayError_returnsNil_forUnknownType() {
+        XCTAssertNil(applePayError(from: ["type": "unknown", "message": "error"]))
+    }
+
+    func test_applePayError_returnsNil_whenMissingMessage() {
+        XCTAssertNil(applePayError(from: ["type": "shippingAddress"]))
+    }
+
+    func test_applePayError_shippingAddress_returnsError() {
+        let error = applePayError(from: ["type": "shippingAddress", "field": "postalCode", "message": "Invalid postal code"])
+        XCTAssertNotNil(error)
+    }
+
+    func test_applePayError_billingAddress_returnsError() {
+        let error = applePayError(from: ["type": "billingAddress", "field": "city", "message": "Invalid city"])
+        XCTAssertNotNil(error)
+    }
+
+    func test_applePayError_contactField_returnsError() {
+        let error = applePayError(from: ["type": "contactField", "field": "phoneNumber", "message": "Invalid phone"])
+        XCTAssertNotNil(error)
+    }
+
+    @available(iOS 15.0, *)
+    func test_applePayError_couponCode_returnsError() {
+        let error = applePayError(from: ["type": "couponCode", "message": "Invalid coupon"])
+        XCTAssertNotNil(error)
+    }
+
+    @available(iOS 15.0, *)
+    func test_applePayError_couponCodeExpired_returnsError() {
+        let error = applePayError(from: ["type": "couponCodeExpired", "message": "Coupon expired"])
+        XCTAssertNotNil(error)
+    }
+
+    func test_applePayError_shippingAddress_usesDefaultKey_whenFieldIsNil() {
+        let error = applePayError(from: ["type": "shippingAddress", "message": "Error"])
+        XCTAssertNotNil(error)
+    }
+
+    // MARK: - ApplePayPaymentMethod.supportedNetworks
+
+    func test_supportedNetworks_returnsAllAvailable_whenBrandsIsNil() {
+        // GIVEN
+        let dict: NSDictionary = ["type": "applepay", "name": "Apple Pay"]
+        let method: ApplePayPaymentMethod = try! dict.decode()
+
+        // WHEN
+        let networks = method.supportedNetworks
+
+        // THEN
+        XCTAssertFalse(networks.isEmpty)
+    }
+
+    func test_supportedNetworks_filtersToMatchingBrands() {
+        // GIVEN — brands only contains "visa"
+        let dict: NSDictionary = ["type": "applepay", "name": "Apple Pay", "brands": ["visa"]]
+        let method: ApplePayPaymentMethod = try! dict.decode()
+
+        // WHEN
+        let networks = method.supportedNetworks
+
+        // THEN
+        XCTAssertTrue(networks.contains(.visa))
+        XCTAssertFalse(networks.contains(.masterCard))
     }
 }
 

--- a/example/src/settings/checkoutConfiguration.ts
+++ b/example/src/settings/checkoutConfiguration.ts
@@ -98,8 +98,13 @@ export const checkoutConfiguration = (config: AppConfiguration) => {
     applepay: {
       merchantID:
         config.applePaySettings?.merchantID ?? ENVIRONMENT.applepayMerchantID,
-      merchantName: config.applePaySettings?.merchantName ?? 'Test Merchant',
       allowOnboarding: config.applePaySettings?.allowOnboarding,
+      summaryItems: [
+        {
+          label: config.applePaySettings?.merchantName ?? 'Test Merchant',
+          amount: config.amount / 100,
+        },
+      ],
       shippingType: config.applePaySettings?.shippingType,
       requiredBillingContactFields: ['phoneticName', 'postalAddress'],
       requiredShippingContactFields: [
@@ -119,8 +124,8 @@ export const checkoutConfiguration = (config: AppConfiguration) => {
         resolve({
           shippingMethods: mockShippingMethods,
           paymentSummaryItems: [
-            { label: 'Shipping', amount: 500 },
-            { label: 'Total', amount: config.amount + 500 },
+            { label: 'Shipping', amount: 5 },
+            { label: 'Total', amount: config.amount / 100 + 5 },
           ],
         });
       },
@@ -129,12 +134,11 @@ export const checkoutConfiguration = (config: AppConfiguration) => {
         resolve: (update: ApplePayShippingMethodUpdateRequest) => void
       ) => {
         console.debug('Apple Pay shipping method changed:', shippingMethod);
-        const shippingCost =
-          shippingMethod.identifier === 'express' ? 1500 : 500;
+        const shippingCost = shippingMethod.identifier === 'express' ? 15 : 5;
         resolve({
           paymentSummaryItems: [
             { label: shippingMethod.label, amount: shippingCost },
-            { label: 'Total', amount: config.amount + shippingCost },
+            { label: 'Total', amount: config.amount / 100 + shippingCost },
           ],
         });
       },
@@ -190,13 +194,13 @@ export const checkoutConfiguration = (config: AppConfiguration) => {
 const mockShippingMethods: ApplePayShippingMethod[] = [
   {
     label: 'Standard Shipping',
-    amount: 500,
+    amount: 5,
     identifier: 'standard',
     detail: '5–7 business days',
   },
   {
     label: 'Express Shipping',
-    amount: 1500,
+    amount: 15,
     identifier: 'express',
     detail: '1–2 business days',
   },

--- a/example/src/settings/checkoutConfiguration.ts
+++ b/example/src/settings/checkoutConfiguration.ts
@@ -158,7 +158,7 @@ export const checkoutConfiguration = (config: AppConfiguration) => {
           resolve({});
         }
       },
-      onAuthorization: (
+      onAuthorize: (
         payment: ApplePayPaymentAuthorization,
         resolve: (result: ApplePayAuthorizationResultRequest) => void
       ) => {

--- a/example/src/settings/checkoutConfiguration.ts
+++ b/example/src/settings/checkoutConfiguration.ts
@@ -1,7 +1,14 @@
 import type {
   AddressLookup,
   AddressLookupItem,
+  ApplePayAuthorizationResultRequest,
+  ApplePayCouponCodeUpdateRequest,
+  ApplePayPaymentAuthorization,
+  ApplePayPaymentContact,
   ApplePayRecurringPaymentRequest,
+  ApplePayShippingContactUpdateRequest,
+  ApplePayShippingMethod,
+  ApplePayShippingMethodUpdateRequest,
   BinLookupData,
   Configuration,
   StoredPaymentMethod,
@@ -102,6 +109,59 @@ export const checkoutConfiguration = (config: AppConfiguration) => {
         'postalAddress',
       ],
       recurringPaymentRequest: mockApplePayRecurringPayment,
+      onShippingContactChange: (
+        contact: ApplePayPaymentContact,
+        resolve: (update: ApplePayShippingContactUpdateRequest) => void
+      ) => {
+        console.debug('Apple Pay shipping contact changed:', contact);
+        // Update shipping methods and summary items based on the new contact.
+        // Call resolve() with no arguments to keep the current values unchanged.
+        resolve({
+          shippingMethods: mockShippingMethods,
+          paymentSummaryItems: [
+            { label: 'Shipping', amount: 500 },
+            { label: 'Total', amount: config.amount + 500 },
+          ],
+        });
+      },
+      onShippingMethodChange: (
+        shippingMethod: ApplePayShippingMethod,
+        resolve: (update: ApplePayShippingMethodUpdateRequest) => void
+      ) => {
+        console.debug('Apple Pay shipping method changed:', shippingMethod);
+        const shippingCost =
+          shippingMethod.identifier === 'express' ? 1500 : 500;
+        resolve({
+          paymentSummaryItems: [
+            { label: shippingMethod.label, amount: shippingCost },
+            { label: 'Total', amount: config.amount + shippingCost },
+          ],
+        });
+      },
+      onCouponCodeChange: (
+        couponCode: string,
+        resolve: (update: ApplePayCouponCodeUpdateRequest) => void
+      ) => {
+        console.debug('Apple Pay coupon code entered:', couponCode);
+        if (couponCode === 'INVALID') {
+          resolve({
+            errors: [
+              { type: 'couponCode', message: 'This coupon code is not valid.' },
+            ],
+          });
+        } else {
+          resolve({});
+        }
+      },
+      onAuthorization: (
+        payment: ApplePayPaymentAuthorization,
+        resolve: (result: ApplePayAuthorizationResultRequest) => void
+      ) => {
+        console.debug('Apple Pay payment authorized:', payment);
+        // Validate billing/shipping address before submission.
+        // Call resolve({ status: 'failure', errors: [...] }) to show errors.
+        resolve({ status: 'success' });
+      },
     },
     googlepay: {
       allowPrepaidCards: config.googlePaySettings?.allowPrepaidCards,
@@ -126,6 +186,21 @@ export const checkoutConfiguration = (config: AppConfiguration) => {
   };
   return configuration;
 };
+
+const mockShippingMethods: ApplePayShippingMethod[] = [
+  {
+    label: 'Standard Shipping',
+    amount: 500,
+    identifier: 'standard',
+    detail: '5–7 business days',
+  },
+  {
+    label: 'Express Shipping',
+    amount: 1500,
+    identifier: 'express',
+    detail: '1–2 business days',
+  },
+];
 
 const mockAddresses: AddressLookupItem[] = [
   {

--- a/example/src/settings/checkoutConfiguration.ts
+++ b/example/src/settings/checkoutConfiguration.ts
@@ -106,6 +106,7 @@ export const checkoutConfiguration = (config: AppConfiguration) => {
         },
       ],
       shippingType: config.applePaySettings?.shippingType,
+      supportsCouponCode: true,
       requiredBillingContactFields: ['phoneticName', 'postalAddress'],
       requiredShippingContactFields: [
         'name',

--- a/ios/AdyenModule.m
+++ b/ios/AdyenModule.m
@@ -66,6 +66,14 @@ RCT_EXTERN_METHOD(isAvailable:(nonnull NSDictionary *)paymentMethod
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(provideShippingContactUpdate:(nonnull NSDictionary *)update)
+
+RCT_EXTERN_METHOD(provideShippingMethodUpdate:(nonnull NSDictionary *)update)
+
+RCT_EXTERN_METHOD(provideCouponCodeUpdate:(nonnull NSDictionary *)update)
+
+RCT_EXTERN_METHOD(provideAuthorizationResult:(nonnull NSDictionary *)result)
+
 @end
 
 // Mock to prevent NativeModule check failure

--- a/ios/Components/ApplePay/ApplePayModule+Delegates.swift
+++ b/ios/Components/ApplePay/ApplePayModule+Delegates.swift
@@ -76,7 +76,7 @@ extension ApplePayModule {
         shippingContactHandler = nil
         let dict = update as? [String: Any] ?? [:]
         let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
-        let shippingMethods = parseShippingMethods(dict) ?? []
+        let shippingMethods = parseShippingMethods(dict) ?? currentShippingMethods
         let errors = parseErrors(dict)
         DispatchQueue.main.async {
             handler(.init(errors: errors, paymentSummaryItems: summaryItems, shippingMethods: shippingMethods))
@@ -101,7 +101,7 @@ extension ApplePayModule {
             couponCodeHandler = nil
             let dict = update as? [String: Any] ?? [:]
             let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
-            let shippingMethods = parseShippingMethods(dict) ?? []
+            let shippingMethods = parseShippingMethods(dict) ?? currentShippingMethods
             let errors = parseErrors(dict)
             DispatchQueue.main.async {
                 handler(.init(errors: errors, paymentSummaryItems: summaryItems, shippingMethods: shippingMethods))

--- a/ios/Components/ApplePay/ApplePayModule+Delegates.swift
+++ b/ios/Components/ApplePay/ApplePayModule+Delegates.swift
@@ -54,13 +54,13 @@ extension ApplePayModule: ApplePayAuthorizationDelegate {
         authorizationHandler = completion
         var body: [String: Any] = [:]
         if let billing = payment.billingContact {
-            body["billingContact"] = billing.jsonObject
+            body[ApplePayKeys.billingContact] = billing.jsonObject
         }
         if let shipping = payment.shippingContact {
-            body["shippingContact"] = shipping.jsonObject
+            body[ApplePayKeys.shippingContact] = shipping.jsonObject
         }
         if let method = payment.shippingMethod {
-            body["shippingMethod"] = method.jsonObject
+            body[ApplePayKeys.shippingMethod] = method.jsonObject
         }
         sendEvent(event: .authorizePayment, body: body)
     }
@@ -114,7 +114,7 @@ extension ApplePayModule {
         guard let handler = authorizationHandler else { return }
         authorizationHandler = nil
         let dict = result as? [String: Any] ?? [:]
-        let success = (dict["status"] as? String) == "success"
+        let success = (dict[ApplePayKeys.Update.status] as? String) == "success"
         let errors = parseErrors(dict)
         let status: PKPaymentAuthorizationStatus = success ? .success : .failure
         DispatchQueue.main.async {
@@ -125,19 +125,19 @@ extension ApplePayModule {
     // MARK: - Private parsing helpers
 
     private func parseSummaryItems(_ dict: [String: Any]) -> [PKPaymentSummaryItem]? {
-        guard let raw = dict["paymentSummaryItems"] as? [[String: Any]] else { return nil }
+        guard let raw = dict[ApplePayKeys.Update.paymentSummaryItems] as? [[String: Any]] else { return nil }
         let items = raw.compactMap(PKPaymentSummaryItem.init)
         return items.isEmpty ? nil : items
     }
 
     private func parseShippingMethods(_ dict: [String: Any]) -> [PKShippingMethod]? {
-        guard let raw = dict["shippingMethods"] as? [[String: Any]] else { return nil }
+        guard let raw = dict[ApplePayKeys.Update.shippingMethods] as? [[String: Any]] else { return nil }
         let methods = raw.compactMap(PKShippingMethod.initiate)
         return methods.isEmpty ? nil : methods
     }
 
     private func parseErrors(_ dict: [String: Any]) -> [Error]? {
-        guard let raw = dict["errors"] as? [[String: Any]] else { return nil }
+        guard let raw = dict[ApplePayKeys.Update.errors] as? [[String: Any]] else { return nil }
         let errors = raw.compactMap { applePayError(from: $0) }
         return errors.isEmpty ? nil : errors
     }

--- a/ios/Components/ApplePay/ApplePayModule+Delegates.swift
+++ b/ios/Components/ApplePay/ApplePayModule+Delegates.swift
@@ -1,0 +1,144 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+import PassKit
+
+// MARK: - ApplePayComponentDelegate
+
+extension ApplePayModule: ApplePayComponentDelegate {
+
+    func didUpdate(
+        contact: PKContact,
+        for payment: ApplePayPayment,
+        completion: @escaping (PKPaymentRequestShippingContactUpdate) -> Void
+    ) {
+        shippingContactHandler = completion
+        currentApplePayPayment = payment
+        sendEvent(event: .updateShippingContact, body: contact.jsonObject)
+    }
+
+    func didUpdate(
+        shippingMethod: PKShippingMethod,
+        for payment: ApplePayPayment,
+        completion: @escaping (PKPaymentRequestShippingMethodUpdate) -> Void
+    ) {
+        shippingMethodHandler = completion
+        currentApplePayPayment = payment
+        sendEvent(event: .updateShippingMethod, body: shippingMethod.jsonObject)
+    }
+
+    @available(iOS 15.0, *)
+    func didUpdate(
+        couponCode: String,
+        for payment: ApplePayPayment,
+        completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void
+    ) {
+        couponCodeHandler = completion
+        currentApplePayPayment = payment
+        sendEvent(event: .updateCouponCode, body: couponCode)
+    }
+}
+
+// MARK: - ApplePayAuthorizationDelegate
+
+extension ApplePayModule: ApplePayAuthorizationDelegate {
+
+    func didAuthorize(
+        payment: PKPayment,
+        completion: @escaping (PKPaymentAuthorizationResult) -> Void
+    ) {
+        authorizationHandler = completion
+        var body: [String: Any] = [:]
+        if let billing = payment.billingContact {
+            body["billingContact"] = billing.jsonObject
+        }
+        if let shipping = payment.shippingContact {
+            body["shippingContact"] = shipping.jsonObject
+        }
+        if let method = payment.shippingMethod {
+            body["shippingMethod"] = method.jsonObject
+        }
+        sendEvent(event: .authorizePayment, body: body)
+    }
+}
+
+// MARK: - Provider methods (JS → native)
+
+extension ApplePayModule {
+
+    @objc
+    func provideShippingContactUpdate(_ update: NSDictionary) {
+        guard let handler = shippingContactHandler else { return }
+        shippingContactHandler = nil
+        let dict = update as? [String: Any] ?? [:]
+        let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
+        let shippingMethods = parseShippingMethods(dict) ?? []
+        let errors = parseErrors(dict)
+        DispatchQueue.main.async {
+            handler(.init(errors: errors, paymentSummaryItems: summaryItems, shippingMethods: shippingMethods))
+        }
+    }
+
+    @objc
+    func provideShippingMethodUpdate(_ update: NSDictionary) {
+        guard let handler = shippingMethodHandler else { return }
+        shippingMethodHandler = nil
+        let dict = update as? [String: Any] ?? [:]
+        let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
+        DispatchQueue.main.async {
+            handler(.init(paymentSummaryItems: summaryItems))
+        }
+    }
+
+    @objc
+    func provideCouponCodeUpdate(_ update: NSDictionary) {
+        if #available(iOS 15.0, *) {
+            guard let handler = couponCodeHandler else { return }
+            couponCodeHandler = nil
+            let dict = update as? [String: Any] ?? [:]
+            let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
+            let shippingMethods = parseShippingMethods(dict) ?? []
+            let errors = parseErrors(dict)
+            DispatchQueue.main.async {
+                handler(.init(errors: errors, paymentSummaryItems: summaryItems, shippingMethods: shippingMethods))
+            }
+        }
+    }
+
+    @objc
+    func provideAuthorizationResult(_ result: NSDictionary) {
+        guard let handler = authorizationHandler else { return }
+        authorizationHandler = nil
+        let dict = result as? [String: Any] ?? [:]
+        let success = (dict["status"] as? String) == "success"
+        let errors = parseErrors(dict)
+        let status: PKPaymentAuthorizationStatus = success ? .success : .failure
+        DispatchQueue.main.async {
+            handler(PKPaymentAuthorizationResult(status: status, errors: errors))
+        }
+    }
+
+    // MARK: - Private parsing helpers
+
+    private func parseSummaryItems(_ dict: [String: Any]) -> [PKPaymentSummaryItem]? {
+        guard let raw = dict["paymentSummaryItems"] as? [[String: Any]] else { return nil }
+        let items = raw.compactMap(PKPaymentSummaryItem.init)
+        return items.isEmpty ? nil : items
+    }
+
+    private func parseShippingMethods(_ dict: [String: Any]) -> [PKShippingMethod]? {
+        guard let raw = dict["shippingMethods"] as? [[String: Any]] else { return nil }
+        let methods = raw.compactMap(PKShippingMethod.initiate)
+        return methods.isEmpty ? nil : methods
+    }
+
+    private func parseErrors(_ dict: [String: Any]) -> [Error]? {
+        guard let raw = dict["errors"] as? [[String: Any]] else { return nil }
+        let errors = raw.compactMap { applePayError(from: $0) }
+        return errors.isEmpty ? nil : errors
+    }
+}

--- a/ios/Components/ApplePay/ApplePayModule.swift
+++ b/ios/Components/ApplePay/ApplePayModule.swift
@@ -14,6 +14,19 @@ internal class ApplePayModule: BaseModuleSender {
 
     private let paymentAuthorizationService: PKPaymentAuthorizationService
 
+    internal var shippingContactHandler: ((PKPaymentRequestShippingContactUpdate) -> Void)?
+    internal var shippingMethodHandler: ((PKPaymentRequestShippingMethodUpdate) -> Void)?
+    internal var authorizationHandler: ((PKPaymentAuthorizationResult) -> Void)?
+    internal var currentApplePayPayment: ApplePayPayment?
+
+    @available(iOS 15.0, *)
+    internal var couponCodeHandler: ((PKPaymentRequestCouponCodeUpdate) -> Void)? {
+        get { _couponCodeHandler as? (PKPaymentRequestCouponCodeUpdate) -> Void }
+        set { _couponCodeHandler = newValue }
+    }
+
+    private var _couponCodeHandler: Any?
+
     override init() {
         self.paymentAuthorizationService = PKPaymentAuthorizationServiceAdapter()
         super.init()
@@ -22,6 +35,10 @@ internal class ApplePayModule: BaseModuleSender {
     init(pkPaymentAuthorizationService: PKPaymentAuthorizationService = PKPaymentAuthorizationServiceAdapter()) {
         self.paymentAuthorizationService = pkPaymentAuthorizationService
         super.init()
+    }
+
+    override func supportedEvents() -> [String]! {
+        super.supportedEvents() + EventName.applePayEvents.map(\.rawValue)
     }
 
     @objc
@@ -43,7 +60,18 @@ internal class ApplePayModule: BaseModuleSender {
 
         currentComponent = applePayComponent
         applePayComponent.delegate = BaseModule.session ?? self
+        applePayComponent.applePayDelegate = self
+        applePayComponent.authorizationDelegate = self
         present(component: applePayComponent)
+    }
+
+    override func cleanUp() {
+        shippingContactHandler = nil
+        shippingMethodHandler = nil
+        _couponCodeHandler = nil
+        authorizationHandler = nil
+        currentApplePayPayment = nil
+        super.cleanUp()
     }
 
     @objc

--- a/ios/Components/ApplePay/ApplePayModule.swift
+++ b/ios/Components/ApplePay/ApplePayModule.swift
@@ -18,6 +18,7 @@ internal class ApplePayModule: BaseModuleSender {
     internal var shippingMethodHandler: ((PKPaymentRequestShippingMethodUpdate) -> Void)?
     internal var authorizationHandler: ((PKPaymentAuthorizationResult) -> Void)?
     internal var currentApplePayPayment: ApplePayPayment?
+    internal var currentShippingMethods: [PKShippingMethod] = []
 
     @available(iOS 15.0, *)
     internal var couponCodeHandler: ((PKPaymentRequestCouponCodeUpdate) -> Void)? {
@@ -58,6 +59,7 @@ internal class ApplePayModule: BaseModuleSender {
             return sendError(error: error)
         }
 
+        currentShippingMethods = applePayParser.shippingMethods ?? []
         currentComponent = applePayComponent
         applePayComponent.delegate = BaseModule.session ?? self
         applePayComponent.applePayDelegate = self
@@ -71,6 +73,7 @@ internal class ApplePayModule: BaseModuleSender {
         _couponCodeHandler = nil
         authorizationHandler = nil
         currentApplePayPayment = nil
+        currentShippingMethods = []
         super.cleanUp()
     }
 

--- a/ios/Components/ApplePay/ApplePayModuleUtilities.swift
+++ b/ios/Components/ApplePay/ApplePayModuleUtilities.swift
@@ -74,18 +74,16 @@ extension PKShippingMethod {
 /// Converts a JS error descriptor dictionary into an NSError for Apple Pay.
 /// Expected keys: `type` (string), `field` (string, optional), `message` (string).
 internal func applePayError(from dict: [String: Any]) -> Error? {
-    guard let type = dict["type"] as? String,
-          let message = dict["message"] as? String else { return nil }
+    guard let type = dict[ApplePayKeys.PaymentError.type] as? String,
+          let message = dict[ApplePayKeys.PaymentError.message] as? String else { return nil }
+    let field = dict[ApplePayKeys.PaymentError.field] as? String
     switch type {
     case "shippingAddress":
-        let key = postalAddressKey(for: dict["field"] as? String)
-        return PKPaymentRequest.paymentShippingAddressInvalidError(withKey: key, localizedDescription: message)
+        return PKPaymentRequest.paymentShippingAddressInvalidError(withKey: postalAddressKey(for: field), localizedDescription: message)
     case "billingAddress":
-        let key = postalAddressKey(for: dict["field"] as? String)
-        return PKPaymentRequest.paymentBillingAddressInvalidError(withKey: key, localizedDescription: message)
+        return PKPaymentRequest.paymentBillingAddressInvalidError(withKey: postalAddressKey(for: field), localizedDescription: message)
     case "contactField":
-        let field = contactField(for: dict["field"] as? String)
-        return PKPaymentRequest.paymentContactInvalidError(withContactField: field, localizedDescription: message)
+        return PKPaymentRequest.paymentContactInvalidError(withContactField: PKContactField.fromString(field ?? ""), localizedDescription: message)
     case "couponCodeExpired":
         if #available(iOS 15.0, *) {
             return PKPaymentRequest.paymentCouponCodeExpiredError(localizedDescription: message)
@@ -98,31 +96,6 @@ internal func applePayError(from dict: [String: Any]) -> Error? {
         return nil
     default:
         return nil
-    }
-}
-
-private func postalAddressKey(for field: String?) -> String {
-    switch field {
-    case "street", "addressLines": return CNPostalAddressStreetKey
-    case "city", "locality": return CNPostalAddressCityKey
-    case "state", "administrativeArea": return CNPostalAddressStateKey
-    case "postalCode": return CNPostalAddressPostalCodeKey
-    case "country": return CNPostalAddressCountryKey
-    case "countryCode": return CNPostalAddressISOCountryCodeKey
-    case "subLocality": return CNPostalAddressSubLocalityKey
-    case "subAdministrativeArea": return CNPostalAddressSubAdministrativeAreaKey
-    default: return field ?? CNPostalAddressStreetKey
-    }
-}
-
-private func contactField(for field: String?) -> PKContactField {
-    switch field {
-    case "phoneNumber", "phone": return .phoneNumber
-    case "emailAddress", "email": return .emailAddress
-    case "name": return .name
-    case "phoneticName": return .phoneticName
-    case "postalAddress": return .postalAddress
-    default: return PKContactField(rawValue: field ?? "")
     }
 }
 
@@ -160,5 +133,19 @@ extension PKContact {
         }
 
         return dictionary
+    }
+}
+
+private func postalAddressKey(for field: String?) -> String {
+    switch field {
+    case "street", "addressLines": return CNPostalAddressStreetKey
+    case "city", "locality": return CNPostalAddressCityKey
+    case "state", "administrativeArea": return CNPostalAddressStateKey
+    case "postalCode": return CNPostalAddressPostalCodeKey
+    case "country": return CNPostalAddressCountryKey
+    case "countryCode": return CNPostalAddressISOCountryCodeKey
+    case "subLocality": return CNPostalAddressSubLocalityKey
+    case "subAdministrativeArea": return CNPostalAddressSubAdministrativeAreaKey
+    default: return field ?? CNPostalAddressStreetKey
     }
 }

--- a/ios/Components/ApplePay/ApplePayModuleUtilities.swift
+++ b/ios/Components/ApplePay/ApplePayModuleUtilities.swift
@@ -1,4 +1,5 @@
 import Adyen
+import Contacts
 import PassKit
 
 extension ApplePayDetails {
@@ -41,6 +42,88 @@ extension PKPaymentNetwork {
         }
     }
 
+}
+
+extension PKShippingMethod {
+    var jsonObject: [String: Any] {
+        var dict: [String: Any] = [
+            ApplePayKeys.SummaryItem.label: label,
+            ApplePayKeys.SummaryItem.amount: amount.stringValue,
+            ApplePayKeys.SummaryItem.type: type == .pending ? "pending" : "final"
+        ]
+        if let identifier {
+            dict[ApplePayKeys.ShippingMethod.identifier] = identifier
+        }
+        if let detail {
+            dict[ApplePayKeys.ShippingMethod.detail] = detail
+        }
+        if #available(iOS 15.0, *), let range = dateComponentsRange {
+            if let start = Calendar.current.date(from: range.startDateComponents) {
+                dict[ApplePayKeys.ShippingMethod.startDate] = iso8601Formatter.string(from: start)
+            }
+            if let end = Calendar.current.date(from: range.endDateComponents) {
+                dict[ApplePayKeys.ShippingMethod.endDate] = iso8601Formatter.string(from: end)
+            }
+        }
+        return dict
+    }
+}
+
+// MARK: - Apple Pay error helpers
+
+/// Converts a JS error descriptor dictionary into an NSError for Apple Pay.
+/// Expected keys: `type` (string), `field` (string, optional), `message` (string).
+internal func applePayError(from dict: [String: Any]) -> Error? {
+    guard let type = dict["type"] as? String,
+          let message = dict["message"] as? String else { return nil }
+    switch type {
+    case "shippingAddress":
+        let key = postalAddressKey(for: dict["field"] as? String)
+        return PKPaymentRequest.paymentShippingAddressInvalidError(withKey: key, localizedDescription: message)
+    case "billingAddress":
+        let key = postalAddressKey(for: dict["field"] as? String)
+        return PKPaymentRequest.paymentBillingAddressInvalidError(withKey: key, localizedDescription: message)
+    case "contactField":
+        let field = contactField(for: dict["field"] as? String)
+        return PKPaymentRequest.paymentContactInvalidError(withContactField: field, localizedDescription: message)
+    case "couponCodeExpired":
+        if #available(iOS 15.0, *) {
+            return PKPaymentRequest.paymentCouponCodeExpiredError(localizedDescription: message)
+        }
+        return nil
+    case "couponCode":
+        if #available(iOS 15.0, *) {
+            return PKPaymentRequest.paymentCouponCodeInvalidError(localizedDescription: message)
+        }
+        return nil
+    default:
+        return nil
+    }
+}
+
+private func postalAddressKey(for field: String?) -> String {
+    switch field {
+    case "street", "addressLines": return CNPostalAddressStreetKey
+    case "city", "locality": return CNPostalAddressCityKey
+    case "state", "administrativeArea": return CNPostalAddressStateKey
+    case "postalCode": return CNPostalAddressPostalCodeKey
+    case "country": return CNPostalAddressCountryKey
+    case "countryCode": return CNPostalAddressISOCountryCodeKey
+    case "subLocality": return CNPostalAddressSubLocalityKey
+    case "subAdministrativeArea": return CNPostalAddressSubAdministrativeAreaKey
+    default: return field ?? CNPostalAddressStreetKey
+    }
+}
+
+private func contactField(for field: String?) -> PKContactField {
+    switch field {
+    case "phoneNumber", "phone": return .phoneNumber
+    case "emailAddress", "email": return .emailAddress
+    case "name": return .name
+    case "phoneticName": return .phoneticName
+    case "postalAddress": return .postalAddress
+    default: return PKContactField(rawValue: field ?? "")
+    }
 }
 
 extension PKContact {

--- a/ios/Components/Base/EventName.swift
+++ b/ios/Components/Base/EventName.swift
@@ -21,6 +21,10 @@ internal enum EventName: String, CaseIterable {
     case changeBinValue = "didChangeBinValueCallback"
     case completeSession = "didSessionCompleteCallback"
     case failSession = "didSessionErrorCallback"
+    case updateShippingContact = "didUpdateShippingContactCallback"
+    case updateShippingMethod = "didUpdateShippingMethodCallback"
+    case updateCouponCode = "didUpdateCouponCodeCallback"
+    case authorizePayment = "didAuthorizePaymentCallback"
 
     static var coreEvents: [EventName] {
         [.fail, .submit, .additionalDetails, .complete]
@@ -40,5 +44,9 @@ internal enum EventName: String, CaseIterable {
 
     static var dropInEvents: [EventName] {
         [.requestOrder, .cancelOrder, .checkBalance, .disableStoredPaymentMethod]
+    }
+
+    static var applePayEvents: [EventName] {
+        [.updateShippingContact, .updateShippingMethod, .updateCouponCode, .authorizePayment]
     }
 }

--- a/ios/Configuration/ApplePay/ApplepayConfigurationParser.swift
+++ b/ios/Configuration/ApplePay/ApplepayConfigurationParser.swift
@@ -104,6 +104,14 @@ public struct ApplepayConfigurationParser {
         return shippingMethods.isEmpty ? nil : shippingMethods
     }
 
+    var supportsCouponCode: Bool {
+        (dict[ApplePayKeys.supportsCouponCode] as? Bool) ?? false
+    }
+
+    var couponCode: String? {
+        dict[ApplePayKeys.couponCode] as? String
+    }
+
     @available(iOS 16.0, *)
     var recurringPaymentRequest: PKRecurringPaymentRequest? {
         guard let recurringDict = dict[ApplePayKeys.recurringPaymentRequest] as? NSDictionary else {
@@ -154,6 +162,11 @@ public struct ApplepayConfigurationParser {
 
         if #available(iOS 16.0, *), let recurringPaymentRequest {
             paymentRequest.recurringPaymentRequest = recurringPaymentRequest
+        }
+
+        if #available(iOS 15.0, *) {
+            paymentRequest.supportsCouponCode = supportsCouponCode
+            paymentRequest.couponCode = couponCode
         }
 
         return paymentRequest

--- a/ios/Configuration/Parameters.swift
+++ b/ios/Configuration/Parameters.swift
@@ -70,6 +70,8 @@ internal enum ApplePayKeys: SubConfig {
     static let supportedCountries = "supportedCountries"
     static let shippingMethods = "shippingMethods"
     static let recurringPaymentRequest = "recurringPaymentRequest"
+    static let supportsCouponCode = "supportsCouponCode"
+    static let couponCode = "couponCode"
 
     enum Recurring {
         static let paymentDescription = "description"

--- a/ios/Configuration/Parameters.swift
+++ b/ios/Configuration/Parameters.swift
@@ -72,6 +72,20 @@ internal enum ApplePayKeys: SubConfig {
     static let recurringPaymentRequest = "recurringPaymentRequest"
     static let supportsCouponCode = "supportsCouponCode"
     static let couponCode = "couponCode"
+    static let shippingMethod = "shippingMethod"
+
+    enum Update {
+        static let paymentSummaryItems = "paymentSummaryItems"
+        static let shippingMethods = "shippingMethods"
+        static let errors = "errors"
+        static let status = "status"
+    }
+
+    enum PaymentError {
+        static let type = "type"
+        static let message = "message"
+        static let field = "field"
+    }
 
     enum Recurring {
         static let paymentDescription = "description"

--- a/src/components/__tests__/startEventListeners.test.ts
+++ b/src/components/__tests__/startEventListeners.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { Event } from '../../core';
+import { startEventListeners } from '../utils/startEventListeners';
+
+// --------------------------------------------------------------------------
+// NativeEventEmitter mock — captures handlers so we can fire them manually
+// --------------------------------------------------------------------------
+
+const mockListeners = new Map<string, ((data: any) => void)[]>();
+
+const mockAddListener = jest.fn(
+  (event: string, handler: (data: any) => void) => {
+    if (!mockListeners.has(event)) mockListeners.set(event, []);
+    mockListeners.get(event)!.push(handler);
+    return { remove: jest.fn() };
+  }
+);
+
+jest.mock('react-native', () => ({
+  NativeEventEmitter: jest.fn().mockImplementation(() => ({
+    addListener: mockAddListener,
+  })),
+}));
+
+function fire(event: Event, data: any = {}) {
+  (mockListeners.get(event) ?? []).forEach((h) => h(data));
+}
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+function createComponent(supported: Event[] = []) {
+  return {
+    isSupported: jest.fn((e: Event) => supported.includes(e)),
+    eventEmitterTarget: {},
+    hide: jest.fn(),
+    handle: jest.fn(),
+    provideShippingContactUpdate: jest.fn(),
+    provideShippingMethodUpdate: jest.fn(),
+    provideCouponCodeUpdate: jest.fn(),
+    provideAuthorizationResult: jest.fn(),
+    removeStored: jest.fn(),
+    provideBalance: jest.fn(),
+    provideOrder: jest.fn(),
+  } as any;
+}
+
+function createRefs(
+  applepay: any = {},
+  card: any = {},
+  dropin: any = {},
+  partialPayment: any = {}
+) {
+  return {
+    onSubmit: { current: jest.fn() },
+    onError: { current: jest.fn() },
+    onComplete: { current: jest.fn() },
+    onAdditionalDetails: { current: jest.fn() },
+    config: {
+      current: {
+        environment: 'test' as const,
+        clientKey: 'test_key',
+        returnUrl: 'app://checkout',
+        applepay,
+        card,
+        dropin,
+        partialPayment,
+      },
+    },
+  } as any;
+}
+
+// --------------------------------------------------------------------------
+
+describe('startEventListeners', () => {
+  beforeEach(() => {
+    mockListeners.clear();
+    mockAddListener.mockClear();
+  });
+
+  // -------------------------------------------------------------------------
+  // subscribeIfSupported
+  // -------------------------------------------------------------------------
+
+  test('does not subscribe to unsupported events', () => {
+    const component = createComponent([]); // no supported events
+    startEventListeners(component, createRefs());
+    expect(mockAddListener).not.toHaveBeenCalled();
+  });
+
+  test('subscribes only to supported events', () => {
+    const component = createComponent([Event.onSubmit, Event.onError]);
+    startEventListeners(component, createRefs());
+    expect(mockAddListener).toHaveBeenCalledTimes(2);
+  });
+
+  test('returns one subscription per supported event', () => {
+    const component = createComponent([Event.onSubmit]);
+    const subs = startEventListeners(component, createRefs());
+    expect(subs).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Core events
+  // -------------------------------------------------------------------------
+
+  test('onSubmit — calls onSubmit ref with payload and component', () => {
+    const refs = createRefs();
+    startEventListeners(createComponent([Event.onSubmit]), refs);
+    fire(Event.onSubmit, {
+      paymentData: {
+        returnUrl: 'app://checkout',
+        paymentMethod: { type: 'scheme' },
+      },
+      extra: { network: 'visa' },
+    });
+    expect(refs.onSubmit.current).toHaveBeenCalledWith(
+      expect.objectContaining({ paymentMethod: { type: 'scheme' } }),
+      expect.anything(),
+      { network: 'visa' }
+    );
+  });
+
+  test('onSubmit — injects returnUrl from config when missing in payload', () => {
+    const refs = createRefs();
+    startEventListeners(createComponent([Event.onSubmit]), refs);
+    fire(Event.onSubmit, {
+      paymentData: { paymentMethod: { type: 'scheme' } },
+      extra: null,
+    });
+    expect(refs.onSubmit.current).toHaveBeenCalledWith(
+      expect.objectContaining({ returnUrl: 'app://checkout' }),
+      expect.anything(),
+      null
+    );
+  });
+
+  test('onError — calls onError ref', () => {
+    const refs = createRefs();
+    startEventListeners(createComponent([Event.onError]), refs);
+    const error = { message: 'fail', errorCode: 'canceledByShopper' };
+    fire(Event.onError, error);
+    expect(refs.onError.current).toHaveBeenCalledWith(error, expect.anything());
+  });
+
+  test('onComplete — calls onComplete ref', () => {
+    const refs = createRefs();
+    startEventListeners(createComponent([Event.onComplete]), refs);
+    const result = {
+      sessionId: 'sid',
+      sessionResult: 'sr',
+      resultCode: 'Authorised',
+      sessionData: 'sd',
+    };
+    fire(Event.onComplete, result);
+    expect(refs.onComplete.current).toHaveBeenCalledWith(
+      result,
+      expect.anything()
+    );
+  });
+
+  test('onAdditionalDetails — calls onAdditionalDetails ref', () => {
+    const refs = createRefs();
+    startEventListeners(createComponent([Event.onAdditionalDetails]), refs);
+    const data = { details: {}, paymentData: 'pd' };
+    fire(Event.onAdditionalDetails, data);
+    expect(refs.onAdditionalDetails.current).toHaveBeenCalledWith(
+      data,
+      expect.anything()
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // viewId filtering
+  // -------------------------------------------------------------------------
+
+  test('filters out events whose viewId does not match', () => {
+    const refs = createRefs();
+    startEventListeners(createComponent([Event.onError]), refs, 'view-1');
+    fire(Event.onError, { viewId: 'view-2', message: 'err', errorCode: 'x' });
+    expect(refs.onError.current).not.toHaveBeenCalled();
+  });
+
+  test('passes through events whose viewId matches', () => {
+    const refs = createRefs();
+    startEventListeners(createComponent([Event.onError]), refs, 'view-1');
+    fire(Event.onError, { viewId: 'view-1', message: 'err', errorCode: 'x' });
+    expect(refs.onError.current).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Apple Pay — onShippingContactChange
+  // -------------------------------------------------------------------------
+
+  test('onApplePayShippingContactChange — calls user callback when configured', () => {
+    const onShippingContactChange = jest.fn();
+    const component = createComponent([Event.onApplePayShippingContactChange]);
+    const refs = createRefs({ onShippingContactChange });
+    startEventListeners(component, refs);
+
+    const contact = { emailAddress: 'a@b.com' };
+    fire(Event.onApplePayShippingContactChange, contact);
+
+    expect(onShippingContactChange).toHaveBeenCalledWith(
+      contact,
+      expect.any(Function)
+    );
+  });
+
+  test('onApplePayShippingContactChange — resolve calls provideShippingContactUpdate', () => {
+    const component = createComponent([Event.onApplePayShippingContactChange]);
+    const onShippingContactChange = jest.fn((_contact: any, resolve: any) =>
+      resolve({ paymentSummaryItems: [] })
+    );
+    startEventListeners(component, createRefs({ onShippingContactChange }));
+
+    fire(Event.onApplePayShippingContactChange, {});
+
+    expect(component.provideShippingContactUpdate).toHaveBeenCalledWith({
+      paymentSummaryItems: [],
+    });
+  });
+
+  test('onApplePayShippingContactChange — auto-resolves with {} when no callback', () => {
+    const component = createComponent([Event.onApplePayShippingContactChange]);
+    startEventListeners(component, createRefs({})); // no onShippingContactChange
+
+    fire(Event.onApplePayShippingContactChange, {});
+
+    expect(component.provideShippingContactUpdate).toHaveBeenCalledWith({});
+  });
+
+  // -------------------------------------------------------------------------
+  // Apple Pay — onShippingMethodChange
+  // -------------------------------------------------------------------------
+
+  test('onApplePayShippingMethodChange — calls user callback when configured', () => {
+    const onShippingMethodChange = jest.fn();
+    const component = createComponent([Event.onApplePayShippingMethodChange]);
+    startEventListeners(component, createRefs({ onShippingMethodChange }));
+
+    const method = { label: 'Express', amount: 15, identifier: 'express' };
+    fire(Event.onApplePayShippingMethodChange, method);
+
+    expect(onShippingMethodChange).toHaveBeenCalledWith(
+      method,
+      expect.any(Function)
+    );
+  });
+
+  test('onApplePayShippingMethodChange — resolve calls provideShippingMethodUpdate', () => {
+    const component = createComponent([Event.onApplePayShippingMethodChange]);
+    const onShippingMethodChange = jest.fn((_method: any, resolve: any) =>
+      resolve({ paymentSummaryItems: [] })
+    );
+    startEventListeners(component, createRefs({ onShippingMethodChange }));
+
+    fire(Event.onApplePayShippingMethodChange, {});
+
+    expect(component.provideShippingMethodUpdate).toHaveBeenCalledWith({
+      paymentSummaryItems: [],
+    });
+  });
+
+  test('onApplePayShippingMethodChange — auto-resolves with {} when no callback', () => {
+    const component = createComponent([Event.onApplePayShippingMethodChange]);
+    startEventListeners(component, createRefs({}));
+
+    fire(Event.onApplePayShippingMethodChange, {});
+
+    expect(component.provideShippingMethodUpdate).toHaveBeenCalledWith({});
+  });
+
+  // -------------------------------------------------------------------------
+  // Apple Pay — onCouponCodeChange
+  // -------------------------------------------------------------------------
+
+  test('onApplePayCouponCodeChange — calls user callback with coupon code', () => {
+    const onCouponCodeChange = jest.fn();
+    const component = createComponent([Event.onApplePayCouponCodeChange]);
+    startEventListeners(component, createRefs({ onCouponCodeChange }));
+
+    fire(Event.onApplePayCouponCodeChange, 'SAVE10');
+
+    expect(onCouponCodeChange).toHaveBeenCalledWith(
+      'SAVE10',
+      expect.any(Function)
+    );
+  });
+
+  test('onApplePayCouponCodeChange — resolve calls provideCouponCodeUpdate', () => {
+    const component = createComponent([Event.onApplePayCouponCodeChange]);
+    const onCouponCodeChange = jest.fn((_code: any, resolve: any) =>
+      resolve({ errors: [{ type: 'couponCode', message: 'Invalid' }] })
+    );
+    startEventListeners(component, createRefs({ onCouponCodeChange }));
+
+    fire(Event.onApplePayCouponCodeChange, 'BADCODE');
+
+    expect(component.provideCouponCodeUpdate).toHaveBeenCalledWith({
+      errors: [{ type: 'couponCode', message: 'Invalid' }],
+    });
+  });
+
+  test('onApplePayCouponCodeChange — auto-resolves with {} when no callback', () => {
+    const component = createComponent([Event.onApplePayCouponCodeChange]);
+    startEventListeners(component, createRefs({}));
+
+    fire(Event.onApplePayCouponCodeChange, 'CODE');
+
+    expect(component.provideCouponCodeUpdate).toHaveBeenCalledWith({});
+  });
+
+  // -------------------------------------------------------------------------
+  // Apple Pay — onAuthorize
+  // -------------------------------------------------------------------------
+
+  test('onApplePayAuthorization — calls user callback with payment data', () => {
+    const onAuthorize = jest.fn();
+    const component = createComponent([Event.onApplePayAuthorization]);
+    startEventListeners(component, createRefs({ onAuthorize }));
+
+    const payment = { billingContact: { emailAddress: 'a@b.com' } };
+    fire(Event.onApplePayAuthorization, payment);
+
+    expect(onAuthorize).toHaveBeenCalledWith(payment, expect.any(Function));
+  });
+
+  test('onApplePayAuthorization — resolve calls provideAuthorizationResult', () => {
+    const component = createComponent([Event.onApplePayAuthorization]);
+    const onAuthorize = jest.fn((_payment: any, resolve: any) =>
+      resolve({
+        status: 'failure',
+        errors: [{ type: 'billingAddress', message: 'Bad address' }],
+      })
+    );
+    startEventListeners(component, createRefs({ onAuthorize }));
+
+    fire(Event.onApplePayAuthorization, {});
+
+    expect(component.provideAuthorizationResult).toHaveBeenCalledWith({
+      status: 'failure',
+      errors: [{ type: 'billingAddress', message: 'Bad address' }],
+    });
+  });
+
+  test('onApplePayAuthorization — auto-resolves with success when no callback', () => {
+    const component = createComponent([Event.onApplePayAuthorization]);
+    startEventListeners(component, createRefs({}));
+
+    fire(Event.onApplePayAuthorization, {});
+
+    expect(component.provideAuthorizationResult).toHaveBeenCalledWith({
+      status: 'success',
+    });
+  });
+});

--- a/src/components/utils/startEventListeners.ts
+++ b/src/components/utils/startEventListeners.ts
@@ -216,7 +216,7 @@ export function startEventListeners(
     (payment) => {
       const resolve = (result: ApplePayAuthorizationResultRequest) =>
         applePayModule.provideAuthorizationResult(result);
-      const callback = refs.config.current.applepay?.onAuthorization;
+      const callback = refs.config.current.applepay?.onAuthorize;
       if (callback) {
         callback(payment, resolve);
       } else {

--- a/src/components/utils/startEventListeners.ts
+++ b/src/components/utils/startEventListeners.ts
@@ -4,6 +4,13 @@ import type {
   AddressLookupItem,
   AdyenActionComponent,
   AdyenError,
+  ApplePayCouponCodeUpdateRequest,
+  ApplePayPaymentAuthorization,
+  ApplePayPaymentContact,
+  ApplePayShippingContactUpdateRequest,
+  ApplePayShippingMethod,
+  ApplePayShippingMethodUpdateRequest,
+  ApplePayAuthorizationResultRequest,
   Configuration,
   Order,
   PartialPaymentComponent,
@@ -14,6 +21,7 @@ import type {
   SubmitModel,
 } from '../../core';
 import { Event } from '../../core';
+import type { ApplePayModule } from '../../modules/applepay/AdyenApplePay';
 import type { RemovesStoredPayment } from '../../modules/dropin/DropInWrapper';
 import type { AdyenEventListener } from '../../modules/base/EventListenerWrapper';
 
@@ -157,6 +165,64 @@ export function startEventListeners(
         shouldUpdatePaymentMethods,
         partialComponent
       )
+  );
+
+  // Apple Pay delegate callbacks
+  const applePayModule = nativeComponent as unknown as ApplePayModule;
+  subscribeIfSupported<ApplePayPaymentContact>(
+    Event.onApplePayShippingContactChange,
+    (contact) => {
+      const resolve = (update: ApplePayShippingContactUpdateRequest) =>
+        applePayModule.provideShippingContactUpdate(update);
+      const callback = refs.config.current.applepay?.onShippingContactChange;
+      if (callback) {
+        callback(contact, resolve);
+      } else {
+        resolve({});
+      }
+    }
+  );
+
+  subscribeIfSupported<ApplePayShippingMethod>(
+    Event.onApplePayShippingMethodChange,
+    (shippingMethod) => {
+      const resolve = (update: ApplePayShippingMethodUpdateRequest) =>
+        applePayModule.provideShippingMethodUpdate(update);
+      const callback = refs.config.current.applepay?.onShippingMethodChange;
+      if (callback) {
+        callback(shippingMethod, resolve);
+      } else {
+        resolve({});
+      }
+    }
+  );
+
+  subscribeIfSupported<string>(
+    Event.onApplePayCouponCodeChange,
+    (couponCode) => {
+      const resolve = (update: ApplePayCouponCodeUpdateRequest) =>
+        applePayModule.provideCouponCodeUpdate(update);
+      const callback = refs.config.current.applepay?.onCouponCodeChange;
+      if (callback) {
+        callback(couponCode, resolve);
+      } else {
+        resolve({});
+      }
+    }
+  );
+
+  subscribeIfSupported<ApplePayPaymentAuthorization>(
+    Event.onApplePayAuthorization,
+    (payment) => {
+      const resolve = (result: ApplePayAuthorizationResultRequest) =>
+        applePayModule.provideAuthorizationResult(result);
+      const callback = refs.config.current.applepay?.onAuthorization;
+      if (callback) {
+        callback(payment, resolve);
+      } else {
+        resolve({ status: 'success' });
+      }
+    }
   );
 
   return eventSubscriptions;

--- a/src/core/configurations/ApplePayConfiguration.ts
+++ b/src/core/configurations/ApplePayConfiguration.ts
@@ -1,3 +1,76 @@
+/** An error object describing why a field in the Apple Pay sheet is invalid. */
+export interface ApplePayError {
+  /**
+   * The category of the error.
+   * - `shippingAddress` — an invalid field in the shipping postal address.
+   * - `billingAddress` — an invalid field in the billing postal address.
+   * - `contactField` — an invalid contact field (phone, email, name, etc.).
+   * - `couponCode` — the coupon code is invalid.
+   * - `couponCodeExpired` — the coupon code has expired.
+   */
+  type:
+    | 'shippingAddress'
+    | 'billingAddress'
+    | 'contactField'
+    | 'couponCode'
+    | 'couponCodeExpired';
+  /**
+   * For `shippingAddress` / `billingAddress`: the CNPostalAddress key of the invalid field
+   * (e.g. `"postalCode"`, `"city"`, `"street"`, `"country"`, `"countryCode"`).
+   * For `contactField`: the PKContactField name
+   * (e.g. `"phoneNumber"`, `"emailAddress"`, `"name"`, `"postalAddress"`).
+   */
+  field?: string;
+  /** A localized description shown in the Apple Pay sheet. */
+  message: string;
+}
+
+/** Data passed to the shipping contact callback. */
+export interface ApplePayShippingContactUpdateRequest {
+  /** Updated payment summary items. If omitted, the current items are kept. */
+  paymentSummaryItems?: ApplePaySummaryItem[];
+  /** Updated shipping methods. If omitted, the current methods are kept. */
+  shippingMethods?: ApplePayShippingMethod[];
+  /** Validation errors to display in the sheet. */
+  errors?: ApplePayError[];
+}
+
+/** Data passed to the shipping method callback. */
+export interface ApplePayShippingMethodUpdateRequest {
+  /** Updated payment summary items. If omitted, the current items are kept. */
+  paymentSummaryItems?: ApplePaySummaryItem[];
+  /** Validation errors to display in the sheet. */
+  errors?: ApplePayError[];
+}
+
+/** Data passed to the coupon code callback. */
+export interface ApplePayCouponCodeUpdateRequest {
+  /** Updated payment summary items. If omitted, the current items are kept. */
+  paymentSummaryItems?: ApplePaySummaryItem[];
+  /** Updated shipping methods. If omitted, the current methods are kept. */
+  shippingMethods?: ApplePayShippingMethod[];
+  /** Validation errors to display in the sheet. */
+  errors?: ApplePayError[];
+}
+
+/** Data passed to the authorization callback. */
+export interface ApplePayAuthorizationResultRequest {
+  /** Whether the authorization succeeded. */
+  status: 'success' | 'failure';
+  /** Validation errors shown when status is `failure`. */
+  errors?: ApplePayError[];
+}
+
+/** Payment details provided in the authorization callback. */
+export interface ApplePayPaymentAuthorization {
+  /** The billing contact if requested. */
+  billingContact?: ApplePayPaymentContact;
+  /** The shipping contact if requested. */
+  shippingContact?: ApplePayPaymentContact;
+  /** The selected shipping method, if any. */
+  shippingMethod?: ApplePayShippingMethod;
+}
+
 export interface ApplePayConfiguration {
   /**  The merchant identifier for apple pay. */
   merchantID: string;
@@ -23,6 +96,38 @@ export interface ApplePayConfiguration {
   shippingMethods?: ApplePayShippingMethod[];
   /** An optional request to set up a recurring payment, typically a subscription. */
   recurringPaymentRequest?: ApplePayRecurringPaymentRequest;
+  /**
+   * Called when the shopper selects or updates a shipping contact.
+   * Call `resolve` with updated summary items, shipping methods, or errors.
+   */
+  onShippingContactChange?: (
+    contact: ApplePayPaymentContact,
+    resolve: (update: ApplePayShippingContactUpdateRequest) => void
+  ) => void;
+  /**
+   * Called when the shopper selects a shipping method.
+   * Call `resolve` with updated summary items or errors.
+   */
+  onShippingMethodChange?: (
+    shippingMethod: ApplePayShippingMethod,
+    resolve: (update: ApplePayShippingMethodUpdateRequest) => void
+  ) => void;
+  /**
+   * Called when the shopper enters or updates a coupon code (iOS 15+).
+   * Call `resolve` with updated summary items, shipping methods, or errors.
+   */
+  onCouponCodeChange?: (
+    couponCode: string,
+    resolve: (update: ApplePayCouponCodeUpdateRequest) => void
+  ) => void;
+  /**
+   * Called when the shopper authorizes the payment, before it is submitted to Adyen.
+   * Call `resolve` with `{ status: 'success' }` to proceed or `{ status: 'failure', errors }` to show errors.
+   */
+  onAuthorization?: (
+    payment: ApplePayPaymentAuthorization,
+    resolve: (result: ApplePayAuthorizationResultRequest) => void
+  ) => void;
 }
 
 /** Collection of values for address field visibility. */

--- a/src/core/configurations/ApplePayConfiguration.ts
+++ b/src/core/configurations/ApplePayConfiguration.ts
@@ -128,7 +128,7 @@ export interface ApplePayConfiguration {
    * Called when the shopper authorizes the payment, before it is submitted to Adyen.
    * Call `resolve` with `{ status: 'success' }` to proceed or `{ status: 'failure', errors }` to show errors.
    */
-  onAuthorization?: (
+  onAuthorize?: (
     payment: ApplePayPaymentAuthorization,
     resolve: (result: ApplePayAuthorizationResultRequest) => void
   ) => void;

--- a/src/core/configurations/ApplePayConfiguration.ts
+++ b/src/core/configurations/ApplePayConfiguration.ts
@@ -96,6 +96,10 @@ export interface ApplePayConfiguration {
   shippingMethods?: ApplePayShippingMethod[];
   /** An optional request to set up a recurring payment, typically a subscription. */
   recurringPaymentRequest?: ApplePayRecurringPaymentRequest;
+  /** Enables the coupon code entry field in the Apple Pay sheet (iOS 15+). */
+  supportsCouponCode?: boolean;
+  /** Pre-fills the coupon code field in the Apple Pay sheet (iOS 15+). */
+  couponCode?: string;
   /**
    * Called when the shopper selects or updates a shipping contact.
    * Call `resolve` with updated summary items, shipping methods, or errors.

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -28,6 +28,14 @@ export enum Event {
   onSessionComplete = 'didSessionCompleteCallback',
   /** Event handler, called when a session flow about to be terminate. */
   onSessionError = 'didSessionErrorCallback',
+  /** Apple Pay: called when the shopper selects or changes a shipping contact. */
+  onApplePayShippingContactChange = 'didUpdateShippingContactCallback',
+  /** Apple Pay: called when the shopper selects or changes a shipping method. */
+  onApplePayShippingMethodChange = 'didUpdateShippingMethodCallback',
+  /** Apple Pay: called when the shopper enters or updates a coupon code. */
+  onApplePayCouponCodeChange = 'didUpdateCouponCodeCallback',
+  /** Apple Pay: called when the shopper authorizes the payment (before submission). */
+  onApplePayAuthorization = 'didAuthorizePaymentCallback',
 }
 
 /** Collection of errors components can throw. */

--- a/src/modules/applepay/AdyenApplePay.ts
+++ b/src/modules/applepay/AdyenApplePay.ts
@@ -1,10 +1,26 @@
 import { NativeModules } from 'react-native';
 import { ModuleMock } from '../base/ModuleMock';
 import { ApplePayWrapper } from './ApplePayWrapper';
-import type { AdyenComponent, ConditionalPaymentComponent } from '../../core';
+import type {
+  AdyenComponent,
+  ConditionalPaymentComponent,
+  ApplePayAuthorizationResultRequest,
+  ApplePayCouponCodeUpdateRequest,
+  ApplePayShippingContactUpdateRequest,
+  ApplePayShippingMethodUpdateRequest,
+} from '../../core';
 
 export interface ApplePayModule
-  extends AdyenComponent, ConditionalPaymentComponent {}
+  extends AdyenComponent, ConditionalPaymentComponent {
+  provideShippingContactUpdate(
+    update: ApplePayShippingContactUpdateRequest
+  ): void;
+  provideShippingMethodUpdate(
+    update: ApplePayShippingMethodUpdateRequest
+  ): void;
+  provideCouponCodeUpdate(update: ApplePayCouponCodeUpdateRequest): void;
+  provideAuthorizationResult(result: ApplePayAuthorizationResultRequest): void;
+}
 
 /** Apple Pay component (only available for iOS) */
 export const AdyenApplePay: ApplePayModule = new ApplePayWrapper(

--- a/src/modules/applepay/ApplePayWrapper.ts
+++ b/src/modules/applepay/ApplePayWrapper.ts
@@ -1,5 +1,9 @@
 import type {
   AdyenActionComponent,
+  ApplePayAuthorizationResultRequest,
+  ApplePayCouponCodeUpdateRequest,
+  ApplePayShippingContactUpdateRequest,
+  ApplePayShippingMethodUpdateRequest,
   Configuration,
   PaymentAction,
   PaymentMethod,
@@ -10,13 +14,16 @@ import type { PaymentModule } from '../base/PaymentComponentWrapper';
 
 /** Native module interface specific to ApplePay */
 interface ApplePayNativeModule extends ApplePayModule, PaymentModule {
-  // TODO: add express payment events
+  provideShippingContactUpdate(
+    update: ApplePayShippingContactUpdateRequest
+  ): void;
+  provideShippingMethodUpdate(
+    update: ApplePayShippingMethodUpdateRequest
+  ): void;
+  provideCouponCodeUpdate(update: ApplePayCouponCodeUpdateRequest): void;
+  provideAuthorizationResult(result: ApplePayAuthorizationResultRequest): void;
 }
 
-/**
- * Apple Pay wrapper - no additional events beyond inherited ones.
- * @todo add express payment events
- */
 export class ApplePayWrapper
   extends PaymentComponentWrapper<ApplePayNativeModule>
   implements ApplePayModule, AdyenActionComponent
@@ -37,5 +44,25 @@ export class ApplePayWrapper
           'This is likely a bug in your integration.'
       );
     }
+  }
+
+  provideShippingContactUpdate(
+    update: ApplePayShippingContactUpdateRequest
+  ): void {
+    this.nativeModule.provideShippingContactUpdate(update);
+  }
+
+  provideShippingMethodUpdate(
+    update: ApplePayShippingMethodUpdateRequest
+  ): void {
+    this.nativeModule.provideShippingMethodUpdate(update);
+  }
+
+  provideCouponCodeUpdate(update: ApplePayCouponCodeUpdateRequest): void {
+    this.nativeModule.provideCouponCodeUpdate(update);
+  }
+
+  provideAuthorizationResult(result: ApplePayAuthorizationResultRequest): void {
+    this.nativeModule.provideAuthorizationResult(result);
   }
 }

--- a/src/modules/applepay/__tests__/ApplePayWrapper.test.ts
+++ b/src/modules/applepay/__tests__/ApplePayWrapper.test.ts
@@ -10,6 +10,10 @@ function createMockApplePayModule() {
     hide: jest.fn(),
     open: jest.fn(),
     isAvailable: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    provideShippingContactUpdate: jest.fn(),
+    provideShippingMethodUpdate: jest.fn(),
+    provideCouponCodeUpdate: jest.fn(),
+    provideAuthorizationResult: jest.fn(),
   } as any;
 }
 
@@ -39,6 +43,46 @@ describe('ApplePayWrapper', () => {
       );
 
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('provider methods', () => {
+    test('provideShippingContactUpdate delegates to native module', () => {
+      const wrapper = new ApplePayWrapper(mockNativeModule);
+      const update = { paymentSummaryItems: [{ label: 'Total', amount: 10 }] };
+      wrapper.provideShippingContactUpdate(update);
+      expect(
+        mockNativeModule.provideShippingContactUpdate
+      ).toHaveBeenCalledWith(update);
+    });
+
+    test('provideShippingMethodUpdate delegates to native module', () => {
+      const wrapper = new ApplePayWrapper(mockNativeModule);
+      const update = { paymentSummaryItems: [{ label: 'Total', amount: 10 }] };
+      wrapper.provideShippingMethodUpdate(update);
+      expect(mockNativeModule.provideShippingMethodUpdate).toHaveBeenCalledWith(
+        update
+      );
+    });
+
+    test('provideCouponCodeUpdate delegates to native module', () => {
+      const wrapper = new ApplePayWrapper(mockNativeModule);
+      const update = {
+        errors: [{ type: 'couponCode' as const, message: 'Invalid' }],
+      };
+      wrapper.provideCouponCodeUpdate(update);
+      expect(mockNativeModule.provideCouponCodeUpdate).toHaveBeenCalledWith(
+        update
+      );
+    });
+
+    test('provideAuthorizationResult delegates to native module', () => {
+      const wrapper = new ApplePayWrapper(mockNativeModule);
+      const result = { status: 'success' as const };
+      wrapper.provideAuthorizationResult(result);
+      expect(mockNativeModule.provideAuthorizationResult).toHaveBeenCalledWith(
+        result
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Adds support for `ApplePayComponentDelegate` and `ApplePayAuthorizationDelegate` callbacks from the native iOS SDK (adyen-ios 5.24.0), following the same event/completion-handler pattern used by Drop-in partial payments.

### New callbacks in `ApplePayConfiguration`

| Callback | Trigger |
|---|---|
| `onShippingContactChange(contact, resolve)` | Shopper selects or updates shipping address |
| `onShippingMethodChange(shippingMethod, resolve)` | Shopper selects a shipping method |
| `onCouponCodeChange(couponCode, resolve)` | Shopper enters or updates a coupon code (iOS 15+) |
| `onAuthorize(payment, resolve)` | Shopper authorizes payment, before submission to Adyen |

### New config fields

- `supportsCouponCode` — enables the coupon code field in the Apple Pay sheet (iOS 15+)
- `couponCode` — pre-fills the coupon code field (iOS 15+)

### How it works

1. Native delegate method fires → stores completion handler → emits JS event
2. JS subscriber calls user callback (or auto-resolves with defaults if no callback configured)
3. JS calls `provideXxx()` on the native module → completion handler is resolved

If no callback is configured the sheet continues uninterrupted (auto-resolved with no changes / success).

### Changes

- **iOS**: `EventName`, `ApplePayModule`, new `ApplePayModule+Delegates.swift`, `ApplePayModuleUtilities`, `ApplepayConfigurationParser`, `AdyenModule.m`
- **JS/TS**: `constants`, `ApplePayConfiguration`, `ApplePayWrapper`, `AdyenApplePay`, `startEventListeners`
- **Docs**: `docs/Configuration.md` updated with new parameters and example
- **Example**: `checkoutConfiguration.ts` updated with working usage of all new callbacks

## Ticket

COSDK-473

## Testing

- Build the example app on iOS 15+ and verify:
  - Shipping contact/method callbacks fire and update the sheet
  - Coupon code field appears with `supportsCouponCode: true`
  - `onAuthorize` fires after biometric confirmation, before `onSubmit`
  - Without any callbacks configured, the sheet completes normally