### PR TITLE
chore: add label run-e2e-tests to SDK update PRs

### DIFF
--- a/.github/workflows/update_sdk_versions.yml
+++ b/.github/workflows/update_sdk_versions.yml
@@ -89,6 +89,7 @@ jobs:
         commit-message: "chore: update ${{ inputs.platform }} SDK to ${{ steps.fetch-version.outputs.version }}"
         title: "Update ${{ inputs.platform }} SDK to ${{ steps.fetch-version.outputs.version }}"
         branch: "update-${{ inputs.platform }}-${{ steps.fetch-version.outputs.version }}"
+        labels: run-e2e-tests
         add-paths: |
           README.md
           adyen-react-native.podspec


### PR DESCRIPTION
## Add `run-e2e-tests` label to SDK version update PRs

Automatically applies the `run-e2e-tests` label to pull requests created by the `Update SDK Versions` workflow.