### PR TITLE
fix: adopt UIScene lifecycle in example app

### DIFF
--- a/example/ios/AdyenExample/Info.plist
+++ b/example/ios/AdyenExample/Info.plist
@@ -60,6 +60,21 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/example/ios/AppDelegate.swift
+++ b/example/ios/AppDelegate.swift
@@ -5,20 +5,50 @@ import ReactAppDependencyProvider
 import UIKit
 
 @main
-class AppDelegate: RCTAppDelegate {
-    override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        self.moduleName = "AdyenExample"
-        self.dependencyProvider = RCTAppDependencyProvider()
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
 
-        // You can add your custom initial props in the dictionary below.
-        // They will be passed down to the ViewController used by React Native.
-        self.initialProps = [:]
+    var reactNativeDelegate: ReactNativeDelegate?
+    var reactNativeFactory: RCTReactNativeFactory?
 
-        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        let delegate = ReactNativeDelegate()
+        let factory = RCTReactNativeFactory(delegate: delegate)
+        delegate.dependencyProvider = RCTAppDependencyProvider()
+
+        reactNativeDelegate = delegate
+        reactNativeFactory = factory
+
+        window = UIWindow(frame: UIScreen.main.bounds)
+
+        factory.startReactNative(
+            withModuleName: "AdyenExample",
+            in: window,
+            launchOptions: launchOptions
+        )
+
+        return true
     }
-  
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        RedirectComponent.applicationDidOpen(from: url)
+    }
+}
+
+class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
     override func sourceURL(for bridge: RCTBridge) -> URL? {
-        self.bundleURL()
+        bundleURL()
     }
 
     override func bundleURL() -> URL? {
@@ -27,9 +57,5 @@ class AppDelegate: RCTAppDelegate {
         #else
             Bundle.main.url(forResource: "main", withExtension: "jsbundle")
         #endif
-    }
-
-    override func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-        RedirectComponent.applicationDidOpen(from: url)
     }
 }


### PR DESCRIPTION
## Summary

- Migrate `AppDelegate` from the deprecated `RCTAppDelegate` subclass to `RCTReactNativeFactory` + `RCTDefaultReactNativeFactoryDelegate` pattern
- Add `application(_:configurationForConnecting:options:)` to `AppDelegate` to satisfy UIKit's scene lifecycle requirement without a separate `SceneDelegate` class
- Add `UIApplicationSceneManifest` to `Info.plist` (single-scene, no multiple-scene support needed)
- Update open-URL callback from the deprecated three-argument form to `application(_:open:options:)`

This resolves the warning introduced in iOS 18.4:
> `UIScene lifecycle will soon be required. Failure to adopt will result in an assert in the future.`

Apps built against the iOS 27 SDK that don't adopt the scene lifecycle **fail to launch**. See [Apple TN3187](https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle) for details.

Ticket: COSDK-1094

#### Test plan
- [ ] Build and run the example app on iOS — no UIScene lifecycle warning in the console
- [ ] Deep link via `myapp://` scheme still opens correctly (RedirectComponent)
- [ ] App launches and React Native renders normally