### PR TITLE
fix: rename ADYCardViewCls to CardViewCls for Expo 52 compatibility

### DIFF
--- a/ios/Views/CardView/ADYCardView.mm
+++ b/ios/Views/CardView/ADYCardView.mm
@@ -86,8 +86,8 @@ using namespace facebook::react;
   return static_cast<const CardViewEventEmitter &>(*_eventEmitter);
 }
 
-Class<RCTComponentViewProtocol> ADYCardViewCls(void) {
+@end
+
+Class<RCTComponentViewProtocol> CardViewCls(void) {
   return ADYCardView.class;
 }
-
-@end


### PR DESCRIPTION
## Summary

`RCTThirdPartyFabricComponentsProvider` (auto-generated by RN codegen) expects a C function named `CardViewCls()`, derived from the component name `'CardView'` in the codegen spec. The function was named `ADYCardViewCls` and placed inside the `@implementation` block, causing a linker error on Expo 52 / RN 0.76 (New Architecture enabled by default):

```
Undefined symbols for architecture arm64:
  "_CardViewCls", referenced from:
      _RCTThirdPartyFabricComponentsProvider in libReact-RCTFabric.a
```

## Changes

- Renamed `ADYCardViewCls` → `CardViewCls` to match what codegen expects
- Moved the function outside `@implementation ADYCardView`, consistent with `PlatformPayViewCls` in `ADYPlatformPayView.mm`