### PR TITLE
docs: add card installment options to Configuration.md

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -52,6 +52,8 @@
 | `onConfirmAddress: (address, lookup) => {}` | The callback to confirm the selected `address` to the `lookup`. Used when `addressVisibility` is set to **lookup**                                        | No       |
 | `onBinLookup: (binData) => {}`              | An optional callback that is triggered when the BIN lookup data is available.                                                                             | No       |
 | `onBinValue: (binValue) => {}`              | An optional callback that is triggered when the BIN (first 6 or 8 PAN digits) typed by the shopper in the PAN field in `CardComponent` changes.           | No       |
+| `installmentOptions`                        | Configuration for installment options. Each key is a card brand (e.g., `"visa"`, `"mc"`, `"amex"`) or `"card"` for defaults that apply to all brands. Each entry has `values` (array of allowed installment counts) and optional `plans` (`"regular"` and/or `"revolving"`). | No       |
+| `showInstallmentAmount`                     | Indicates whether to show the installment amount in the payment form. Defaults to **false**.                                                              | No       |
 
 ### 3D Secure 2
 
@@ -166,6 +168,12 @@ const configuration = {
     onBinLookup: binData => {
       console.log('BIN data: ', JSON.stringify(binData));
     },
+    installmentOptions: {
+      card: { values: [2, 3] },
+      visa: { values: [2, 3, 4], plans: ['revolving'] },
+      mc: { values: [2, 3] },
+    },
+    showInstallmentAmount: true,
   },
   threeDS2: {
     requestorAppUrl: 'https://YOUR_UNIVERSAL_APP_LINK.com/',

--- a/src/components/__tests__/startEventListeners.test.ts
+++ b/src/components/__tests__/startEventListeners.test.ts
@@ -275,7 +275,10 @@ describe('startEventListeners', () => {
 
     fire(Event.onApplePayCouponCodeChange, { couponCode: 'SAVE10' });
 
-    expect(onCouponCodeChange).toHaveBeenCalledWith('SAVE10', expect.any(Function));
+    expect(onCouponCodeChange).toHaveBeenCalledWith(
+      'SAVE10',
+      expect.any(Function)
+    );
   });
 
   test('onApplePayCouponCodeChange — resolve calls provideCouponCodeUpdate', () => {

--- a/src/modules/applepay/AdyenApplePay.ts
+++ b/src/modules/applepay/AdyenApplePay.ts
@@ -16,7 +16,9 @@ export interface ApplePayModule
   provideShippingContactUpdate(
     update: ApplePayShippingContactUpdateRequest
   ): void;
-  provideShippingMethodUpdate(update: ApplePayShippingMethodUpdateRequest): void;
+  provideShippingMethodUpdate(
+    update: ApplePayShippingMethodUpdateRequest
+  ): void;
   provideAuthorizationResult(result: ApplePayAuthorizationResult): void;
 }
 

--- a/src/modules/applepay/ApplePayWrapper.ts
+++ b/src/modules/applepay/ApplePayWrapper.ts
@@ -18,7 +18,9 @@ interface ApplePayNativeModule extends ApplePayModule, PaymentModule {
   provideShippingContactUpdate(
     update: ApplePayShippingContactUpdateRequest
   ): void;
-  provideShippingMethodUpdate(update: ApplePayShippingMethodUpdateRequest): void;
+  provideShippingMethodUpdate(
+    update: ApplePayShippingMethodUpdateRequest
+  ): void;
   provideAuthorizationResult(result: ApplePayAuthorizationResult): void;
 }
 
@@ -48,11 +50,15 @@ export class ApplePayWrapper
     this.nativeModule.provideCouponCodeUpdate(update);
   }
 
-  provideShippingContactUpdate(update: ApplePayShippingContactUpdateRequest): void {
+  provideShippingContactUpdate(
+    update: ApplePayShippingContactUpdateRequest
+  ): void {
     this.nativeModule.provideShippingContactUpdate(update);
   }
 
-  provideShippingMethodUpdate(update: ApplePayShippingMethodUpdateRequest): void {
+  provideShippingMethodUpdate(
+    update: ApplePayShippingMethodUpdateRequest
+  ): void {
     this.nativeModule.provideShippingMethodUpdate(update);
   }
 

--- a/src/modules/applepay/__tests__/ApplePayWrapper.test.ts
+++ b/src/modules/applepay/__tests__/ApplePayWrapper.test.ts
@@ -81,20 +81,24 @@ describe('ApplePayWrapper', () => {
   describe('provideShippingContactUpdate', () => {
     test('should delegate to native module', () => {
       const wrapper = new ApplePayWrapper(mockNativeModule);
-      const update = { paymentSummaryItems: [{ label: 'Total', amount: '10' }] };
+      const update = {
+        paymentSummaryItems: [{ label: 'Total', amount: '10' }],
+      };
 
       wrapper.provideShippingContactUpdate(update as any);
 
-      expect(mockNativeModule.provideShippingContactUpdate).toHaveBeenCalledWith(
-        update
-      );
+      expect(
+        mockNativeModule.provideShippingContactUpdate
+      ).toHaveBeenCalledWith(update);
     });
   });
 
   describe('provideShippingMethodUpdate', () => {
     test('should delegate to native module', () => {
       const wrapper = new ApplePayWrapper(mockNativeModule);
-      const update = { paymentSummaryItems: [{ label: 'Total', amount: '15' }] };
+      const update = {
+        paymentSummaryItems: [{ label: 'Total', amount: '15' }],
+      };
 
       wrapper.provideShippingMethodUpdate(update as any);
 


### PR DESCRIPTION
## Summary

Adds documentation for `installmentOptions` and `showInstallmentAmount` card configuration parameters to `docs/Configuration.md`, including a description table entry and an example usage snippet.

Also includes prettier autofix for pre-existing lint errors in Apple Pay and test files.

## Testing

Docs-only change, no functional code modified.