### PR TITLE
fix: run cleanup on the main thread

### DIFF
--- a/example/ios/AdyenExample.xcodeproj/project.pbxproj
+++ b/example/ios/AdyenExample.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		82F3A2CBB5BB992B05F32EE3 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CF789D357E922939DFD4AED9 /* PrivacyInfo.xcprivacy */; };
 		945936B12AE185B700F3E676 /* ApplePayConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945936B02AE185B700F3E676 /* ApplePayConfigurationTests.swift */; };
 		94FC2FEC2AF28DAE009F6FC1 /* CardConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94FC2FEB2AF28DAE009F6FC1 /* CardConfigurationTests.swift */; };
+		E70D4FB42FF77A5D00C09021 /* ThreadingSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70D4FB32FF77A5D00C09021 /* ThreadingSafetyTests.swift */; };
 		E732B0CD2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E732B0CC2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift */; };
 		E741F0FE2E38DECD000D0F42 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E741F0FD2E38DEC6000D0F42 /* AppDelegate.swift */; };
 		E773B1092BE3B48900638431 /* DropInConfigurationParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E773B1082BE3B48900638431 /* DropInConfigurationParserTests.swift */; };
@@ -59,6 +60,7 @@
 		948B9B002A83D269003D15B4 /* AdyenExampleTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AdyenExampleTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		94FC2FEB2AF28DAE009F6FC1 /* CardConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardConfigurationTests.swift; sourceTree = "<group>"; };
 		CF789D357E922939DFD4AED9 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = AdyenExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		E70D4FB32FF77A5D00C09021 /* ThreadingSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadingSafetyTests.swift; sourceTree = "<group>"; };
 		E732B0CC2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayModuleUtilitiesTests.swift; sourceTree = "<group>"; };
 		E741F0FD2E38DEC6000D0F42 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E757C9D727737E6700B62256 /* AdyenExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = AdyenExample.entitlements; path = AdyenExample/AdyenExample.entitlements; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 				E77961CD2F334E4300728F99 /* BaseAddressLookupTests.swift */,
 				E77961CE2F334E4300728F99 /* BaseModuleSenderTests.swift */,
 				E77961CF2F334E4300728F99 /* MockEmitter.swift */,
+				E70D4FB32FF77A5D00C09021 /* ThreadingSafetyTests.swift */,
 				E7BBA45B2E8AB9040068997A /* ApplePayModuleTests.swift */,
 				E732B0CC2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift */,
 			);
@@ -464,6 +467,7 @@
 				E77961D02F334E4300728F99 /* BaseAddressLookupTests.swift in Sources */,
 				E77961D12F334E4300728F99 /* BaseModuleSenderTests.swift in Sources */,
 				E77961D22F334E4300728F99 /* MockEmitter.swift in Sources */,
+				E70D4FB42FF77A5D00C09021 /* ThreadingSafetyTests.swift in Sources */,
 				94FC2FEC2AF28DAE009F6FC1 /* CardConfigurationTests.swift in Sources */,
 				E77D207A2CDBB31900FED3F0 /* AnalyticsParserTests.swift in Sources */,
 				E77D207B2CDBB31900FED3F0 /* RootConfigurationtParserTests.swift in Sources */,
@@ -684,7 +688,7 @@
 					"$(inherited)",
 					" ",
 				);
-				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_VERSION = 5.0;
@@ -762,7 +766,7 @@
 					"$(inherited)",
 					" ",
 				);
-				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 5.0;

--- a/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
@@ -1,0 +1,91 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@testable import adyen_react_native
+import UIKit
+import XCTest
+
+final class ThreadingSafetyTests: XCTestCase {
+
+    override func tearDown() {
+        BaseModule.currentPresenter = nil
+        BaseModule.currentModule = nil
+        BaseModule.session = nil
+        EmbeddedComponentBusModule.shared = nil
+        super.tearDown()
+    }
+
+    func test_baseModuleCleanUp_fromBackgroundThread_dismissesPresenterOnMainThread() {
+        let expectation = expectation(description: "Presenter should be dismissed")
+        let sut = TestableBaseModule()
+        let presenter = MockPresenterViewController()
+        presenter.onDismiss = {
+            expectation.fulfill()
+        }
+        BaseModule.currentPresenter = presenter
+
+        DispatchQueue.global().async {
+            sut.cleanUp()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(presenter.dismissCalled)
+        XCTAssertTrue(presenter.dismissCalledOnMainThread)
+        XCTAssertNil(BaseModule.currentPresenter)
+    }
+
+    func test_embeddedComponentBusUnsubscribe_fromBackgroundThread_dismissesPresenterOnMainThread() {
+        let expectation = expectation(description: "Presenter should be dismissed")
+        let sut = EmbeddedComponentBusModule()
+        let presenter = MockPresenterViewController()
+        presenter.onDismiss = {
+            expectation.fulfill()
+        }
+        BaseModule.currentPresenter = presenter
+
+        sut.subscribe("card-view")
+
+        DispatchQueue.global().async {
+            sut.unsubscribe("card-view")
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(presenter.dismissCalled)
+        XCTAssertTrue(presenter.dismissCalledOnMainThread)
+        XCTAssertNil(BaseModule.currentPresenter)
+    }
+}
+
+private final class TestableBaseModule: BaseModule {
+    override init() {
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private final class MockPresenterViewController: UIViewController {
+    var dismissCalled = false
+    var dismissCalledOnMainThread = false
+    var onDismiss: (() -> Void)?
+
+    private var mockPresentedViewController: UIViewController? = UIViewController()
+
+    override var presentedViewController: UIViewController? {
+        mockPresentedViewController
+    }
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        dismissCalled = true
+        dismissCalledOnMainThread = Thread.isMainThread
+        mockPresentedViewController = nil
+        completion?()
+        onDismiss?()
+    }
+}

--- a/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
@@ -4,6 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@_spi(AdyenInternal) import Adyen
 @testable import adyen_react_native
 import UIKit
 import XCTest
@@ -57,6 +58,227 @@ final class ThreadingSafetyTests: XCTestCase {
         XCTAssertTrue(presenter.dismissCalledOnMainThread)
         XCTAssertNil(BaseModule.currentPresenter)
     }
+
+    func test_ensureMainThread_runsImmediately_whenAlreadyOnMainThread() {
+        let expectation = expectation(description: "Work should run immediately")
+
+        DispatchQueue.main.async {
+            var didRun = false
+
+            ensureMainThread {
+                didRun = true
+                XCTAssertTrue(Thread.isMainThread)
+            }
+
+            XCTAssertTrue(didRun)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_ensureMainThread_dispatchesWorkToMainThread_fromBackgroundThread() {
+        let expectation = expectation(description: "Work should run on main thread")
+
+        DispatchQueue.global().async {
+            ensureMainThread {
+                XCTAssertTrue(Thread.isMainThread)
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_baseModuleCleanUp_withoutPresentedViewController_clearsPresenter() {
+        let expectation = expectation(description: "Presenter should be cleared")
+
+        DispatchQueue.main.async {
+            let sut = TestableBaseModule()
+            BaseModule.currentPresenter = UIViewController()
+
+            sut.cleanUp()
+
+            XCTAssertNil(BaseModule.currentPresenter)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_embeddedComponentBusUpdate_fromBackgroundThread_callsLookupHandlerOnMainThread() {
+        let expectation = expectation(description: "Lookup handler should be called")
+        let sut = EmbeddedComponentBusModule()
+
+        sut.storeLookupHandler(for: "card-view") { addresses in
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(addresses.count, 1)
+            XCTAssertEqual(addresses.first?.postalAddress.street, "Main St")
+            expectation.fulfill()
+        }
+
+        DispatchQueue.global().async {
+            sut.update("card-view", results: [Self.lookupAddress] as NSArray)
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_embeddedComponentBusConfirmSuccess_fromBackgroundThread_callsCompletionOnMainThread() {
+        let expectation = expectation(description: "Completion handler should receive success")
+        let sut = EmbeddedComponentBusModule()
+
+        sut.storeLookupCompletionHandler(for: "card-view") { result in
+            XCTAssertTrue(Thread.isMainThread)
+            guard case let .success(address) = result else {
+                return XCTFail("Expected success result")
+            }
+            XCTAssertEqual(address.street, "Main St")
+            expectation.fulfill()
+        }
+
+        DispatchQueue.global().async {
+            sut.confirm("card-view", success: NSNumber(value: true), address: Self.lookupAddress)
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_embeddedComponentBusConfirmFailure_fromBackgroundThread_callsCompletionOnMainThread() {
+        let expectation = expectation(description: "Completion handler should receive failure")
+        let sut = EmbeddedComponentBusModule()
+
+        sut.storeLookupCompletionHandler(for: "card-view") { result in
+            XCTAssertTrue(Thread.isMainThread)
+            guard case let .failure(error) = result else {
+                return XCTFail("Expected failure result")
+            }
+            XCTAssertEqual(error.localizedDescription, "Address not found")
+            expectation.fulfill()
+        }
+
+        DispatchQueue.global().async {
+            sut.confirm(
+                "card-view",
+                success: NSNumber(value: false),
+                address: ["message": "Address not found"]
+            )
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_embeddedComponentBusHide_fromBackgroundThread_dismissesPresenterOnMainThread() {
+        let expectation = expectation(description: "Presenter should be dismissed")
+        let sut = EmbeddedComponentBusModule()
+        let presenter = MockPresenterViewController()
+        presenter.onDismiss = {
+            expectation.fulfill()
+        }
+        BaseModule.currentPresenter = presenter
+
+        _ = sut.register(viewId: "card-view")
+
+        DispatchQueue.global().async {
+            sut.hide("card-view", success: NSNumber(value: true), event: [:])
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(presenter.dismissCalled)
+        XCTAssertTrue(presenter.dismissCalledOnMainThread)
+        XCTAssertNil(BaseModule.currentPresenter)
+    }
+
+    func test_embeddedComponentBusHandle_withNilAction_doesNotEmitError() {
+        let expectation = expectation(description: "No error should be emitted")
+        let sut = EmbeddedComponentBusModule()
+        let emitter = MockEmitter()
+        sut.emitterOverride = emitter
+
+        DispatchQueue.global().async {
+            sut.handle("card-view", action: nil)
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(emitter.events.count, 0)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_embeddedComponentBusHandle_withoutActionHandler_emitsError() {
+        let expectation = expectation(description: "Error should be emitted")
+        let sut = EmbeddedComponentBusModule()
+        let emitter = MockEmitter()
+        sut.emitterOverride = emitter
+
+        DispatchQueue.global().async {
+            sut.handle("card-view", action: [:])
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(emitter.eventCount(named: EventName.fail.rawValue), 1)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_embeddedComponentBusHandle_withoutRegisteredProxy_emitsError() {
+        let expectation = expectation(description: "Error should be emitted")
+        let sut = EmbeddedComponentBusModule()
+        let emitter = MockEmitter()
+        sut.emitterOverride = emitter
+        sut.createActionHandlerIfNeeded(context: Self.context, locale: nil)
+
+        DispatchQueue.global().async {
+            sut.handle("card-view", action: [:])
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(emitter.eventCount(named: EventName.fail.rawValue), 1)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_embeddedComponentBusHandle_withInvalidAction_emitsError() {
+        let expectation = expectation(description: "Invalid action error should be emitted")
+        let sut = EmbeddedComponentBusModule()
+        let emitter = MockEmitter()
+        sut.emitterOverride = emitter
+        sut.createActionHandlerIfNeeded(context: Self.context, locale: nil)
+        _ = sut.register(viewId: "card-view")
+
+        DispatchQueue.global().async {
+            sut.handle("card-view", action: [:])
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(emitter.eventCount(named: EventName.fail.rawValue), 1)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    private static let lookupAddress: NSDictionary = [
+        "id": "addr1",
+        "address": [
+            "street": "Main St",
+            "houseNumberOrName": "123",
+            "city": "Amsterdam",
+            "postalCode": "1012AB",
+            "country": "NL"
+        ]
+    ]
+
+    private static let context = AdyenContext(
+        apiContext: try! APIContext(environment: Environment.test, clientKey: "local_DUMMYKEYFORTESTING"),
+        payment: nil
+    )
 }
 
 private final class TestableBaseModule: BaseModule {

--- a/ios/Components/Base/BaseModule.swift
+++ b/ios/Components/Base/BaseModule.swift
@@ -99,16 +99,8 @@ internal class BaseModule: RCTEventEmitter {
     }
 
     internal func cleanUp() {
-        BaseModule.session = nil
-        BaseModule.currentModule = nil
-        currentComponent = nil
-
-        guard BaseModule.currentPresenter?.presentedViewController != nil else {
-            BaseModule.currentPresenter = nil
-            return
-        }
-        BaseModule.currentPresenter?.dismiss(animated: true) {
-            BaseModule.currentPresenter = nil
+        ensureMainThread { [weak self] in
+            self?.cleanUpOnMainThread()
         }
     }
 
@@ -133,6 +125,21 @@ internal class BaseModule: RCTEventEmitter {
         }
         return error
     }
+
+    private func cleanUpOnMainThread() {
+        BaseModule.session = nil
+        BaseModule.currentModule = nil
+        currentComponent = nil
+
+        guard BaseModule.currentPresenter?.presentedViewController != nil else {
+            BaseModule.currentPresenter = nil
+            return
+        }
+
+        BaseModule.currentPresenter?.dismiss(animated: true) {
+            BaseModule.currentPresenter = nil
+        }
+    }
 }
 
 extension BaseModule: PresentationDelegate {
@@ -140,7 +147,7 @@ extension BaseModule: PresentationDelegate {
     internal func present(component: PresentableComponent) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            
+
             guard let presenter = BaseModule.currentPresenter ?? UIViewController.topPresenter else {
                 return self.sendError(error: ModuleException.notKeyWindow)
             }

--- a/ios/Components/Base/ThreadUtilities.swift
+++ b/ios/Components/Base/ThreadUtilities.swift
@@ -1,0 +1,15 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+internal func ensureMainThread(_ work: @escaping () -> Void) {
+    if Thread.isMainThread {
+        work()
+    } else {
+        DispatchQueue.main.async(execute: work)
+    }
+}

--- a/ios/Components/Embedded/EmbeddedComponentBusModule.swift
+++ b/ios/Components/Embedded/EmbeddedComponentBusModule.swift
@@ -12,6 +12,9 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
 
     static var shared: EmbeddedComponentBusModule?
 
+    // Main-thread-only mutable state. Access these properties via the `*OnMainThread` helpers
+    // or through JS entry points that dispatch with `ensureMainThread(_:)`.
+
     /// Per-viewId delegate proxies
     private var delegates: [String: EmbeddedComponentDelegateProxy] = [:]
 

--- a/ios/Components/Embedded/EmbeddedComponentBusModule.swift
+++ b/ios/Components/Embedded/EmbeddedComponentBusModule.swift
@@ -81,15 +81,15 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
 
     @objc
     func subscribe(_ viewId: String) {
-        subscribedViews.insert(viewId)
+        ensureMainThread { [weak self] in
+            self?.subscribeOnMainThread(viewId)
+        }
     }
 
     @objc
     func unsubscribe(_ viewId: String) {
-        subscribedViews.remove(viewId)
-        unregister(viewId: viewId)
-        if subscribedViews.isEmpty {
-            cleanUp()
+        ensureMainThread { [weak self] in
+            self?.unsubscribeOnMainThread(viewId)
         }
     }
 
@@ -97,6 +97,51 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
 
     @objc
     func handle(_ viewId: String, action actionDict: NSDictionary?) {
+        ensureMainThread { [weak self] in
+            self?.handleOnMainThread(viewId, action: actionDict)
+        }
+    }
+
+    @objc
+    func update(_ viewId: String, results: NSArray?) {
+        ensureMainThread { [weak self] in
+            self?.updateOnMainThread(viewId, results: results)
+        }
+    }
+
+    @objc
+    func confirm(_ viewId: String, success: NSNumber, address: NSDictionary) {
+        ensureMainThread { [weak self] in
+            self?.confirmOnMainThread(viewId, success: success, address: address)
+        }
+    }
+
+    @objc
+    func hide(_ viewId: String, success: NSNumber, event _: NSDictionary) {
+        ensureMainThread { [weak self] in
+            self?.hideOnMainThread(viewId, success: success)
+        }
+    }
+
+    override func cleanUp() {
+        ensureMainThread { [weak self] in
+            self?.cleanUpOnMainThread()
+        }
+    }
+
+    private func subscribeOnMainThread(_ viewId: String) {
+        subscribedViews.insert(viewId)
+    }
+
+    private func unsubscribeOnMainThread(_ viewId: String) {
+        subscribedViews.remove(viewId)
+        unregister(viewId: viewId)
+        if subscribedViews.isEmpty {
+            cleanUpOnMainThread()
+        }
+    }
+
+    private func handleOnMainThread(_ viewId: String, action actionDict: NSDictionary?) {
         guard let actionDict else { return }
         guard let handler = actionHandler else {
             sendError(error: ModuleException.componentNotRegistered(viewId))
@@ -108,51 +153,45 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
         }
         do {
             let action = try parseAction(from: actionDict)
-            DispatchQueue.main.async {
-                handler.delegate = proxy
-                handler.handle(action)
-            }
+            handler.delegate = proxy
+            handler.handle(action)
         } catch {
             sendError(error: error)
         }
     }
 
-    @objc
-    func update(_ viewId: String, results: NSArray?) {
+    private func updateOnMainThread(_ viewId: String, results: NSArray?) {
         guard let lookupHandler = lookupHandlers[viewId] else { return }
+
         let addressModels: [LookupAddressModel] = (results ?? [])
             .compactMap { $0 as? NSDictionary }
             .compactMap { try? $0.decode() }
-        DispatchQueue.main.async {
-            lookupHandler(addressModels)
-        }
+        lookupHandler(addressModels)
     }
 
-    @objc
-    func confirm(_ viewId: String, success: NSNumber, address: NSDictionary) {
+    private func confirmOnMainThread(_ viewId: String, success: NSNumber, address: NSDictionary) {
         guard let lookupCompletionHandler = lookupCompletionHandlers[viewId] else { return }
-        DispatchQueue.main.async {
-            if !success.boolValue, let message = address[Keys.message] as? String {
-                return lookupCompletionHandler(.failure(AddressError(message: message)))
-            }
-            do {
-                let addressModel: LookupAddressModel = try address.decode()
-                lookupCompletionHandler(.success(addressModel.postalAddress))
-            } catch {
-                lookupCompletionHandler(.failure(error))
-            }
+
+        if !success.boolValue, let message = address[Keys.message] as? String {
+            return lookupCompletionHandler(.failure(AddressError(message: message)))
+        }
+
+        do {
+            let addressModel: LookupAddressModel = try address.decode()
+            lookupCompletionHandler(.success(addressModel.postalAddress))
+        } catch {
+            lookupCompletionHandler(.failure(error))
         }
     }
 
-    @objc
-    func hide(_ viewId: String, success: NSNumber, event _: NSDictionary) {
+    private func hideOnMainThread(_ viewId: String, success: NSNumber) {
         unregister(viewId: viewId)
         if delegates.isEmpty {
             dismiss(success.boolValue)
         }
     }
 
-    override func cleanUp() {
+    private func cleanUpOnMainThread() {
         delegates.removeAll()
         subscribedViews.removeAll()
         actionHandler?.cancelIfNeeded()


### PR DESCRIPTION
## Summary
- route `BaseModule.cleanUp()` through a main-thread helper before dismissing the presenter
- serialize embedded component bus cleanup-related entry points onto the main thread
- add iOS regression coverage for background-thread `cleanUp()` and `unsubscribe()` calls

## Ticket
- COIOS-902

## Notes
- simulator crash was reproducible before this fix.