### PR TITLE
feat: add PayByBank instant payment component fragment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ example/package-lock.json
 #Example credentials
 example/secrets.json
 example/android/gradlew.bat
+example/android/gradle/gradle-daemon-jvm.properties

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
@@ -69,7 +69,7 @@ abstract class BaseComponentFragment<TComponent, TState : PaymentComponentState<
     savedInstanceState: Bundle?,
   ) {
     super.onViewCreated(view, savedInstanceState)
-    view.findViewById<ImageButton>(R.id.close_button).setOnClickListener {
+    view.findViewById<ImageButton>(R.id.close_button)?.setOnClickListener {
       viewModel.cancel()
     }
     viewLifecycleOwner.lifecycleScope.launch {

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
@@ -6,10 +6,12 @@
 
 package com.adyenreactnativesdk.component.base.instant
 
+import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageButton
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -45,6 +47,11 @@ abstract class BaseComponentFragment<TComponent, TState : PaymentComponentState<
       return if (session == null) advancedViewModel else sessionViewModel
     }
 
+  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
+    super.onCreateDialog(savedInstanceState).also {
+      it.setCanceledOnTouchOutside(false)
+    }
+
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
@@ -56,6 +63,9 @@ abstract class BaseComponentFragment<TComponent, TState : PaymentComponentState<
     savedInstanceState: Bundle?,
   ) {
     super.onViewCreated(view, savedInstanceState)
+    view.findViewById<ImageButton>(R.id.close_button).setOnClickListener {
+      viewModel.cancel()
+    }
     viewLifecycleOwner.lifecycleScope.launch {
       repeatOnLifecycle(Lifecycle.State.STARTED) {
         launch { viewModel.componentDataFlow.collect(::setupComponent) }

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
@@ -7,6 +7,7 @@
 package com.adyenreactnativesdk.component.base.instant
 
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -51,6 +52,11 @@ abstract class BaseComponentFragment<TComponent, TState : PaymentComponentState<
     super.onCreateDialog(savedInstanceState).also {
       it.setCanceledOnTouchOutside(false)
     }
+
+  override fun onCancel(dialog: DialogInterface) {
+    super.onCancel(dialog)
+    viewModel.cancel()
+  }
 
   override fun onCreateView(
     inflater: LayoutInflater,

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/viewmodel/AdvancedComponentViewModel.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/viewmodel/AdvancedComponentViewModel.kt
@@ -46,6 +46,10 @@ class AdvancedComponentViewModel<TState : PaymentComponentState<*>> :
     AdyenPaymentPackage.messageBus.onException(exception)
   }
 
+  override fun cancel() {
+    AdyenPaymentPackage.messageBus.onException(ModuleException.Canceled())
+  }
+
   companion object {
     private const val TAG = "AdvancedViewModel"
   }

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/viewmodel/BaseViewModel.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/viewmodel/BaseViewModel.kt
@@ -33,6 +33,8 @@ internal interface ViewModelInterface<TState : PaymentComponentState<*>> {
 
   fun componentStarted()
 
+  fun cancel()
+
   val events: Flow<ComponentEvent>
   val componentDataFlow: Flow<ComponentData<TState>>
 }
@@ -58,6 +60,8 @@ abstract class BaseViewModel<TState : PaymentComponentState<*>> :
       _events.emit(ComponentEvent.ComponentCreated)
     }
   }
+
+  abstract override fun cancel()
 
   protected suspend fun emitData(componentData: ComponentData<TState>) {
     _componentDataFlow.emit(componentData)

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/viewmodel/SessionsComponentViewModel.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/viewmodel/SessionsComponentViewModel.kt
@@ -42,6 +42,10 @@ class SessionsComponentViewModel<TState : PaymentComponentState<*>> :
     AdyenPaymentPackage.messageBus.onSessionException(exception)
   }
 
+  override fun cancel() {
+    AdyenPaymentPackage.messageBus.onSessionException(ModuleException.Canceled())
+  }
+
   companion object {
     private const val TAG = "SessionsViewModel"
   }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
@@ -14,7 +14,8 @@ import com.adyenreactnativesdk.component.base.ModuleException
 import com.adyenreactnativesdk.component.base.instant.IInstantFragment
 import com.adyenreactnativesdk.component.instant.fragment.IdealFragment
 import com.adyenreactnativesdk.component.instant.fragment.InstantFragment
-import com.adyenreactnativesdk.component.instant.fragment.PayByBankFragment
+import com.adyenreactnativesdk.component.instant.fragment.PayByBankGlobalFragment
+import com.adyenreactnativesdk.component.instant.fragment.PayByBankUSFragment
 import com.adyenreactnativesdk.component.instant.fragment.TwintFragment
 import com.adyenreactnativesdk.configuration.CheckoutConfigurationFactory
 import com.adyenreactnativesdk.util.messaging.MessageBus
@@ -57,7 +58,8 @@ class InstantModule(
     fragment =
       when (paymentMethod.type) {
         PaymentMethodTypes.IDEAL -> IdealFragment
-        PaymentMethodTypes.PAY_BY_BANK_US -> PayByBankFragment
+        PaymentMethodTypes.PAY_BY_BANK -> PayByBankGlobalFragment
+        PaymentMethodTypes.PAY_BY_BANK_US -> PayByBankUSFragment
         PaymentMethodTypes.TWINT -> TwintFragment
         else -> InstantFragment
       }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
@@ -14,6 +14,7 @@ import com.adyenreactnativesdk.component.base.ModuleException
 import com.adyenreactnativesdk.component.base.instant.IInstantFragment
 import com.adyenreactnativesdk.component.instant.fragment.IdealFragment
 import com.adyenreactnativesdk.component.instant.fragment.InstantFragment
+import com.adyenreactnativesdk.component.instant.fragment.PayByBankFragment
 import com.adyenreactnativesdk.component.instant.fragment.TwintFragment
 import com.adyenreactnativesdk.configuration.CheckoutConfigurationFactory
 import com.adyenreactnativesdk.util.messaging.MessageBus
@@ -56,6 +57,7 @@ class InstantModule(
     fragment =
       when (paymentMethod.type) {
         PaymentMethodTypes.IDEAL -> IdealFragment
+        PaymentMethodTypes.PAY_BY_BANK_US -> PayByBankFragment
         PaymentMethodTypes.TWINT -> TwintFragment
         else -> InstantFragment
       }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/InstantModule.kt
@@ -55,14 +55,7 @@ class InstantModule(
       return sendError(e)
     }
 
-    fragment =
-      when (paymentMethod.type) {
-        PaymentMethodTypes.IDEAL -> IdealFragment
-        PaymentMethodTypes.PAY_BY_BANK -> PayByBankGlobalFragment
-        PaymentMethodTypes.PAY_BY_BANK_US -> PayByBankUSFragment
-        PaymentMethodTypes.TWINT -> TwintFragment
-        else -> InstantFragment
-      }
+    fragment = fragmentForType(paymentMethod.type)
 
     currentModule = this
     fragment?.show(
@@ -96,5 +89,14 @@ class InstantModule(
   companion object {
     private const val COMPONENT_NAME = "AdyenInstant"
     private var fragment: IInstantFragment? = null
+
+    internal fun fragmentForType(type: String?): IInstantFragment =
+      when (type) {
+        PaymentMethodTypes.IDEAL -> IdealFragment
+        PaymentMethodTypes.PAY_BY_BANK -> PayByBankGlobalFragment
+        PaymentMethodTypes.PAY_BY_BANK_US -> PayByBankUSFragment
+        PaymentMethodTypes.TWINT -> TwintFragment
+        else -> InstantFragment
+      }
   }
 }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/PayByBankFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/PayByBankFragment.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ */
+
+package com.adyenreactnativesdk.component.instant.fragment
+
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import com.adyen.checkout.components.core.ComponentCallback
+import com.adyen.checkout.components.core.PaymentMethod
+import com.adyen.checkout.paybybankus.PayByBankUSComponent
+import com.adyen.checkout.paybybankus.PayByBankUSComponentState
+import com.adyen.checkout.sessions.core.CheckoutSession
+import com.adyen.checkout.sessions.core.SessionComponentCallback
+import com.adyenreactnativesdk.component.base.instant.BaseInstantComponentFragment
+import com.adyenreactnativesdk.component.base.instant.IInstantFragment
+import com.adyenreactnativesdk.component.base.instant.InstantFragmentDelegate
+
+class PayByBankFragment(
+  configuration: CheckoutConfiguration,
+  paymentMethod: PaymentMethod,
+  session: CheckoutSession?,
+) : BaseInstantComponentFragment<PayByBankUSComponent, PayByBankUSComponentState>(configuration, paymentMethod, session) {
+  override val logTag: String = TAG
+
+  override fun createComponent(
+    paymentMethod: PaymentMethod,
+    configuration: CheckoutConfiguration,
+    callback: ComponentCallback<PayByBankUSComponentState>,
+  ): PayByBankUSComponent =
+    PayByBankUSComponent.PROVIDER.get(
+      this,
+      paymentMethod,
+      configuration,
+      callback,
+    )
+
+  override fun createComponent(
+    session: CheckoutSession,
+    paymentMethod: PaymentMethod,
+    configuration: CheckoutConfiguration,
+    callback: SessionComponentCallback<PayByBankUSComponentState>,
+  ): PayByBankUSComponent =
+    PayByBankUSComponent.PROVIDER.get(
+      this,
+      session,
+      paymentMethod,
+      configuration,
+      callback,
+    )
+
+  companion object : IInstantFragment by InstantFragmentDelegate(
+    "PayByBankFragment",
+    ::PayByBankFragment,
+  ) {
+    internal const val TAG = "PayByBankFragment"
+  }
+}

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/PayByBankGlobalFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/PayByBankGlobalFragment.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ */
+
+package com.adyenreactnativesdk.component.instant.fragment
+
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import com.adyen.checkout.components.core.ComponentCallback
+import com.adyen.checkout.components.core.PaymentMethod
+import com.adyen.checkout.paybybank.PayByBankComponent
+import com.adyen.checkout.paybybank.PayByBankComponentState
+import com.adyen.checkout.sessions.core.CheckoutSession
+import com.adyen.checkout.sessions.core.SessionComponentCallback
+import com.adyenreactnativesdk.component.base.instant.BaseInstantComponentFragment
+import com.adyenreactnativesdk.component.base.instant.IInstantFragment
+import com.adyenreactnativesdk.component.base.instant.InstantFragmentDelegate
+
+class PayByBankGlobalFragment(
+  configuration: CheckoutConfiguration,
+  paymentMethod: PaymentMethod,
+  session: CheckoutSession?,
+) : BaseInstantComponentFragment<PayByBankComponent, PayByBankComponentState>(configuration, paymentMethod, session) {
+  override val logTag: String = TAG
+
+  override fun createComponent(
+    paymentMethod: PaymentMethod,
+    configuration: CheckoutConfiguration,
+    callback: ComponentCallback<PayByBankComponentState>,
+  ): PayByBankComponent =
+    PayByBankComponent.PROVIDER.get(
+      this,
+      paymentMethod,
+      configuration,
+      callback,
+    )
+
+  override fun createComponent(
+    session: CheckoutSession,
+    paymentMethod: PaymentMethod,
+    configuration: CheckoutConfiguration,
+    callback: SessionComponentCallback<PayByBankComponentState>,
+  ): PayByBankComponent =
+    PayByBankComponent.PROVIDER.get(
+      this,
+      session,
+      paymentMethod,
+      configuration,
+      callback,
+    )
+
+  companion object : IInstantFragment by InstantFragmentDelegate(
+    "PayByBankGlobalFragment",
+    ::PayByBankGlobalFragment,
+  ) {
+    internal const val TAG = "PayByBankGlobalFragment"
+  }
+}

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/PayByBankUSFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/PayByBankUSFragment.kt
@@ -18,7 +18,7 @@ import com.adyenreactnativesdk.component.base.instant.BaseInstantComponentFragme
 import com.adyenreactnativesdk.component.base.instant.IInstantFragment
 import com.adyenreactnativesdk.component.base.instant.InstantFragmentDelegate
 
-class PayByBankFragment(
+class PayByBankUSFragment(
   configuration: CheckoutConfiguration,
   paymentMethod: PaymentMethod,
   session: CheckoutSession?,
@@ -52,9 +52,9 @@ class PayByBankFragment(
     )
 
   companion object : IInstantFragment by InstantFragmentDelegate(
-    "PayByBankFragment",
-    ::PayByBankFragment,
+    "PayByBankUSFragment",
+    ::PayByBankUSFragment,
   ) {
-    internal const val TAG = "PayByBankFragment"
+    internal const val TAG = "PayByBankUSFragment"
   }
 }

--- a/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
@@ -23,12 +23,6 @@ class ActionFragment(
   private var actionHandled: Boolean = false
   var component: GenericActionComponent? = null
 
-  override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?,
-  ): View = inflater.inflate(R.layout.fragment_instant, container)
-
   override fun onStart() {
     super.onStart()
 

--- a/android/src/main/res/drawable/ic_close.xml
+++ b/android/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright (c) 2025 Adyen N.V.
+  ~
+  ~ This file is open source and available under the MIT license. See the LICENSE file for more info.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorOnSurface"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
+
+</vector>

--- a/android/src/main/res/layout/fragment_instant.xml
+++ b/android/src/main/res/layout/fragment_instant.xml
@@ -10,6 +10,18 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <ImageButton
+        android:id="@+id/close_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@android:string/cancel"
+        android:padding="8dp"
+        android:src="@drawable/ic_close"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <ScrollView
         android:id="@+id/component_container"
         android:layout_width="match_parent"
@@ -17,7 +29,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/close_button">
 
         <com.adyen.checkout.ui.core.AdyenComponentView
             android:id="@+id/component_view"

--- a/android/src/test/java/com/adyenreactnativesdk/component/base/viewmodel/AdvancedComponentViewModelTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/component/base/viewmodel/AdvancedComponentViewModelTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ */
+
+package com.adyenreactnativesdk.component.base.viewmodel
+
+import com.adyenreactnativesdk.AdyenPaymentPackage
+import com.adyenreactnativesdk.component.base.ModuleException
+import com.adyenreactnativesdk.util.messaging.MessageBus
+import com.adyenreactnativesdk.util.messaging.MockEmitter
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AdvancedComponentViewModelTest {
+  private lateinit var mockEmitter: MockEmitter
+
+  @Before
+  fun setUp() {
+    mockEmitter = MockEmitter()
+    injectMessageBus(MessageBus(mockEmitter))
+  }
+
+  @After
+  fun tearDown() {
+    injectMessageBus(null)
+  }
+
+  @Test
+  fun `cancel sends Canceled exception via messageBus`() {
+    // GIVEN
+    val sut = AdvancedComponentViewModel<Nothing>()
+
+    // WHEN
+    sut.cancel()
+
+    // THEN
+    assertEquals(1, mockEmitter.errors.size)
+    assertTrue(mockEmitter.errors[0].error is ModuleException.Canceled)
+  }
+
+  /**
+   * Injects [bus] into [AdyenPaymentPackage]'s companion-object backing field via reflection.
+   * The `@Volatile private var _messageBus` compiles to a static field on the outer JVM class.
+   */
+  private fun injectMessageBus(bus: MessageBus?) {
+    val field = AdyenPaymentPackage::class.java.getDeclaredField("_messageBus")
+    field.isAccessible = true
+    field.set(null, bus)
+  }
+}

--- a/android/src/test/java/com/adyenreactnativesdk/component/base/viewmodel/SessionsComponentViewModelTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/component/base/viewmodel/SessionsComponentViewModelTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ */
+
+package com.adyenreactnativesdk.component.base.viewmodel
+
+import com.adyenreactnativesdk.AdyenPaymentPackage
+import com.adyenreactnativesdk.component.base.ModuleException
+import com.adyenreactnativesdk.util.messaging.MessageBus
+import com.adyenreactnativesdk.util.messaging.MockEmitter
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SessionsComponentViewModelTest {
+  private lateinit var mockEmitter: MockEmitter
+
+  @Before
+  fun setUp() {
+    mockEmitter = MockEmitter()
+    injectMessageBus(MessageBus(mockEmitter))
+  }
+
+  @After
+  fun tearDown() {
+    injectMessageBus(null)
+  }
+
+  @Test
+  fun `cancel sends Canceled exception via messageBus onSessionException`() {
+    // GIVEN
+    val sut = SessionsComponentViewModel<Nothing>()
+
+    // WHEN
+    sut.cancel()
+
+    // THEN
+    assertEquals(1, mockEmitter.errors.size)
+    assertTrue(mockEmitter.errors[0].error is ModuleException.Canceled)
+  }
+
+  /**
+   * Injects [bus] into [AdyenPaymentPackage]'s companion-object backing field via reflection.
+   * The `@Volatile private var _messageBus` compiles to a static field on the outer JVM class.
+   */
+  private fun injectMessageBus(bus: MessageBus?) {
+    val field = AdyenPaymentPackage::class.java.getDeclaredField("_messageBus")
+    field.isAccessible = true
+    field.set(null, bus)
+  }
+}

--- a/android/src/test/java/com/adyenreactnativesdk/component/instant/InstantModuleTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/component/instant/InstantModuleTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ */
+
+package com.adyenreactnativesdk.component.instant
+
+import com.adyen.checkout.components.core.PaymentMethodTypes
+import com.adyenreactnativesdk.component.instant.fragment.IdealFragment
+import com.adyenreactnativesdk.component.instant.fragment.InstantFragment
+import com.adyenreactnativesdk.component.instant.fragment.PayByBankGlobalFragment
+import com.adyenreactnativesdk.component.instant.fragment.PayByBankUSFragment
+import com.adyenreactnativesdk.component.instant.fragment.TwintFragment
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InstantModuleTest {
+  @Test
+  fun `fragmentForType returns IdealFragment for IDEAL`() {
+    assertEquals(IdealFragment, InstantModule.fragmentForType(PaymentMethodTypes.IDEAL))
+  }
+
+  @Test
+  fun `fragmentForType returns PayByBankGlobalFragment for PAY_BY_BANK`() {
+    assertEquals(PayByBankGlobalFragment, InstantModule.fragmentForType(PaymentMethodTypes.PAY_BY_BANK))
+  }
+
+  @Test
+  fun `fragmentForType returns PayByBankUSFragment for PAY_BY_BANK_US`() {
+    assertEquals(PayByBankUSFragment, InstantModule.fragmentForType(PaymentMethodTypes.PAY_BY_BANK_US))
+  }
+
+  @Test
+  fun `fragmentForType returns TwintFragment for TWINT`() {
+    assertEquals(TwintFragment, InstantModule.fragmentForType(PaymentMethodTypes.TWINT))
+  }
+
+  @Test
+  fun `fragmentForType returns InstantFragment for unrecognised type`() {
+    assertEquals(InstantFragment, InstantModule.fragmentForType("unknown_payment_method"))
+  }
+
+  @Test
+  fun `fragmentForType returns InstantFragment for null type`() {
+    assertEquals(InstantFragment, InstantModule.fragmentForType(null))
+  }
+}

--- a/example/ios/AdyenExample.xcodeproj/project.pbxproj
+++ b/example/ios/AdyenExample.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		E70D4FB42FF77A5D00C09021 /* ThreadingSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70D4FB32FF77A5D00C09021 /* ThreadingSafetyTests.swift */; };
 		E732B0CD2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E732B0CC2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift */; };
 		E741F0FE2E38DECD000D0F42 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E741F0FD2E38DEC6000D0F42 /* AppDelegate.swift */; };
+		E745059C2FF3C380009FC440 /* InstantModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E745059B2FF3C380009FC440 /* InstantModuleTests.swift */; };
+		E745059D2FF3C380009FC440 /* BaseModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E745059A2FF3C380009FC440 /* BaseModuleTests.swift */; };
 		E773B1092BE3B48900638431 /* DropInConfigurationParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E773B1082BE3B48900638431 /* DropInConfigurationParserTests.swift */; };
 		E77961D02F334E4300728F99 /* BaseAddressLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77961CD2F334E4300728F99 /* BaseAddressLookupTests.swift */; };
 		E77961D12F334E4300728F99 /* BaseModuleSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77961CE2F334E4300728F99 /* BaseModuleSenderTests.swift */; };
@@ -63,6 +65,8 @@
 		E70D4FB32FF77A5D00C09021 /* ThreadingSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadingSafetyTests.swift; sourceTree = "<group>"; };
 		E732B0CC2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayModuleUtilitiesTests.swift; sourceTree = "<group>"; };
 		E741F0FD2E38DEC6000D0F42 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E745059A2FF3C380009FC440 /* BaseModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseModuleTests.swift; sourceTree = "<group>"; };
+		E745059B2FF3C380009FC440 /* InstantModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantModuleTests.swift; sourceTree = "<group>"; };
 		E757C9D727737E6700B62256 /* AdyenExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = AdyenExample.entitlements; path = AdyenExample/AdyenExample.entitlements; sourceTree = "<group>"; };
 		E773B1082BE3B48900638431 /* DropInConfigurationParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropInConfigurationParserTests.swift; sourceTree = "<group>"; };
 		E77961CD2F334E4300728F99 /* BaseAddressLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAddressLookupTests.swift; sourceTree = "<group>"; };
@@ -214,6 +218,8 @@
 		E7BBA45C2E8AB9040068997A /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				E745059A2FF3C380009FC440 /* BaseModuleTests.swift */,
+				E745059B2FF3C380009FC440 /* InstantModuleTests.swift */,
 				E77961D32F336F8000728F99 /* BaseModuleSenderDelegatesTests.swift */,
 				E77961CD2F334E4300728F99 /* BaseAddressLookupTests.swift */,
 				E77961CE2F334E4300728F99 /* BaseModuleSenderTests.swift */,
@@ -476,6 +482,8 @@
 				E788D7AD2C77515800FE9BC6 /* ApplePayRecurringConfigurationParserTests.swift in Sources */,
 				E732B0CD2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift in Sources */,
 				945936B12AE185B700F3E676 /* ApplePayConfigurationTests.swift in Sources */,
+				E745059C2FF3C380009FC440 /* InstantModuleTests.swift in Sources */,
+				E745059D2FF3C380009FC440 /* BaseModuleTests.swift in Sources */,
 				E77AE1202E605FCD00607717 /* EncodablePaymentComponentDataTests.swift in Sources */,
 				E773B1092BE3B48900638431 /* DropInConfigurationParserTests.swift in Sources */,
 				E7BBA45D2E8AB9040068997A /* ApplePayModuleTests.swift in Sources */,

--- a/example/ios/AdyenExampleTests/Modules/BaseModuleTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/BaseModuleTests.swift
@@ -121,21 +121,6 @@ final class BaseModuleTests: XCTestCase {
         XCTAssertNil(sut.currentComponent)
     }
 
-    func test_cleanUp_withEmptyStack_stillClearsStaticState() {
-        let exp = expectation(description: "cleanUp completes")
-        BaseModule.currentModule = sut
-        sut.currentComponent = MockComponent()
-
-        DispatchQueue.main.async {
-            self.sut.cleanUp()
-            exp.fulfill()
-        }
-
-        wait(for: [exp], timeout: 1.0)
-        XCTAssertNil(BaseModule.currentModule)
-        XCTAssertNil(sut.currentComponent)
-    }
-
     // MARK: - dismiss
 
     func test_dismiss_withNoCurrentComponent_callsCleanUp() {
@@ -149,24 +134,6 @@ final class BaseModuleTests: XCTestCase {
 
         wait(for: [exp], timeout: 1.0)
         XCTAssertNil(BaseModule.currentModule)
-    }
-
-    func test_dismiss_fromBackgroundThread_clearsStateOnMainThread() {
-        let exp = expectation(description: "state cleared on main thread")
-        BaseModule.currentModule = sut
-        var clearedOnMain = false
-
-        // Observe via a mock that verifies the clear happens on the main thread
-        DispatchQueue.global().async {
-            self.sut.dismiss(false)
-            DispatchQueue.main.async {
-                clearedOnMain = Thread.isMainThread && BaseModule.currentModule == nil
-                exp.fulfill()
-            }
-        }
-
-        wait(for: [exp], timeout: 1.0)
-        XCTAssertTrue(clearedOnMain)
     }
 
     // MARK: - checkErrorType
@@ -358,7 +325,7 @@ private final class MockDismissableViewController: UIViewController {
 
 private final class MockComponent: Component {
     var context: AdyenContext = .init(
-      apiContext: try! APIContext(environment: Environment.test, clientKey: "local_DUMMYKEYFORTESTING"),
+        apiContext: try! APIContext(environment: Environment.test, clientKey: "local_DUMMYKEYFORTESTING"),
         payment: nil
     )
 }

--- a/example/ios/AdyenExampleTests/Modules/BaseModuleTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/BaseModuleTests.swift
@@ -1,0 +1,390 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import XCTest
+@_spi(AdyenInternal) import Adyen
+@testable import adyen_react_native
+import UIKit
+
+final class BaseModuleTests: XCTestCase {
+
+    var sut: TestableModule!
+
+    override func setUp() {
+        super.setUp()
+        sut = TestableModule()
+    }
+
+    override func tearDown() {
+        sut = nil
+        BaseModule.presenterStack.removeAll()
+        BaseModule.currentModule = nil
+        BaseModule.session = nil
+        BaseModule.topPresenterProvider = { UIViewController.topPresenter }
+        super.tearDown()
+    }
+
+    // MARK: - presenterStack / currentPresenter
+
+    func test_currentPresenter_isNil_whenStackIsEmpty() {
+        XCTAssertTrue(BaseModule.presenterStack.isEmpty)
+        XCTAssertNil(BaseModule.currentPresenter)
+    }
+
+    func test_currentPresenter_returnsSingleEntry() {
+        let vc = UIViewController()
+        BaseModule.presenterStack = [vc]
+        XCTAssertTrue(BaseModule.currentPresenter === vc)
+    }
+
+    func test_currentPresenter_returnsLastEntry_withMultipleVCs() {
+        let first = UIViewController()
+        let last = UIViewController()
+        BaseModule.presenterStack = [first, UIViewController(), last]
+        XCTAssertTrue(BaseModule.currentPresenter === last)
+    }
+
+    // MARK: - cleanUp — presenterStack state
+
+    func test_cleanUp_withEmptyStack_doesNotCrash() {
+        let exp = expectation(description: "cleanUp on main thread")
+        BaseModule.presenterStack = []
+
+        DispatchQueue.main.async {
+            self.sut.cleanUp()
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(BaseModule.presenterStack.isEmpty)
+    }
+
+    func test_cleanUp_clearsEntireStack() {
+        let exp = expectation(description: "cleanUp on main thread")
+        BaseModule.presenterStack = [UIViewController(), UIViewController(), UIViewController()]
+
+        DispatchQueue.main.async {
+            self.sut.cleanUp()
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(BaseModule.presenterStack.isEmpty)
+    }
+
+    /// Verifies the linked-list dismissal: only presenterStack.first receives `dismiss`.
+    func test_cleanUp_withMultipleVCsInStack_dismissesOnlyFirstVC() {
+        let exp = expectation(description: "first VC dismissed")
+        let rootMock = MockDismissableViewController()
+        let paymentMock = MockDismissableViewController()
+        rootMock.onDismiss = { exp.fulfill() }
+        BaseModule.presenterStack = [rootMock, paymentMock]
+
+        DispatchQueue.main.async {
+            self.sut.cleanUp()
+        }
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(rootMock.dismissCalled, "Root (first) VC should be dismissed")
+        XCTAssertFalse(paymentMock.dismissCalled, "Payment (last) VC should NOT be dismissed directly")
+        XCTAssertTrue(BaseModule.presenterStack.isEmpty)
+    }
+
+    // MARK: - cleanUp — static state
+
+    func test_cleanUp_clearsCurrentModule() {
+        let exp = expectation(description: "cleanUp completes")
+        BaseModule.currentModule = sut
+
+        DispatchQueue.main.async {
+            self.sut.cleanUp()
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertNil(BaseModule.currentModule)
+    }
+
+    func test_cleanUp_clearsCurrentComponent() {
+        let exp = expectation(description: "cleanUp completes")
+        sut.currentComponent = MockComponent()
+
+        DispatchQueue.main.async {
+            self.sut.cleanUp()
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertNil(sut.currentComponent)
+    }
+
+    func test_cleanUp_withEmptyStack_stillClearsStaticState() {
+        let exp = expectation(description: "cleanUp completes")
+        BaseModule.currentModule = sut
+        sut.currentComponent = MockComponent()
+
+        DispatchQueue.main.async {
+            self.sut.cleanUp()
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertNil(BaseModule.currentModule)
+        XCTAssertNil(sut.currentComponent)
+    }
+
+    // MARK: - dismiss
+
+    func test_dismiss_withNoCurrentComponent_callsCleanUp() {
+        let exp = expectation(description: "dismiss completes")
+        BaseModule.currentModule = sut
+
+        DispatchQueue.global().async {
+            self.sut.dismiss(false)
+            DispatchQueue.main.async { exp.fulfill() }
+        }
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertNil(BaseModule.currentModule)
+    }
+
+    func test_dismiss_fromBackgroundThread_clearsStateOnMainThread() {
+        let exp = expectation(description: "state cleared on main thread")
+        BaseModule.currentModule = sut
+        var clearedOnMain = false
+
+        // Observe via a mock that verifies the clear happens on the main thread
+        DispatchQueue.global().async {
+            self.sut.dismiss(false)
+            DispatchQueue.main.async {
+                clearedOnMain = Thread.isMainThread && BaseModule.currentModule == nil
+                exp.fulfill()
+            }
+        }
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(clearedOnMain)
+    }
+
+    // MARK: - checkErrorType
+
+    func test_checkErrorType_componentCancelled_returnsCanceled() {
+        let result = sut.checkErrorType(ComponentError.cancelled)
+        XCTAssertEqual((result as? KnownError)?.errorCode, "canceledByShopper")
+    }
+
+    func test_checkErrorType_otherError_returnsOriginalError() {
+        let original = NSError(domain: "test.domain", code: 42)
+        let result = sut.checkErrorType(original)
+        XCTAssertTrue((result as NSError) === original)
+    }
+
+    // MARK: - hide
+
+    func test_hide_success_callsDismiss_andClearsState() {
+        let exp = expectation(description: "hide clears state")
+        let rootMock = MockDismissableViewController()
+        rootMock.onDismiss = { exp.fulfill() }
+        BaseModule.presenterStack = [rootMock]
+
+        DispatchQueue.main.async {
+            self.sut.hide(NSNumber(value: true), event: [:])
+        }
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(rootMock.dismissCalled)
+        XCTAssertTrue(BaseModule.presenterStack.isEmpty)
+    }
+
+    func test_hide_withEmptyStack_doesNotCrash() {
+        let exp = expectation(description: "hide completes without crash")
+
+        DispatchQueue.main.async {
+            self.sut.hide(NSNumber(value: false), event: [:])
+            DispatchQueue.main.async { exp.fulfill() }
+        }
+
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    // MARK: - present(component:) via PresentationDelegate
+
+    func test_present_requiresModal_wrapsComponentInNavigationController() {
+        let exp = expectation(description: "presenter.present called")
+        let mockPresenter = MockPresentingViewController()
+        mockPresenter.onPresent = { _ in exp.fulfill() }
+        let mockComponent = MockPresentableComponent(requiresModalPresentation: true)
+        BaseModule.presenterStack = [mockPresenter]
+
+        sut.present(component: mockComponent)
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(mockPresenter.lastPresentedViewController is UINavigationController)
+        let nav = mockPresenter.lastPresentedViewController as? UINavigationController
+        XCTAssertTrue(nav?.viewControllers.first === mockComponent.viewController)
+    }
+
+    func test_present_requiresModal_addsRightCancelBarButton() {
+        let exp = expectation(description: "presenter.present called")
+        let mockPresenter = MockPresentingViewController()
+        mockPresenter.onPresent = { _ in exp.fulfill() }
+        let mockComponent = MockPresentableComponent(requiresModalPresentation: true)
+        BaseModule.presenterStack = [mockPresenter]
+
+        sut.present(component: mockComponent)
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertNotNil(mockComponent.viewController.navigationItem.rightBarButtonItem)
+    }
+
+    func test_present_noModalRequired_presentsComponentViewControllerDirectly() {
+        let exp = expectation(description: "presenter.present called")
+        let mockPresenter = MockPresentingViewController()
+        mockPresenter.onPresent = { _ in exp.fulfill() }
+        let mockComponent = MockPresentableComponent(requiresModalPresentation: false)
+        BaseModule.presenterStack = [mockPresenter]
+
+        sut.present(component: mockComponent)
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(mockPresenter.lastPresentedViewController === mockComponent.viewController)
+    }
+
+    func test_present_appendsPresentedViewControllerToStack() {
+        let exp = expectation(description: "stack updated")
+        let mockPresenter = MockPresentingViewController()
+        mockPresenter.onPresent = { _ in exp.fulfill() }
+        let mockComponent = MockPresentableComponent(requiresModalPresentation: false)
+        BaseModule.presenterStack = [mockPresenter]
+
+        sut.present(component: mockComponent)
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(BaseModule.presenterStack.count, 2)
+        XCTAssertTrue(BaseModule.presenterStack.first === mockPresenter)
+        XCTAssertTrue(BaseModule.presenterStack.last === mockComponent.viewController)
+    }
+
+    func test_present_setsCurrentModule() {
+        let exp = expectation(description: "present dispatched")
+        let mockPresenter = MockPresentingViewController()
+        mockPresenter.onPresent = { _ in exp.fulfill() }
+        BaseModule.presenterStack = [mockPresenter]
+
+        sut.present(component: MockPresentableComponent(requiresModalPresentation: false))
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(BaseModule.currentModule === sut)
+    }
+
+    func test_present_withEmptyStack_usesTopPresenterProvider() {
+        let exp = expectation(description: "topPresenter used when stack is empty")
+        let injectedPresenter = MockPresentingViewController()
+        injectedPresenter.onPresent = { _ in exp.fulfill() }
+        // Stack is empty → falls through to topPresenterProvider
+        BaseModule.presenterStack = []
+        BaseModule.topPresenterProvider = { injectedPresenter }
+
+        sut.present(component: MockPresentableComponent(requiresModalPresentation: false))
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(injectedPresenter.presentCalled)
+        // topPresenter itself is pushed as the first stack entry, then the presented VC
+        XCTAssertEqual(BaseModule.presenterStack.count, 2)
+        XCTAssertTrue(BaseModule.presenterStack.first === injectedPresenter)
+    }
+
+    func test_present_withNoPresenterAndNoTopPresenter_sendsNotKeyWindowError() {
+        let exp = expectation(description: "error sent")
+        let mockEmitter = MockEmitter()
+        sut.emitterOverride = mockEmitter
+        BaseModule.presenterStack = []
+        BaseModule.topPresenterProvider = { nil }
+
+        sut.present(component: MockPresentableComponent(requiresModalPresentation: false))
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(mockEmitter.eventCount(named: EventName.fail.rawValue), 1)
+    }
+
+    func test_present_usesCurrentPresenter_fromStack() {
+        let exp = expectation(description: "correct presenter used")
+        let firstPresenter = MockPresentingViewController()
+        let secondPresenter = MockPresentingViewController()
+        secondPresenter.onPresent = { _ in exp.fulfill() }
+        // secondPresenter is last → currentPresenter
+        BaseModule.presenterStack = [firstPresenter, secondPresenter]
+
+        sut.present(component: MockPresentableComponent(requiresModalPresentation: false))
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertFalse(firstPresenter.presentCalled, "First VC should not be used as presenter")
+        XCTAssertTrue(secondPresenter.presentCalled, "Last (current) VC should be used as presenter")
+    }
+}
+
+// MARK: - Helpers
+
+private final class TestableModule: BaseModuleSender {
+    override init() {
+        super.init()
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) {
+        fatalError()
+    }
+}
+
+private final class MockDismissableViewController: UIViewController {
+    var dismissCalled = false
+    var onDismiss: (() -> Void)?
+
+    private var _presentedVC: UIViewController? = UIViewController()
+    override var presentedViewController: UIViewController? {
+        _presentedVC
+    }
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        dismissCalled = true
+        _presentedVC = nil
+        completion?()
+        onDismiss?()
+    }
+}
+
+private final class MockComponent: Component {
+    var context: AdyenContext = .init(
+        apiContext: try! APIContext(environment: .test, clientKey: "local_DUMMYKEYFORTESTING"),
+        payment: nil
+    )
+}
+
+private final class MockPresentingViewController: UIViewController {
+    var presentCalled = false
+    var lastPresentedViewController: UIViewController?
+    var onPresent: ((UIViewController) -> Void)?
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        presentCalled = true
+        lastPresentedViewController = viewControllerToPresent
+        completion?()
+        onPresent?(viewControllerToPresent)
+    }
+}
+
+private final class MockPresentableComponent: PresentableComponent {
+    var context: AdyenContext = .init(
+        apiContext: try! APIContext(environment: .test, clientKey: "local_DUMMYKEYFORTESTING"),
+        payment: nil
+    )
+    let viewController = UIViewController()
+    let requiresModalPresentation: Bool
+
+    init(requiresModalPresentation: Bool) {
+        self.requiresModalPresentation = requiresModalPresentation
+    }
+}

--- a/example/ios/AdyenExampleTests/Modules/BaseModuleTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/BaseModuleTests.swift
@@ -11,7 +11,7 @@ import UIKit
 
 final class BaseModuleTests: XCTestCase {
 
-    var sut: TestableModule!
+    private var sut: TestableModule!
 
     override func setUp() {
         super.setUp()
@@ -358,7 +358,7 @@ private final class MockDismissableViewController: UIViewController {
 
 private final class MockComponent: Component {
     var context: AdyenContext = .init(
-        apiContext: try! APIContext(environment: .test, clientKey: "local_DUMMYKEYFORTESTING"),
+      apiContext: try! APIContext(environment: Environment.test, clientKey: "local_DUMMYKEYFORTESTING"),
         payment: nil
     )
 }
@@ -378,7 +378,7 @@ private final class MockPresentingViewController: UIViewController {
 
 private final class MockPresentableComponent: PresentableComponent {
     var context: AdyenContext = .init(
-        apiContext: try! APIContext(environment: .test, clientKey: "local_DUMMYKEYFORTESTING"),
+        apiContext: try! APIContext(environment: Environment.test, clientKey: "local_DUMMYKEYFORTESTING"),
         payment: nil
     )
     let viewController = UIViewController()

--- a/example/ios/AdyenExampleTests/Modules/InstantModuleTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/InstantModuleTests.swift
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import XCTest
+@testable @_spi(AdyenInternal) import Adyen
+@testable import adyen_react_native
+
+final class InstantModuleTests: XCTestCase {
+
+    // MARK: - flow(for:)
+
+    func test_flow_payByBankUS() throws {
+        // GIVEN – decode from JSON so we don't depend on any internal init
+        let dict: NSDictionary = ["type": "paybybank_AIS_DD", "name": "Pay By Bank US"]
+        let method: PayByBankUSPaymentMethod = try dict.decode()
+
+        // WHEN
+        let flow = InstantModule.flow(for: method)
+
+        // THEN
+        guard case .payByBankUS = flow else {
+            return XCTFail("Expected .payByBankUS, got \(flow)")
+        }
+    }
+
+    func test_flow_issuerList() throws {
+        // GIVEN – IssuerListPaymentMethod only has init(from:), so use JSON decode
+        let dict: NSDictionary = ["type": "ideal", "name": "iDEAL", "issuers": []]
+        let method: IssuerListPaymentMethod = try dict.decode()
+
+        // WHEN
+        let flow = InstantModule.flow(for: method)
+
+        // THEN
+        guard case .issuerList = flow else {
+            return XCTFail("Expected .issuerList, got \(flow)")
+        }
+    }
+
+    func test_flow_instant_fallsBackForUnknownType() {
+        // GIVEN – InstantPaymentMethod is the SDK's generic fallback type
+        let method = InstantPaymentMethod(type: .payPal, name: "PayPal")
+
+        // WHEN
+        let flow = InstantModule.flow(for: method)
+
+        // THEN
+        guard case .instant = flow else {
+            return XCTFail("Expected .instant, got \(flow)")
+        }
+    }
+}

--- a/example/ios/AdyenExampleTests/Modules/InstantModuleTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/InstantModuleTests.swift
@@ -25,111 +25,94 @@ final class InstantModuleTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - flow(for:)
+    // MARK: - PaymentFlowType.init(_:)
 
-    func test_flow_payByBankUS() throws {
+    func test_flowType_payByBankUS() throws {
         // GIVEN
         let dict: NSDictionary = ["type": "paybybank_AIS_DD", "name": "Pay By Bank US"]
         let method: PayByBankUSPaymentMethod = try dict.decode()
 
         // WHEN
-        let flow = InstantModule.flow(for: method)
+        let flowType = InstantModule.PaymentFlowType(method)
 
         // THEN
-        guard case .payByBankUS = flow else {
-            return XCTFail("Expected .payByBankUS, got \(flow)")
+        guard case .payByBankUS = flowType else {
+            return XCTFail("Expected .payByBankUS, got \(flowType)")
         }
     }
 
-    func test_flow_issuerList() throws {
+    func test_flowType_issuerList() throws {
         // GIVEN
         let dict: NSDictionary = ["type": "ideal", "name": "iDEAL", "issuers": []]
         let method: IssuerListPaymentMethod = try dict.decode()
 
         // WHEN
-        let flow = InstantModule.flow(for: method)
+        let flowType = InstantModule.PaymentFlowType(method)
 
         // THEN
-        guard case .issuerList = flow else {
-            return XCTFail("Expected .issuerList, got \(flow)")
+        guard case .issuerList = flowType else {
+            return XCTFail("Expected .issuerList, got \(flowType)")
         }
     }
 
-    func test_flow_instant_fallsBackForUnknownType() {
+    func test_flowType_instant_fallsBackForUnknownType() {
         // GIVEN
         let method = InstantPaymentMethod(type: .payPal, name: "PayPal")
 
         // WHEN
-        let flow = InstantModule.flow(for: method)
+        let flowType = InstantModule.PaymentFlowType(method)
 
         // THEN
-        guard case .instant = flow else {
-            return XCTFail("Expected .instant, got \(flow)")
+        guard case .instant = flowType else {
+            return XCTFail("Expected .instant, got \(flowType)")
         }
     }
 
-    // MARK: - Flow.launchStyle
+    // MARK: - PaymentFlowType.buildFlow(with:)
 
-    func test_launchStyle_payByBankUS() throws {
-        // GIVEN
-        let dict: NSDictionary = ["type": "paybybank_AIS_DD", "name": "Pay By Bank US"]
-        let method: PayByBankUSPaymentMethod = try dict.decode()
-
-        // WHEN / THEN
-        XCTAssertEqual(InstantModule.Flow.payByBankUS(method).launchStyle, .present)
-    }
-
-    func test_launchStyle_issuerList() throws {
-        // GIVEN
-        let dict: NSDictionary = ["type": "ideal", "name": "iDEAL", "issuers": []]
-        let method: IssuerListPaymentMethod = try dict.decode()
-
-        // WHEN / THEN
-        XCTAssertEqual(InstantModule.Flow.issuerList(method).launchStyle, .present)
-    }
-
-    func test_launchStyle_instant() {
-        // GIVEN
-        let method = InstantPaymentMethod(type: .payPal, name: "PayPal")
-
-        // WHEN / THEN
-        XCTAssertEqual(InstantModule.Flow.instant(method).launchStyle, .initiatePayment)
-    }
-
-    // MARK: - makeComponent(for:context:)
-
-    func test_makeComponent_payByBankUS() throws {
+    func test_buildFlow_payByBankUS() throws {
         // GIVEN
         let dict: NSDictionary = ["type": "paybybank_AIS_DD", "name": "Pay By Bank US"]
         let method: PayByBankUSPaymentMethod = try dict.decode()
 
         // WHEN
-        let component = InstantModule.makeComponent(for: .payByBankUS(method), context: context)
+        let flow = InstantModule.PaymentFlowType.payByBankUS(method).buildFlow(with: context)
 
         // THEN
+        guard case let .present(component) = flow else {
+            return XCTFail("Expected .present, got \(flow)")
+        }
         XCTAssertTrue(component is PayByBankUSComponent, "Expected PayByBankUSComponent, got \(type(of: component))")
+        XCTAssertTrue(flow.paymentComponent is PayByBankUSComponent, "Expected paymentComponent to be PayByBankUSComponent, got \(type(of: flow.paymentComponent))")
     }
 
-    func test_makeComponent_issuerList() throws {
+    func test_buildFlow_issuerList() throws {
         // GIVEN
         let dict: NSDictionary = ["type": "ideal", "name": "iDEAL", "issuers": []]
         let method: IssuerListPaymentMethod = try dict.decode()
 
         // WHEN
-        let component = InstantModule.makeComponent(for: .issuerList(method), context: context)
+        let flow = InstantModule.PaymentFlowType.issuerList(method).buildFlow(with: context)
 
         // THEN
+        guard case let .present(component) = flow else {
+            return XCTFail("Expected .present, got \(flow)")
+        }
         XCTAssertTrue(component is IssuerListComponent, "Expected IssuerListComponent, got \(type(of: component))")
+        XCTAssertTrue(flow.paymentComponent is IssuerListComponent, "Expected paymentComponent to be IssuerListComponent, got \(type(of: flow.paymentComponent))")
     }
 
-    func test_makeComponent_instant() {
+    func test_buildFlow_instant() {
         // GIVEN
         let method = InstantPaymentMethod(type: .payPal, name: "PayPal")
 
         // WHEN
-        let component = InstantModule.makeComponent(for: .instant(method), context: context)
+        let flow = InstantModule.PaymentFlowType.instant(method).buildFlow(with: context)
 
         // THEN
-        XCTAssertTrue(component is InstantPaymentComponent, "Expected InstantPaymentComponent, got \(type(of: component))")
+        guard case let .submit(instant) = flow else {
+            return XCTFail("Expected .submit, got \(flow)")
+        }
+        XCTAssertTrue(flow.paymentComponent is InstantPaymentComponent, "Expected paymentComponent to be InstantPaymentComponent, got \(type(of: flow.paymentComponent))")
     }
 }

--- a/example/ios/AdyenExampleTests/Modules/InstantModuleTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/InstantModuleTests.swift
@@ -10,10 +10,25 @@ import XCTest
 
 final class InstantModuleTests: XCTestCase {
 
+    // MARK: - Setup
+
+    private var context: AdyenContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let apiContext = try APIContext(environment: Environment.test, clientKey: "test_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        context = AdyenContext(apiContext: apiContext, payment: nil)
+    }
+
+    override func tearDown() {
+        context = nil
+        super.tearDown()
+    }
+
     // MARK: - flow(for:)
 
     func test_flow_payByBankUS() throws {
-        // GIVEN – decode from JSON so we don't depend on any internal init
+        // GIVEN
         let dict: NSDictionary = ["type": "paybybank_AIS_DD", "name": "Pay By Bank US"]
         let method: PayByBankUSPaymentMethod = try dict.decode()
 
@@ -27,7 +42,7 @@ final class InstantModuleTests: XCTestCase {
     }
 
     func test_flow_issuerList() throws {
-        // GIVEN – IssuerListPaymentMethod only has init(from:), so use JSON decode
+        // GIVEN
         let dict: NSDictionary = ["type": "ideal", "name": "iDEAL", "issuers": []]
         let method: IssuerListPaymentMethod = try dict.decode()
 
@@ -41,7 +56,7 @@ final class InstantModuleTests: XCTestCase {
     }
 
     func test_flow_instant_fallsBackForUnknownType() {
-        // GIVEN – InstantPaymentMethod is the SDK's generic fallback type
+        // GIVEN
         let method = InstantPaymentMethod(type: .payPal, name: "PayPal")
 
         // WHEN
@@ -51,5 +66,70 @@ final class InstantModuleTests: XCTestCase {
         guard case .instant = flow else {
             return XCTFail("Expected .instant, got \(flow)")
         }
+    }
+
+    // MARK: - Flow.launchStyle
+
+    func test_launchStyle_payByBankUS() throws {
+        // GIVEN
+        let dict: NSDictionary = ["type": "paybybank_AIS_DD", "name": "Pay By Bank US"]
+        let method: PayByBankUSPaymentMethod = try dict.decode()
+
+        // WHEN / THEN
+        XCTAssertEqual(InstantModule.Flow.payByBankUS(method).launchStyle, .present)
+    }
+
+    func test_launchStyle_issuerList() throws {
+        // GIVEN
+        let dict: NSDictionary = ["type": "ideal", "name": "iDEAL", "issuers": []]
+        let method: IssuerListPaymentMethod = try dict.decode()
+
+        // WHEN / THEN
+        XCTAssertEqual(InstantModule.Flow.issuerList(method).launchStyle, .present)
+    }
+
+    func test_launchStyle_instant() {
+        // GIVEN
+        let method = InstantPaymentMethod(type: .payPal, name: "PayPal")
+
+        // WHEN / THEN
+        XCTAssertEqual(InstantModule.Flow.instant(method).launchStyle, .initiatePayment)
+    }
+
+    // MARK: - makeComponent(for:context:)
+
+    func test_makeComponent_payByBankUS() throws {
+        // GIVEN
+        let dict: NSDictionary = ["type": "paybybank_AIS_DD", "name": "Pay By Bank US"]
+        let method: PayByBankUSPaymentMethod = try dict.decode()
+
+        // WHEN
+        let component = InstantModule.makeComponent(for: .payByBankUS(method), context: context)
+
+        // THEN
+        XCTAssertTrue(component is PayByBankUSComponent, "Expected PayByBankUSComponent, got \(type(of: component))")
+    }
+
+    func test_makeComponent_issuerList() throws {
+        // GIVEN
+        let dict: NSDictionary = ["type": "ideal", "name": "iDEAL", "issuers": []]
+        let method: IssuerListPaymentMethod = try dict.decode()
+
+        // WHEN
+        let component = InstantModule.makeComponent(for: .issuerList(method), context: context)
+
+        // THEN
+        XCTAssertTrue(component is IssuerListComponent, "Expected IssuerListComponent, got \(type(of: component))")
+    }
+
+    func test_makeComponent_instant() {
+        // GIVEN
+        let method = InstantPaymentMethod(type: .payPal, name: "PayPal")
+
+        // WHEN
+        let component = InstantModule.makeComponent(for: .instant(method), context: context)
+
+        // THEN
+        XCTAssertTrue(component is InstantPaymentComponent, "Expected InstantPaymentComponent, got \(type(of: component))")
     }
 }

--- a/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class ThreadingSafetyTests: XCTestCase {
 
     override func tearDown() {
-        BaseModule.currentPresenter = nil
+        BaseModule.presenterStack.removeAll()
         BaseModule.currentModule = nil
         BaseModule.session = nil
         EmbeddedComponentBusModule.shared = nil
@@ -26,7 +26,7 @@ final class ThreadingSafetyTests: XCTestCase {
         presenter.onDismiss = {
             expectation.fulfill()
         }
-        BaseModule.currentPresenter = presenter
+        BaseModule.presenterStack = [presenter]
 
         DispatchQueue.global().async {
             sut.cleanUp()
@@ -45,7 +45,7 @@ final class ThreadingSafetyTests: XCTestCase {
         presenter.onDismiss = {
             expectation.fulfill()
         }
-        BaseModule.currentPresenter = presenter
+        BaseModule.presenterStack = [presenter]
 
         sut.subscribe("card-view")
 
@@ -95,7 +95,7 @@ final class ThreadingSafetyTests: XCTestCase {
 
         DispatchQueue.main.async {
             let sut = TestableBaseModule()
-            BaseModule.currentPresenter = UIViewController()
+            BaseModule.presenterStack = [UIViewController()]
 
             sut.cleanUp()
 
@@ -175,7 +175,7 @@ final class ThreadingSafetyTests: XCTestCase {
         presenter.onDismiss = {
             expectation.fulfill()
         }
-        BaseModule.currentPresenter = presenter
+        BaseModule.presenterStack = [presenter]
 
         _ = sut.register(viewId: "card-view")
 

--- a/example/src/components/Checkout/AdvancedCheckout.tsx
+++ b/example/src/components/Checkout/AdvancedCheckout.tsx
@@ -123,6 +123,7 @@ const AdvancedCheckout = () => {
           showDropIn={true}
           showEmbeddedComponents={true}
           showDropBasedComponents={true}
+          showInstant={true}
         />
       </AdyenCheckout>
     </View>

--- a/example/src/components/Checkout/SessionsComponentsCheckout.tsx
+++ b/example/src/components/Checkout/SessionsComponentsCheckout.tsx
@@ -90,7 +90,7 @@ const SessionsComponentsCheckout = () => {
         onComplete={didComplete}
         onError={didFail}
       >
-        <CheckoutNavigator showEmbeddedComponents={true} />
+        <CheckoutNavigator showEmbeddedComponents={true} showInstant={true} />
       </AdyenCheckout>
     </View>
   );

--- a/example/src/components/Checkout/components/PaymentMethodsList.tsx
+++ b/example/src/components/Checkout/components/PaymentMethodsList.tsx
@@ -5,10 +5,14 @@ import PaymentMethodListItem from './PaymentMethodListItem';
 import Styles from '../../common/Styles';
 
 interface PaymentMethodsListProps {
+  title: string;
   paymentMethods: PaymentMethod[] | undefined;
 }
 
-const PaymentMethodsList = ({ paymentMethods }: PaymentMethodsListProps) => {
+const PaymentMethodsList = ({
+  title,
+  paymentMethods,
+}: PaymentMethodsListProps) => {
   const { start } = useAdyenCheckout();
 
   if (!paymentMethods) {
@@ -17,7 +21,7 @@ const PaymentMethodsList = ({ paymentMethods }: PaymentMethodsListProps) => {
 
   return (
     <View>
-      <AdaptiveText style={Styles.paddedTitle}>Components</AdaptiveText>
+      <AdaptiveText style={Styles.paddedTitle}>{title}</AdaptiveText>
       {paymentMethods.map((paymentMethod) => {
         return (
           <PaymentMethodListItem

--- a/example/src/components/Checkout/components/PaymentMethodsView.tsx
+++ b/example/src/components/Checkout/components/PaymentMethodsView.tsx
@@ -34,6 +34,10 @@ const PaymentMethods = (prop: PaymentMethodsProps) => {
     prop.route.params?.showDropBasedComponents ?? false;
   const showInstant = prop.route.params?.showInstant ?? false;
 
+  if (!paymentMethods) {
+    return <Text>No payment methods available</Text>;
+  }
+
   const nonNativeMethods = paymentMethods?.paymentMethods.filter(
     (pm) =>
       !NATIVE_COMPONENTS.includes(pm.type) &&
@@ -45,10 +49,6 @@ const PaymentMethods = (prop: PaymentMethodsProps) => {
 
   if (!isReady) {
     return <ActivityIndicator />;
-  }
-
-  if (!paymentMethods) {
-    return <Text>No payment methods available</Text>;
   }
 
   return (

--- a/example/src/components/Checkout/components/PaymentMethodsView.tsx
+++ b/example/src/components/Checkout/components/PaymentMethodsView.tsx
@@ -1,4 +1,8 @@
-import { useAdyenCheckout } from '@adyen/react-native';
+import {
+  useAdyenCheckout,
+  NATIVE_COMPONENTS,
+  UNSUPPORTED_PAYMENT_METHODS,
+} from '@adyen/react-native';
 import { Text, ActivityIndicator } from 'react-native';
 import PageScrollView from '../../common/PageScrollView';
 import PaymentMethodsList from './PaymentMethodsList';
@@ -12,6 +16,7 @@ export type PaymentMethodsParams = {
   showDropIn?: boolean;
   showEmbeddedComponents?: boolean;
   showDropBasedComponents?: boolean;
+  showInstant?: boolean;
 };
 
 export type PaymentMethodsProps = NativeStackScreenProps<
@@ -27,6 +32,16 @@ const PaymentMethods = (prop: PaymentMethodsProps) => {
     prop.route.params?.showEmbeddedComponents ?? false;
   const showDropinBasedComponents =
     prop.route.params?.showDropBasedComponents ?? false;
+  const showInstant = prop.route.params?.showInstant ?? false;
+
+  const nonNativeMethods = paymentMethods?.paymentMethods.filter(
+    (pm) =>
+      !NATIVE_COMPONENTS.includes(pm.type) &&
+      !UNSUPPORTED_PAYMENT_METHODS.includes(pm.type)
+  );
+  const nativeMethods = paymentMethods?.paymentMethods.filter((pm) =>
+    NATIVE_COMPONENTS.includes(pm.type)
+  );
 
   if (!isReady) {
     return <ActivityIndicator />;
@@ -51,8 +66,18 @@ const PaymentMethods = (prop: PaymentMethodsProps) => {
         </>
       )}
 
+      {showInstant && (
+        <PaymentMethodsList
+          title="Instant components"
+          paymentMethods={nonNativeMethods}
+        />
+      )}
+
       {showDropinBasedComponents && (
-        <PaymentMethodsList paymentMethods={paymentMethods.paymentMethods} />
+        <PaymentMethodsList
+          title="Drop-in based components (deprecated)"
+          paymentMethods={nativeMethods}
+        />
       )}
     </PageScrollView>
   );

--- a/example/src/components/Checkout/components/PaymentMethodsView.tsx
+++ b/example/src/components/Checkout/components/PaymentMethodsView.tsx
@@ -34,6 +34,10 @@ const PaymentMethods = (prop: PaymentMethodsProps) => {
     prop.route.params?.showDropBasedComponents ?? false;
   const showInstant = prop.route.params?.showInstant ?? false;
 
+  if (!isReady) {
+    return <ActivityIndicator />;
+  }
+
   if (!paymentMethods) {
     return <Text>No payment methods available</Text>;
   }
@@ -46,10 +50,6 @@ const PaymentMethods = (prop: PaymentMethodsProps) => {
   const nativeMethods = paymentMethods?.paymentMethods.filter((pm) =>
     NATIVE_COMPONENTS.includes(pm.type)
   );
-
-  if (!isReady) {
-    return <ActivityIndicator />;
-  }
 
   return (
     <PageScrollView>

--- a/example/src/router/CheckoutNavigator.tsx
+++ b/example/src/router/CheckoutNavigator.tsx
@@ -12,6 +12,7 @@ export type CheckoutStackParamList = {
     showDropIn?: boolean;
     showEmbeddedComponents?: boolean;
     showDropBasedComponents?: boolean;
+    showInstant?: boolean;
   };
   CardForm: undefined;
 };
@@ -26,11 +27,17 @@ export interface CheckoutNavigatorProps {
   showDropIn?: boolean;
   showEmbeddedComponents?: boolean;
   showDropBasedComponents?: boolean;
+  showInstant?: boolean;
 }
 
 // Generic Checkout Navigator with CardForm modal
 export const CheckoutNavigator = (prop: CheckoutNavigatorProps) => {
-  const { showDropIn, showEmbeddedComponents, showDropBasedComponents } = prop;
+  const {
+    showDropIn,
+    showEmbeddedComponents,
+    showDropBasedComponents,
+    showInstant,
+  } = prop;
 
   return (
     <CheckoutStack.Navigator>
@@ -41,6 +48,7 @@ export const CheckoutNavigator = (prop: CheckoutNavigatorProps) => {
           showDropIn,
           showEmbeddedComponents,
           showDropBasedComponents,
+          showInstant,
         }}
         options={{ headerShown: false }}
       />

--- a/ios/Components/Base/BaseModule.swift
+++ b/ios/Components/Base/BaseModule.swift
@@ -28,6 +28,10 @@ internal class BaseModule: RCTEventEmitter {
         presenterStack.last
     }
 
+    /// Resolves the topmost view controller when the presenter stack is empty.
+    /// Defaults to `UIViewController.topPresenter`; override in tests to inject a mock.
+    internal static var topPresenterProvider: @MainActor () -> UIViewController? = { UIViewController.topPresenter }
+
     internal var currentComponent: Component?
 
     #if DEBUG
@@ -151,13 +155,13 @@ internal class BaseModule: RCTEventEmitter {
 extension BaseModule: PresentationDelegate {
 
     internal func present(component: PresentableComponent) {
-        DispatchQueue.main.async { [weak self] in
+        DispatchQueue.main.async { @MainActor [weak self] in
             guard let self else { return }
 
             let presenter: UIViewController
             if let currentPresenter = BaseModule.currentPresenter {
                 presenter = currentPresenter
-            } else if let topPresenter = UIViewController.topPresenter {
+            } else if let topPresenter = BaseModule.topPresenterProvider() {
                 presenter = topPresenter
                 BaseModule.presenterStack.append(topPresenter)
             } else {

--- a/ios/Components/Base/BaseModule.swift
+++ b/ios/Components/Base/BaseModule.swift
@@ -155,8 +155,8 @@ extension BaseModule: PresentationDelegate {
             guard let self else { return }
 
             let presenter: UIViewController
-            if let currentPResenter = BaseModule.currentPresenter {
-                presenter = currentPResenter
+            if let currentPresenter = BaseModule.currentPresenter {
+                presenter = currentPresenter
             } else if let topPresenter = UIViewController.topPresenter {
                 presenter = topPresenter
                 BaseModule.presenterStack.append(topPresenter)

--- a/ios/Components/Base/BaseModule.swift
+++ b/ios/Components/Base/BaseModule.swift
@@ -175,6 +175,7 @@ extension BaseModule: PresentationDelegate {
             let viewController: UIViewController
             if component.requiresModalPresentation {
                 viewController = UINavigationController(rootViewController: component.viewController)
+                viewController.presentationController?.delegate = self
                 component.viewController.navigationItem.rightBarButtonItem = .init(barButtonSystemItem: .cancel,
                                                                                    target: self,
                                                                                    action: #selector(self.cancelDidPress))
@@ -192,4 +193,12 @@ extension BaseModule: PresentationDelegate {
         sendError(error: ModuleException.canceled)
     }
 
+}
+
+extension BaseModule: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        // Remove the swiped-away VC from the stack
+        BaseModule.presenterStack.removeAll { $0 === presentationController.presentedViewController }
+        cancelDidPress()
+    }
 }

--- a/ios/Components/Base/BaseModule.swift
+++ b/ios/Components/Base/BaseModule.swift
@@ -155,7 +155,7 @@ internal class BaseModule: RCTEventEmitter {
 extension BaseModule: PresentationDelegate {
 
     internal func present(component: PresentableComponent) {
-        DispatchQueue.main.async { @MainActor [weak self] in
+        DispatchQueue.main.async { [weak self] in
             guard let self else { return }
 
             let presenter: UIViewController

--- a/ios/Components/Base/BaseModule.swift
+++ b/ios/Components/Base/BaseModule.swift
@@ -17,7 +17,16 @@ internal class BaseModule: RCTEventEmitter {
     internal static var session: AdyenSession?
     internal weak static var sessionDelegate: SessionErrorDelegate?
     internal weak static var currentModule: BaseModule?
-    internal static var currentPresenter: UIViewController?
+
+    /// Stack of view controllers that have presented payment UI.
+    /// Appended to on each `present(component:)` call; cleared on cleanup.
+    /// Dismissing from the first entry cascades through the whole chain.
+    internal static var presenterStack: [UIViewController] = []
+
+    /// The most-recently-added presenter (used when deciding where to present next).
+    internal static var currentPresenter: UIViewController? {
+        presenterStack.last
+    }
 
     internal var currentComponent: Component?
 
@@ -105,7 +114,7 @@ internal class BaseModule: RCTEventEmitter {
     }
 
     internal func dismiss(_ result: Bool) {
-        DispatchQueue.main.async { [weak self] in
+        ensureMainThread { [weak self] in
             guard let self else { return }
             if let component = self.currentComponent {
                 component.finalizeIfNeeded(with: result) {
@@ -131,14 +140,11 @@ internal class BaseModule: RCTEventEmitter {
         BaseModule.currentModule = nil
         currentComponent = nil
 
-        guard BaseModule.currentPresenter?.presentedViewController != nil else {
-            BaseModule.currentPresenter = nil
-            return
-        }
+        let root = BaseModule.presenterStack.first
+        BaseModule.presenterStack.removeAll()
 
-        BaseModule.currentPresenter?.dismiss(animated: true) {
-            BaseModule.currentPresenter = nil
-        }
+        guard root?.presentedViewController != nil else { return }
+        root?.dismiss(animated: true)
     }
 }
 
@@ -148,12 +154,17 @@ extension BaseModule: PresentationDelegate {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
 
-            guard let presenter = BaseModule.currentPresenter ?? UIViewController.topPresenter else {
+            let presenter: UIViewController
+            if let currentPResenter = BaseModule.currentPresenter {
+                presenter = currentPResenter
+            } else if let topPresenter = UIViewController.topPresenter {
+                presenter = topPresenter
+                BaseModule.presenterStack.append(topPresenter)
+            } else {
                 return self.sendError(error: ModuleException.notKeyWindow)
             }
 
             defer {
-                BaseModule.currentPresenter = presenter
                 BaseModule.currentModule = self
             }
 
@@ -168,6 +179,7 @@ extension BaseModule: PresentationDelegate {
             }
 
             presenter.present(viewController, animated: true)
+            BaseModule.presenterStack.append(viewController)
         }
     }
 

--- a/ios/Components/InstantModule.swift
+++ b/ios/Components/InstantModule.swift
@@ -50,11 +50,4 @@ internal final class InstantModule: BaseActionModule {
         }
     }
 
-    // MARK: - Presentation
-
-    @objc private func closeButtonPressed() {
-        sendError(error: ModuleException.canceled)
-        dismiss(false)
-    }
-
 }

--- a/ios/Components/InstantModule.swift
+++ b/ios/Components/InstantModule.swift
@@ -14,47 +14,42 @@ internal final class InstantModule: BaseActionModule {
 
     // MARK: - Internal
 
-    internal enum LaunchStyle: Equatable {
-        case initiatePayment
-        case present
-    }
+    internal enum PaymentFlow {
+        case submit(InstantPaymentComponent)
+        case present(PaymentComponent & PresentableComponent)
 
-    internal enum Flow {
-        case payByBankUS(PayByBankUSPaymentMethod)
-        case issuerList(IssuerListPaymentMethod)
-        case instant(PaymentMethod)
-
-        var launchStyle: LaunchStyle {
+        var paymentComponent: PaymentComponent {
             switch self {
-            case .instant:
-                return .initiatePayment
-            case .payByBankUS, .issuerList:
-                return .present
+            case let .submit(instant):
+                return instant
+            case let .present(presentable):
+                return presentable
             }
         }
     }
 
-    /// Maps a `PaymentMethod` to the matching `Flow`. Pure logic — no context required.
-    internal static func flow(for paymentMethod: PaymentMethod) -> Flow {
-        switch paymentMethod {
-        case let bankMethod as PayByBankUSPaymentMethod:
-            return .payByBankUS(bankMethod)
-        case let issuerMethod as IssuerListPaymentMethod:
-            return .issuerList(issuerMethod)
-        default:
-            return .instant(paymentMethod)
-        }
-    }
+    internal enum PaymentFlowType {
+        case payByBankUS(PayByBankUSPaymentMethod)
+        case issuerList(IssuerListPaymentMethod)
+        case instant(PaymentMethod)
 
-    /// Creates the appropriate `PaymentComponent` for a given `Flow`. Pure factory — no module state required.
-    internal static func makeComponent(for flow: Flow, context: AdyenContext) -> PaymentComponent {
-        switch flow {
-        case let .payByBankUS(pm):
-            return PayByBankUSComponent(paymentMethod: pm, context: context)
-        case let .issuerList(pm):
-            return IssuerListComponent(paymentMethod: pm, context: context)
-        case let .instant(pm):
-            return InstantPaymentComponent(paymentMethod: pm, context: context, order: nil)
+        internal init(_ paymentMethod: PaymentMethod) {
+            switch paymentMethod {
+            case let pm as PayByBankUSPaymentMethod: self = .payByBankUS(pm)
+            case let pm as IssuerListPaymentMethod: self = .issuerList(pm)
+            default: self = .instant(paymentMethod)
+            }
+        }
+
+        internal func buildFlow(with context: AdyenContext) -> PaymentFlow {
+            switch self {
+            case let .payByBankUS(pm):
+                return .present(PayByBankUSComponent(paymentMethod: pm, context: context))
+            case let .issuerList(pm):
+                return .present(IssuerListComponent(paymentMethod: pm, context: context))
+            case let .instant(pm):
+                return .submit(InstantPaymentComponent(paymentMethod: pm, context: context, order: nil))
+            }
         }
     }
 
@@ -75,26 +70,24 @@ internal final class InstantModule: BaseActionModule {
         let locale = BaseModule.session?.sessionContext.shopperLocale ?? parser.shopperLocale
         createActionHandlerIfNeeded(context: context, locale: locale)
 
-        let flow = InstantModule.flow(for: paymentMethod)
-        let component = InstantModule.makeComponent(for: flow, context: context)
-        component.delegate = BaseModule.session ?? self
-        currentComponent = component
+        let flow = PaymentFlowType(paymentMethod).buildFlow(with: context)
 
-        ensureMainThread { [weak self] in
-            self?.launch(component, style: flow.launchStyle)
-        }
+        flow.paymentComponent.delegate = BaseModule.session ?? self
+        currentComponent = flow.paymentComponent
+
+        launch(flow)
     }
 
     // MARK: - Private
 
-    private func launch(_ component: PaymentComponent, style: LaunchStyle) {
-        switch style {
-        case .initiatePayment:
-            (component as? InstantPaymentComponent)?.initiatePayment()
-        case .present:
-            if let presentable = component as? PresentableComponent {
-                present(component: presentable)
+    private func launch(_ type: PaymentFlow) {
+        switch type {
+        case let .submit(instant):
+            ensureMainThread {
+                instant.initiatePayment()
             }
+        case let .present(presentable):
+            present(component: presentable)
         }
     }
 

--- a/ios/Components/InstantModule.swift
+++ b/ios/Components/InstantModule.swift
@@ -28,13 +28,33 @@ internal final class InstantModule: BaseActionModule {
 
         createActionHandlerIfNeeded(context: context, locale: locale)
 
-        let component = InstantPaymentComponent(paymentMethod: paymentMethod, context: context, order: nil)
+        let component: PaymentComponent
+        switch paymentMethod {
+        case let bankMethod as PayByBankUSPaymentMethod:
+            component = PayByBankUSComponent(paymentMethod: bankMethod, context: context)
+        case let issuerMethod as IssuerListPaymentMethod:
+            component = IssuerListComponent(paymentMethod: issuerMethod, context: context)
+        default:
+            component = InstantPaymentComponent(paymentMethod: paymentMethod, context: context, order: nil)
+        }
+
         component.delegate = BaseModule.session ?? self
         currentComponent = component
 
-        DispatchQueue.main.async {
-            component.initiatePayment()
+        if let instantComponent = component as? InstantPaymentComponent {
+            DispatchQueue.main.async {
+                instantComponent.initiatePayment()
+            }
+        } else if let presentableCompomponent = component as? PresentableComponent {
+            present(component: presentableCompomponent)
         }
+    }
+
+    // MARK: - Presentation
+
+    @objc private func closeButtonPressed() {
+        sendError(error: ModuleException.canceled)
+        dismiss(false)
     }
 
 }

--- a/ios/Components/InstantModule.swift
+++ b/ios/Components/InstantModule.swift
@@ -12,6 +12,28 @@ import React
 @objc(AdyenInstant)
 internal final class InstantModule: BaseActionModule {
 
+    // MARK: - Internal
+
+    internal enum Flow {
+        case payByBankUS(PayByBankUSPaymentMethod)
+        case issuerList(IssuerListPaymentMethod)
+        case instant(PaymentMethod)
+    }
+
+    /// Maps a `PaymentMethod` to the matching `Flow`. Pure logic — no context required.
+    internal static func flow(for paymentMethod: PaymentMethod) -> Flow {
+        switch paymentMethod {
+        case let bankMethod as PayByBankUSPaymentMethod:
+            return .payByBankUS(bankMethod)
+        case let issuerMethod as IssuerListPaymentMethod:
+            return .issuerList(issuerMethod)
+        default:
+            return .instant(paymentMethod)
+        }
+    }
+
+    // MARK: - React Methods
+
     @objc
     func open(_ paymentMethodsDict: NSDictionary, configuration: NSDictionary) {
         let parser = RootConfigurationParser(configuration: configuration)
@@ -29,13 +51,13 @@ internal final class InstantModule: BaseActionModule {
         createActionHandlerIfNeeded(context: context, locale: locale)
 
         let component: PaymentComponent
-        switch paymentMethod {
-        case let bankMethod as PayByBankUSPaymentMethod:
+        switch InstantModule.flow(for: paymentMethod) {
+        case let .payByBankUS(bankMethod):
             component = PayByBankUSComponent(paymentMethod: bankMethod, context: context)
-        case let issuerMethod as IssuerListPaymentMethod:
+        case let .issuerList(issuerMethod):
             component = IssuerListComponent(paymentMethod: issuerMethod, context: context)
-        default:
-            component = InstantPaymentComponent(paymentMethod: paymentMethod, context: context, order: nil)
+        case let .instant(method):
+            component = InstantPaymentComponent(paymentMethod: method, context: context, order: nil)
         }
 
         component.delegate = BaseModule.session ?? self

--- a/ios/Components/InstantModule.swift
+++ b/ios/Components/InstantModule.swift
@@ -14,10 +14,24 @@ internal final class InstantModule: BaseActionModule {
 
     // MARK: - Internal
 
+    internal enum LaunchStyle: Equatable {
+        case initiatePayment
+        case present
+    }
+
     internal enum Flow {
         case payByBankUS(PayByBankUSPaymentMethod)
         case issuerList(IssuerListPaymentMethod)
         case instant(PaymentMethod)
+
+        var launchStyle: LaunchStyle {
+            switch self {
+            case .instant:
+                return .initiatePayment
+            case .payByBankUS, .issuerList:
+                return .present
+            }
+        }
     }
 
     /// Maps a `PaymentMethod` to the matching `Flow`. Pure logic — no context required.
@@ -29,6 +43,18 @@ internal final class InstantModule: BaseActionModule {
             return .issuerList(issuerMethod)
         default:
             return .instant(paymentMethod)
+        }
+    }
+
+    /// Creates the appropriate `PaymentComponent` for a given `Flow`. Pure factory — no module state required.
+    internal static func makeComponent(for flow: Flow, context: AdyenContext) -> PaymentComponent {
+        switch flow {
+        case let .payByBankUS(pm):
+            return PayByBankUSComponent(paymentMethod: pm, context: context)
+        case let .issuerList(pm):
+            return IssuerListComponent(paymentMethod: pm, context: context)
+        case let .instant(pm):
+            return InstantPaymentComponent(paymentMethod: pm, context: context, order: nil)
         }
     }
 
@@ -47,28 +73,28 @@ internal final class InstantModule: BaseActionModule {
         }
 
         let locale = BaseModule.session?.sessionContext.shopperLocale ?? parser.shopperLocale
-
         createActionHandlerIfNeeded(context: context, locale: locale)
 
-        let component: PaymentComponent
-        switch InstantModule.flow(for: paymentMethod) {
-        case let .payByBankUS(bankMethod):
-            component = PayByBankUSComponent(paymentMethod: bankMethod, context: context)
-        case let .issuerList(issuerMethod):
-            component = IssuerListComponent(paymentMethod: issuerMethod, context: context)
-        case let .instant(method):
-            component = InstantPaymentComponent(paymentMethod: method, context: context, order: nil)
-        }
-
+        let flow = InstantModule.flow(for: paymentMethod)
+        let component = InstantModule.makeComponent(for: flow, context: context)
         component.delegate = BaseModule.session ?? self
         currentComponent = component
 
-        if let instantComponent = component as? InstantPaymentComponent {
-            DispatchQueue.main.async {
-                instantComponent.initiatePayment()
+        ensureMainThread { [weak self] in
+            self?.launch(component, style: flow.launchStyle)
+        }
+    }
+
+    // MARK: - Private
+
+    private func launch(_ component: PaymentComponent, style: LaunchStyle) {
+        switch style {
+        case .initiatePayment:
+            (component as? InstantPaymentComponent)?.initiatePayment()
+        case .present:
+            if let presentable = component as? PresentableComponent {
+                present(component: presentable)
             }
-        } else if let presentableCompomponent = component as? PresentableComponent {
-            present(component: presentableCompomponent)
         }
     }
 

--- a/src/core/components.ts
+++ b/src/core/components.ts
@@ -63,7 +63,6 @@ export const NATIVE_COMPONENTS = [
   'billdesk_online',
   'billdesk_wallet',
   'dotpay',
-  'entercash',
   'eps',
   'molpay_ebanking_fpx_MY',
   'molpay_ebanking_TH',
@@ -73,7 +72,6 @@ export const NATIVE_COMPONENTS = [
   'onlinebanking_IN',
   'onlineBanking_PL',
   'onlineBanking_SK',
-  'paybybank',
   'wallet_IN',
 
   /** Await */


### PR DESCRIPTION
## Summary

- Adds `PayByBankUSFragment` (renamed from `PayByBankFragment`) — handles `paybybankus` via `PayByBankUSComponent`
- Adds `PayByBankGlobalFragment` — handles `paybybank` (non-US) via `PayByBankComponent`
- Routes both `PaymentMethodTypes.PAY_BY_BANK` and `PAY_BY_BANK_US` in `InstantModule`
- Adds a close (×) button to the instant component bottom sheet (top-left), wired to dismiss and fire `onError` with `canceledByShopper`
- Prevents accidental dismissal by disabling outside-tap via `setCanceledOnTouchOutside(false)`
- Moves cancellation logic into the ViewModel layer (`cancel()` on `ViewModelInterface`) so `BaseModule` stays clean; `AdvancedComponentViewModel` and `SessionsComponentViewModel` each call the appropriate `messageBus` method

Ticket: COSDK-1218

#### Test plan

- [x] Open a `paybybank` payment method — bank list drawer appears with a close button
- [x] Open a `paybybankus` payment method — same drawer behaviour
- [x] Tap outside the drawer — drawer does not dismiss
- [x] Tap the × button — drawer dismisses and JS `onError` receives `canceledByShopper`
- [x] Sessions and Advanced flows both behave correctly for cancellation

### Screen recording

https://github.com/user-attachments/assets/1ba1a6e1-175e-41ec-9a64-c62073756374

https://github.com/user-attachments/assets/2b679eec-29bf-4a61-a332-f3ef538ed234
