### PR TITLE
feat: disable store payment field for Twint

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/configuration/CheckoutConfigurationFactory.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/CheckoutConfigurationFactory.kt
@@ -7,6 +7,7 @@ import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.dropin.dropIn
 import com.adyen.checkout.giftcard.giftCard
 import com.adyen.checkout.googlepay.googlePay
+import com.adyen.checkout.twint.twint
 import com.adyenreactnativesdk.component.base.ModuleException
 import com.facebook.react.bridge.ReadableMap
 
@@ -47,6 +48,9 @@ object CheckoutConfigurationFactory {
       giftCard {
         val parser = PartialPaymentParser(json)
         setPinRequired(parser.pinRequired)
+      }
+      twint {
+        showStorePaymentField = false
       }
     }
   }


### PR DESCRIPTION
## Summary

- Adds `import com.adyen.checkout.twint.twint` to `CheckoutConfigurationFactory`
- Configures `showStorePaymentField = false` for the Twint component in `CheckoutConfigurationFactory.get()`

On iOS SDK Twint does not support storing payment methods, so this field should be hidden on Android as well.

Ticket: COSDK-1322