### PR TITLE
feat: add onCouponCodeChange callback and supportsCouponCode/couponCode config to ApplePay (COSDK-473)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -87,8 +87,11 @@
 | `supportedCountries`            | A list of two-letter country codes for limiting payment to cards from specific countries or regions. When provided will filter the selectable payment passes to those issued in the supported countries.                                                                                                                                                                                    | No                                      |
 | `shippingMethods`               | The list of shipping methods available for a payment request. Corresponds to [ApplePayShippingMethod](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest/1916121-shippingmethods).                                                                                                                                                                       | No                                      |
 | `recurringPaymentRequest`       | A class that represents a request to set up a recurring payment, typically a subscription. Corresponds to [PKRecurringPaymentRequest](#applepay-recurring-payment).                                                                                                                                                                                                                         | No                                      |
+| `supportsCouponCode`            | When **true**, the Apple Pay sheet displays a coupon code entry field. Requires iOS 15+. Defaults to **false**.                                                                                                                                                                                                                                                                             | No                                      |
+| `couponCode`                    | Pre-fills the coupon code field in the Apple Pay sheet. Requires iOS 15+.                                                                                                                                                                                                                                                                                                                   | No                                      |
 | `onShippingContactChange(contact, resolve) => {}` | Called when the shopper selects or updates a shipping contact. Call `resolve({ paymentSummaryItems?, shippingMethods?, errors? })` to update the sheet. Pass an empty array for `shippingMethods` to indicate no shipping is available. Omit fields to keep current values. | No                                      |
 | `onShippingMethodChange(shippingMethod, resolve) => {}` | Called when the shopper selects a shipping method. Call `resolve({ paymentSummaryItems? })` to update the sheet. Omit to keep current summary items. | No                                      |
+| `onCouponCodeChange(couponCode, resolve) => {}` | Called when the shopper enters or updates a coupon code. Requires `supportsCouponCode: true` and iOS 15+. Call `resolve({ paymentSummaryItems?, shippingMethods?, errors? })` to update the sheet. | No                                      |
 | `onAuthorize(payment, actions) => {}` | Called after the shopper authorizes the payment (Face ID / Touch ID), before it is submitted to Adyen. Call `actions.resolve()` to proceed or `actions.reject(errors?)` to show field-level errors and keep the sheet open. If omitted, the payment is automatically approved. | No                                      |
 
 #### ApplePay Recurring payment
@@ -242,6 +245,7 @@ const configuration = {
     ],
     requiredBillingContactFields: ['phoneticName', 'postalAddress'],
     requiredShippingContactFields: ['name', 'phone', 'email', 'postalAddress'],
+    supportsCouponCode: true,
     onShippingContactChange: (contact, resolve) => {
       resolve({
         shippingMethods: [
@@ -262,6 +266,13 @@ const configuration = {
           { label: '{YOUR_MERCHANT_NAME}', amount: 98 + shippingCost },
         ],
       });
+    },
+    onCouponCodeChange: (couponCode, resolve) => {
+      if (couponCode === 'SAVE10') {
+        resolve({ paymentSummaryItems: [{ label: '{YOUR_MERCHANT_NAME}', amount: 88.2 }] });
+      } else {
+        resolve({ errors: [{ type: 'couponCode', message: 'This coupon code is not valid.' }] });
+      }
     },
     onAuthorize: (payment, actions) => {
       // Optionally validate billing/shipping contact before submission.

--- a/example/ios/AdyenExampleTests/Modules/ApplePayModuleUtilitiesTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/ApplePayModuleUtilitiesTests.swift
@@ -88,6 +88,12 @@ final class ApplePayModuleUtilitiesTests: XCTestCase {
         XCTAssertNotNil(error)
     }
 
+    @available(iOS 15.0, *)
+    func test_applePayError_couponCode_returnsError() {
+        let error = applePayError(from: ["type": "couponCode", "message": "Invalid coupon"])
+        XCTAssertNotNil(error)
+    }
+
     func test_applePayError_shippingAddress_usesDefaultKey_whenFieldIsNil() {
         let error = applePayError(from: ["type": "shippingAddress", "message": "Error"])
         XCTAssertNotNil(error)

--- a/ios/AdyenModule.m
+++ b/ios/AdyenModule.m
@@ -66,6 +66,8 @@ RCT_EXTERN_METHOD(isAvailable:(nonnull NSDictionary *)paymentMethod
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(provideCouponCodeUpdate:(nonnull NSDictionary *)update)
+
 RCT_EXTERN_METHOD(provideShippingContactUpdate:(nonnull NSDictionary *)update)
 
 RCT_EXTERN_METHOD(provideShippingMethodUpdate:(nonnull NSDictionary *)update)

--- a/ios/Components/ApplePay/ApplePayModule+Delegates.swift
+++ b/ios/Components/ApplePay/ApplePayModule+Delegates.swift
@@ -93,6 +93,7 @@ extension ApplePayModule {
         let shippingMethods = parseShippingMethods(dict) ?? currentShippingMethods
         let errors = parseErrors(dict)
         DispatchQueue.main.async {
+            self.currentShippingMethods = shippingMethods
             handler(.init(errors: errors, paymentSummaryItems: summaryItems, shippingMethods: shippingMethods))
         }
     }

--- a/ios/Components/ApplePay/ApplePayModule+Delegates.swift
+++ b/ios/Components/ApplePay/ApplePayModule+Delegates.swift
@@ -42,6 +42,21 @@ extension ApplePayModule: ApplePayComponentDelegate {
     }
 }
 
+// MARK: - Coupon code delegate (iOS 15+)
+
+extension ApplePayModule {
+    @available(iOS 15.0, *)
+    func didUpdate(
+        couponCode: String,
+        for payment: ApplePayPayment,
+        completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void
+    ) {
+        couponCodeHandler = completion
+        currentApplePayPayment = payment
+        sendEvent(event: .updateCouponCode, body: [ApplePayKeys.couponCode: couponCode])
+    }
+}
+
 // MARK: - ApplePayAuthorizationDelegate
 
 extension ApplePayModule: ApplePayAuthorizationDelegate {
@@ -79,6 +94,20 @@ extension ApplePayModule {
         let status: PKPaymentAuthorizationStatus = success ? .success : .failure
         DispatchQueue.main.async {
             handler(PKPaymentAuthorizationResult(status: status, errors: errors))
+        }
+    }
+
+    @available(iOS 15.0, *)
+    @objc
+    func provideCouponCodeUpdate(_ update: NSDictionary) {
+        guard let handler = couponCodeHandler else { return }
+        couponCodeHandler = nil
+        let dict = update as? [String: Any] ?? [:]
+        let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
+        let shippingMethods = parseShippingMethods(dict) ?? currentShippingMethods
+        let errors = parseErrors(dict)
+        DispatchQueue.main.async {
+            handler(.init(errors: errors, paymentSummaryItems: summaryItems, shippingMethods: shippingMethods))
         }
     }
 

--- a/ios/Components/ApplePay/ApplePayModule+Delegates.swift
+++ b/ios/Components/ApplePay/ApplePayModule+Delegates.swift
@@ -33,20 +33,6 @@ extension ApplePayModule: ApplePayComponentDelegate {
 
     @available(iOS 15.0, *)
     func didUpdate(
-        couponCode _: String,
-        for payment: ApplePayPayment,
-        completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void
-    ) {
-        // Coupon code support is added in the next PR. Auto-resolve to keep the sheet responsive.
-        completion(.init(errors: nil, paymentSummaryItems: payment.summaryItems, shippingMethods: currentShippingMethods))
-    }
-}
-
-// MARK: - Coupon code delegate (iOS 15+)
-
-extension ApplePayModule {
-    @available(iOS 15.0, *)
-    func didUpdate(
         couponCode: String,
         for payment: ApplePayPayment,
         completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void

--- a/ios/Components/ApplePay/ApplePayModule.swift
+++ b/ios/Components/ApplePay/ApplePayModule.swift
@@ -17,6 +17,13 @@ internal class ApplePayModule: BaseModuleSender {
     internal var shippingContactHandler: ((PKPaymentRequestShippingContactUpdate) -> Void)?
     internal var shippingMethodHandler: ((PKPaymentRequestShippingMethodUpdate) -> Void)?
     internal var authorizationHandler: ((PKPaymentAuthorizationResult) -> Void)?
+    private var _couponCodeHandler: Any?
+    @available(iOS 15.0, *)
+    internal var couponCodeHandler: ((PKPaymentRequestCouponCodeUpdate) -> Void)? {
+        get { _couponCodeHandler as? (PKPaymentRequestCouponCodeUpdate) -> Void }
+        set { _couponCodeHandler = newValue }
+    }
+
     internal var currentApplePayPayment: ApplePayPayment?
     internal var currentShippingMethods: [PKShippingMethod] = []
 
@@ -62,6 +69,7 @@ internal class ApplePayModule: BaseModuleSender {
     override func cleanUp() {
         shippingContactHandler = nil
         shippingMethodHandler = nil
+        if #available(iOS 15.0, *) { couponCodeHandler = nil }
         authorizationHandler = nil
         currentApplePayPayment = nil
         currentShippingMethods = []

--- a/ios/Components/ApplePay/ApplePayModuleUtilities.swift
+++ b/ios/Components/ApplePay/ApplePayModuleUtilities.swift
@@ -84,6 +84,11 @@ internal func applePayError(from dict: [String: Any]) -> Error? {
         return PKPaymentRequest.paymentBillingAddressInvalidError(withKey: postalAddressKey(for: field), localizedDescription: message)
     case "contactField":
         return PKPaymentRequest.paymentContactInvalidError(withContactField: PKContactField.fromString(field ?? ""), localizedDescription: message)
+    case "couponCode":
+        if #available(iOS 15.0, *) {
+            return PKPaymentRequest.paymentCouponCodeInvalidError(localizedDescription: message)
+        }
+        return nil
     default:
         return nil
     }

--- a/ios/Components/Base/EventName.swift
+++ b/ios/Components/Base/EventName.swift
@@ -24,6 +24,7 @@ internal enum EventName: String, CaseIterable {
     case authorizePayment = "didAuthorizePaymentCallback"
     case updateShippingContact = "didUpdateShippingContactCallback"
     case updateShippingMethod = "didUpdateShippingMethodCallback"
+    case updateCouponCode = "didUpdateCouponCodeCallback"
 
     static var coreEvents: [EventName] {
         [.fail, .submit, .additionalDetails, .complete]
@@ -46,6 +47,6 @@ internal enum EventName: String, CaseIterable {
     }
 
     static var applePayEvents: [EventName] {
-        [.authorizePayment, .updateShippingContact, .updateShippingMethod]
+        [.authorizePayment, .updateShippingContact, .updateShippingMethod, .updateCouponCode]
     }
 }

--- a/ios/Configuration/ApplePay/ApplepayConfigurationParser.swift
+++ b/ios/Configuration/ApplePay/ApplepayConfigurationParser.swift
@@ -104,6 +104,14 @@ public struct ApplepayConfigurationParser {
         return shippingMethods.isEmpty ? nil : shippingMethods
     }
 
+    var supportsCouponCode: Bool {
+        dict[ApplePayKeys.supportsCouponCode] as? Bool ?? false
+    }
+
+    var couponCode: String? {
+        dict[ApplePayKeys.couponCode] as? String
+    }
+
     @available(iOS 16.0, *)
     var recurringPaymentRequest: PKRecurringPaymentRequest? {
         guard let recurringDict = dict[ApplePayKeys.recurringPaymentRequest] as? NSDictionary else {
@@ -151,6 +159,13 @@ public struct ApplepayConfigurationParser {
         paymentRequest.shippingType = shippingType ?? .shipping
         paymentRequest.supportedCountries = supportedCountries
         paymentRequest.shippingMethods = shippingMethods
+
+        if #available(iOS 15.0, *) {
+            paymentRequest.supportsCouponCode = supportsCouponCode
+            if let couponCode {
+                paymentRequest.couponCode = couponCode
+            }
+        }
 
         if #available(iOS 16.0, *), let recurringPaymentRequest {
             paymentRequest.recurringPaymentRequest = recurringPaymentRequest

--- a/ios/Configuration/Parameters.swift
+++ b/ios/Configuration/Parameters.swift
@@ -71,6 +71,8 @@ internal enum ApplePayKeys: SubConfig {
     static let shippingMethods = "shippingMethods"
     static let recurringPaymentRequest = "recurringPaymentRequest"
     static let shippingMethod = "shippingMethod"
+    static let supportsCouponCode = "supportsCouponCode"
+    static let couponCode = "couponCode"
 
     enum Update {
         static let paymentSummaryItems = "paymentSummaryItems"

--- a/src/components/__tests__/startEventListeners.test.ts
+++ b/src/components/__tests__/startEventListeners.test.ts
@@ -38,6 +38,7 @@ function createComponent(supported: Event[] = []) {
     handle: jest.fn(),
     provideShippingContactUpdate: jest.fn(),
     provideShippingMethodUpdate: jest.fn(),
+    provideCouponCodeUpdate: jest.fn(),
     provideAuthorizationResult: jest.fn(),
     removeStored: jest.fn(),
     provideBalance: jest.fn(),
@@ -261,6 +262,43 @@ describe('startEventListeners', () => {
     fire(Event.onApplePayShippingMethodChange, {});
 
     expect(component.provideShippingMethodUpdate).toHaveBeenCalledWith({});
+  });
+
+  // -------------------------------------------------------------------------
+  // Apple Pay — onCouponCodeChange
+  // -------------------------------------------------------------------------
+
+  test('onApplePayCouponCodeChange — calls user callback with coupon code string', () => {
+    const onCouponCodeChange = jest.fn();
+    const component = createComponent([Event.onApplePayCouponCodeChange]);
+    startEventListeners(component, createRefs({ onCouponCodeChange }));
+
+    fire(Event.onApplePayCouponCodeChange, { couponCode: 'SAVE10' });
+
+    expect(onCouponCodeChange).toHaveBeenCalledWith('SAVE10', expect.any(Function));
+  });
+
+  test('onApplePayCouponCodeChange — resolve calls provideCouponCodeUpdate', () => {
+    const component = createComponent([Event.onApplePayCouponCodeChange]);
+    const onCouponCodeChange = jest.fn((_code: any, resolve: any) =>
+      resolve({ errors: [{ type: 'couponCode', message: 'Invalid' }] })
+    );
+    startEventListeners(component, createRefs({ onCouponCodeChange }));
+
+    fire(Event.onApplePayCouponCodeChange, { couponCode: 'BADCODE' });
+
+    expect(component.provideCouponCodeUpdate).toHaveBeenCalledWith({
+      errors: [{ type: 'couponCode', message: 'Invalid' }],
+    });
+  });
+
+  test('onApplePayCouponCodeChange — auto-resolves with {} when no callback', () => {
+    const component = createComponent([Event.onApplePayCouponCodeChange]);
+    startEventListeners(component, createRefs({}));
+
+    fire(Event.onApplePayCouponCodeChange, { couponCode: 'CODE' });
+
+    expect(component.provideCouponCodeUpdate).toHaveBeenCalledWith({});
   });
 
   // -------------------------------------------------------------------------

--- a/src/components/utils/startEventListeners.ts
+++ b/src/components/utils/startEventListeners.ts
@@ -5,6 +5,7 @@ import type {
   AdyenActionComponent,
   AdyenError,
   ApplePayAuthorizationActions,
+  ApplePayCouponCodeUpdateRequest,
   ApplePayPaymentAuthorization,
   ApplePayPaymentContact,
   ApplePayShippingContactUpdateRequest,
@@ -169,6 +170,20 @@ export function startEventListeners(
 
   // Apple Pay delegate callbacks
   const applePayModule = nativeComponent as unknown as ApplePayModule;
+
+  subscribeIfSupported<string>(
+    Event.onApplePayCouponCodeChange,
+    (couponCode) => {
+      const resolve = (update: ApplePayCouponCodeUpdateRequest) =>
+        applePayModule.provideCouponCodeUpdate(update);
+      const callback = refs.config.current.applepay?.onCouponCodeChange;
+      if (callback) {
+        callback(couponCode, resolve);
+      } else {
+        resolve({});
+      }
+    }
+  );
 
   subscribeIfSupported<ApplePayPaymentContact>(
     Event.onApplePayShippingContactChange,

--- a/src/components/utils/startEventListeners.ts
+++ b/src/components/utils/startEventListeners.ts
@@ -171,14 +171,14 @@ export function startEventListeners(
   // Apple Pay delegate callbacks
   const applePayModule = nativeComponent as unknown as ApplePayModule;
 
-  subscribeIfSupported<string>(
+  subscribeIfSupported<{ couponCode: string }>(
     Event.onApplePayCouponCodeChange,
-    (couponCode) => {
+    (data) => {
       const resolve = (update: ApplePayCouponCodeUpdateRequest) =>
         applePayModule.provideCouponCodeUpdate(update);
       const callback = refs.config.current.applepay?.onCouponCodeChange;
       if (callback) {
-        callback(couponCode, resolve);
+        callback(data.couponCode, resolve);
       } else {
         resolve({});
       }

--- a/src/components/utils/startEventListeners.ts
+++ b/src/components/utils/startEventListeners.ts
@@ -5,6 +5,7 @@ import type {
   AdyenActionComponent,
   AdyenError,
   ApplePayAuthorizationActions,
+  ApplePayCouponCodeEvent,
   ApplePayCouponCodeUpdateRequest,
   ApplePayPaymentAuthorization,
   ApplePayPaymentContact,
@@ -171,7 +172,7 @@ export function startEventListeners(
   // Apple Pay delegate callbacks
   const applePayModule = nativeComponent as unknown as ApplePayModule;
 
-  subscribeIfSupported<{ couponCode: string }>(
+  subscribeIfSupported<ApplePayCouponCodeEvent>(
     Event.onApplePayCouponCodeChange,
     (data) => {
       const resolve = (update: ApplePayCouponCodeUpdateRequest) =>

--- a/src/core/configurations/ApplePayConfiguration.ts
+++ b/src/core/configurations/ApplePayConfiguration.ts
@@ -23,6 +23,10 @@ export interface ApplePayConfiguration {
   shippingMethods?: ApplePayShippingMethod[];
   /** An optional request to set up a recurring payment, typically a subscription. */
   recurringPaymentRequest?: ApplePayRecurringPaymentRequest;
+  /** Enable the coupon code entry field in the Apple Pay sheet (iOS 15+). */
+  supportsCouponCode?: boolean;
+  /** Pre-fill the coupon code field with this value (iOS 15+). */
+  couponCode?: string;
   /**
    * Called when the shopper selects or updates a shipping contact.
    * Call `resolve({ paymentSummaryItems, shippingMethods, errors })` to update the sheet.
@@ -38,6 +42,14 @@ export interface ApplePayConfiguration {
   onShippingMethodChange?: (
     shippingMethod: ApplePayShippingMethod,
     resolve: (update: ApplePayShippingMethodUpdateRequest) => void
+  ) => void;
+  /**
+   * Called when the shopper enters or changes a coupon code (iOS 15+).
+   * Call `resolve({ paymentSummaryItems, shippingMethods, errors })` to update the sheet.
+   */
+  onCouponCodeChange?: (
+    couponCode: string,
+    resolve: (update: ApplePayCouponCodeUpdateRequest) => void
   ) => void;
   /**
    * Called after the shopper authorizes the payment, before it is submitted to Adyen.
@@ -170,6 +182,16 @@ export interface ApplePayError {
 
 /** Data passed to the shipping contact callback. */
 export interface ApplePayShippingContactUpdateRequest {
+  /** Updated payment summary items. If omitted, the current items are kept. */
+  paymentSummaryItems?: ApplePaySummaryItem[];
+  /** Updated shipping methods. If omitted, the current methods are kept. */
+  shippingMethods?: ApplePayShippingMethod[];
+  /** Validation errors to display in the sheet. */
+  errors?: ApplePayError[];
+}
+
+/** Data passed to the coupon code callback. */
+export interface ApplePayCouponCodeUpdateRequest {
   /** Updated payment summary items. If omitted, the current items are kept. */
   paymentSummaryItems?: ApplePaySummaryItem[];
   /** Updated shipping methods. If omitted, the current methods are kept. */

--- a/src/core/configurations/ApplePayConfiguration.ts
+++ b/src/core/configurations/ApplePayConfiguration.ts
@@ -167,8 +167,9 @@ export interface ApplePayError {
    * - `shippingAddress` — an invalid field in the shipping postal address.
    * - `billingAddress` — an invalid field in the billing postal address.
    * - `contactField` — an invalid contact field (phone, email, name, etc.).
+   * - `couponCode` — an invalid or unrecognised coupon code (iOS 15+).
    */
-  type: 'shippingAddress' | 'billingAddress' | 'contactField';
+  type: 'shippingAddress' | 'billingAddress' | 'contactField' | 'couponCode';
   /**
    * For `shippingAddress` / `billingAddress`: the CNPostalAddress key of the invalid field
    * (e.g. `"postalCode"`, `"city"`, `"street"`, `"country"`, `"countryCode"`).

--- a/src/core/configurations/ApplePayConfiguration.ts
+++ b/src/core/configurations/ApplePayConfiguration.ts
@@ -190,6 +190,11 @@ export interface ApplePayShippingContactUpdateRequest {
   errors?: ApplePayError[];
 }
 
+/** Payload received from the native coupon code event. */
+export interface ApplePayCouponCodeEvent {
+  couponCode: string;
+}
+
 /** Data passed to the coupon code callback. */
 export interface ApplePayCouponCodeUpdateRequest {
   /** Updated payment summary items. If omitted, the current items are kept. */

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -34,6 +34,8 @@ export enum Event {
   onApplePayShippingContactChange = 'didUpdateShippingContactCallback',
   /** Apple Pay: called when the shopper selects or changes a shipping method. */
   onApplePayShippingMethodChange = 'didUpdateShippingMethodCallback',
+  /** Apple Pay: called when the shopper enters or changes a coupon code (iOS 15+). */
+  onApplePayCouponCodeChange = 'didUpdateCouponCodeCallback',
 }
 
 /** Collection of errors components can throw. */

--- a/src/modules/applepay/AdyenApplePay.ts
+++ b/src/modules/applepay/AdyenApplePay.ts
@@ -3,6 +3,7 @@ import { ModuleMock } from '../base/ModuleMock';
 import { ApplePayWrapper } from './ApplePayWrapper';
 import type {
   AdyenComponent,
+  ApplePayCouponCodeUpdateRequest,
   ApplePayShippingContactUpdateRequest,
   ApplePayShippingMethodUpdateRequest,
   ConditionalPaymentComponent,
@@ -11,6 +12,7 @@ import type { ApplePayAuthorizationResult } from './ApplePayInternalTypes';
 
 export interface ApplePayModule
   extends AdyenComponent, ConditionalPaymentComponent {
+  provideCouponCodeUpdate(update: ApplePayCouponCodeUpdateRequest): void;
   provideShippingContactUpdate(
     update: ApplePayShippingContactUpdateRequest
   ): void;

--- a/src/modules/applepay/ApplePayWrapper.ts
+++ b/src/modules/applepay/ApplePayWrapper.ts
@@ -1,5 +1,6 @@
 import type {
   AdyenActionComponent,
+  ApplePayCouponCodeUpdateRequest,
   ApplePayShippingContactUpdateRequest,
   ApplePayShippingMethodUpdateRequest,
   Configuration,
@@ -13,6 +14,7 @@ import type { PaymentModule } from '../base/PaymentComponentWrapper';
 
 /** Native module interface specific to ApplePay */
 interface ApplePayNativeModule extends ApplePayModule, PaymentModule {
+  provideCouponCodeUpdate(update: ApplePayCouponCodeUpdateRequest): void;
   provideShippingContactUpdate(
     update: ApplePayShippingContactUpdateRequest
   ): void;
@@ -40,6 +42,10 @@ export class ApplePayWrapper
           'This is likely a bug in your integration.'
       );
     }
+  }
+
+  provideCouponCodeUpdate(update: ApplePayCouponCodeUpdateRequest): void {
+    this.nativeModule.provideCouponCodeUpdate(update);
   }
 
   provideShippingContactUpdate(update: ApplePayShippingContactUpdateRequest): void {


### PR DESCRIPTION
Adds coupon code support to ApplePay (iOS 15+). Merchants can enable the coupon code field via supportsCouponCode, pre-fill it with couponCode, and react to changes via onCouponCodeChange. Auto-resolves with empty update if no callback configured.

Ticket: COSDK-473
Chain: 3/3 — targets `feat/applepay-shipping` (PR #1093).