### PR TITLE
[WIP] docs: enforce Architecture.md integrity and document public API surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,14 @@ This is a React Native SDK with three platform targets:
 ## Refactoring Conventions
 
 - **Before adding or refactoring native modules, events, or class hierarchies**, review `docs/Architecture.md` to understand the existing structure and patterns.
+- **After changing any of the following, update `docs/Architecture.md` in the same PR**:
+  - Directory structure (files added/removed/renamed under `src/`, `ios/`, `android/`)
+  - Wrapper class hierarchy or native class hierarchies (iOS `BaseModule` tree, Android `BaseModule`/`AppCompatModule` tree)
+  - Core interfaces in `core/types.ts` (`AdyenComponent`, `AdyenActionComponent`, `ConditionalPaymentComponent`, module interfaces)
+  - Configuration hierarchy (`core/configurations/`)
+  - Embedded view event-bus contracts (`modules/embedded/`, `specs/`)
+  - Cross-platform event names, error codes, or result codes
+- **Validate `docs/Architecture.md` integrity before committing**: grep the codebase for every class/interface named in the document and confirm each still exists with the documented signature. Remove or update stale entries — do not leave the document describing classes that no longer exist.
 - **Cross-platform consistency**: Check for mismatched class names, error codes, and enum values across all three platforms.
 - **Before renaming symbols with `sed`**, verify there are no unintended substring matches — e.g. `s/Event/PaymentEvent/g` will correctly rename `EventName` but also corrupt `coreEvent` into `corePaymentEvent`. Use whole-word matching or targeted per-symbol replacements.
 - **After moving a file to a new package/directory**, update the `package` declaration (Kotlin) and update imports in every consumer (Kotlin and JS/TS).
@@ -46,6 +54,15 @@ This is a React Native SDK with three platform targets:
   - **JS**: `src/**/__tests__/`
   - **iOS**: `example/ios/AdyenExampleTests/`
   - **Android**: `android/src/test/java/com/adyenreactnativesdk/`
+
+## Public API
+
+The package's public API is the set of symbols re-exported through `src/index.ts` (barrel: `./components`, `./core`, `./hooks`, `./modules`). Treat these as the contractual API.
+
+- **`docs/Architecture.md` must contain a "Public API" section** listing every exported symbol grouped by category (components, hooks, types/interfaces, configurations, constants/enums, module wrappers). Keep it in sync with `src/index.ts`.
+- **Before adding a new export**, ask the user whether it should be public. Prefer exporting from the most specific barrel (`core/index.ts`, `modules/index.ts`, etc.) rather than reaching for `src/index.ts` directly.
+- **Before removing or renaming an export**, treat it as a breaking change: search `example/`, all three test targets, and `docs/` for usages; update them in the same PR; and follow the breaking-change review in the Verification Checklist.
+- **Never re-export internal helpers** (e.g. `getWrapper`, `ModuleMock`, `utils.ts`) through a public barrel.
 
 ## Code Style
 
@@ -75,5 +92,6 @@ Before considering work complete:
 4. Kotlin files formatted (`ktlint android -F`)
 5. Cross-platform naming verified (JS, iOS, Android aligned)
 6. Old references updated in all three test targets
-7. If public API changed: reviewed for breaking changes and discussed with user
+7. If public API changed: `docs/Architecture.md` "Public API" section updated, breaking changes reviewed and discussed with user, and `example/` usages updated
+8. If directory structure, class hierarchy, interfaces, configurations, or event/error/result codes changed: `docs/Architecture.md` updated and integrity-validated (every documented symbol still exists in code)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,12 +57,12 @@ This is a React Native SDK with three platform targets:
 
 ## Public API
 
-The package's public API is the set of symbols re-exported through `src/index.ts` (barrel: `./components`, `./core`, `./hooks`, `./modules`). Treat these as the contractual API.
+The package's public API is the set of symbols re-exported through `src/index.ts` (barrel: `./components`, `./core`, `./hooks`, `./modules`). Treat these as the contractual API. The canonical list of exports lives in `docs/PublicAPI.md`.
 
-- **`docs/Architecture.md` must contain a "Public API" section** listing every exported symbol grouped by category (components, hooks, types/interfaces, configurations, constants/enums, module wrappers). Keep it in sync with `src/index.ts`.
+- **`docs/PublicAPI.md` is the source of truth for the public API surface.** Keep it in sync with `src/index.ts` — when the barrels change, update `docs/PublicAPI.md` in the same PR.
 - **Before adding a new export**, ask the user whether it should be public. Prefer exporting from the most specific barrel (`core/index.ts`, `modules/index.ts`, etc.) rather than reaching for `src/index.ts` directly.
 - **Before removing or renaming an export**, treat it as a breaking change: search `example/`, all three test targets, and `docs/` for usages; update them in the same PR; and follow the breaking-change review in the Verification Checklist.
-- **Never re-export internal helpers** (e.g. `getWrapper`, `ModuleMock`, `utils.ts`) through a public barrel.
+- **Never re-export internal helpers** (e.g. `getWrapper`, `ModuleMock`, `utils.ts`) through a public barrel. The "Internal (not exported)" section of `docs/PublicAPI.md` lists symbols that must stay internal.
 
 ## Code Style
 
@@ -92,6 +92,6 @@ Before considering work complete:
 4. Kotlin files formatted (`ktlint android -F`)
 5. Cross-platform naming verified (JS, iOS, Android aligned)
 6. Old references updated in all three test targets
-7. If public API changed: `docs/Architecture.md` "Public API" section updated, breaking changes reviewed and discussed with user, and `example/` usages updated
+7. If public API changed: `docs/PublicAPI.md` updated, breaking changes reviewed and discussed with user, and `example/` usages updated
 8. If directory structure, class hierarchy, interfaces, configurations, or event/error/result codes changed: `docs/Architecture.md` updated and integrity-validated (every documented symbol still exists in code)
 

--- a/docs/PublicAPI.md
+++ b/docs/PublicAPI.md
@@ -1,0 +1,151 @@
+# Public API
+
+The package's public API is the set of symbols re-exported through `src/index.ts` (barrel: `./components`, `./core`, `./hooks`, `./modules`). This document is the canonical list of those exports.
+
+> **Keeping this document in sync is mandatory** — see `AGENTS.md` → "Public API". When the barrels change, update this document in the same PR. Symbols not listed here are internal and must not be re-exported through `src/index.ts`.
+
+## Components
+
+Re-exported from `src/components/index.ts`.
+
+| Symbol | Kind | Source |
+| --- | --- | --- |
+| `AdyenCheckout` | React component | `components/AdyenCheckout.tsx` |
+| `AdyenCheckoutProps` | type | `components/AdyenCheckout.tsx` |
+| `ApplePayButton` | React component | `components/ApplePayButton.tsx` |
+| `ApplePayButtonProps` | interface | `components/ApplePayButton.tsx` |
+| `ApplePayButtonTheme` | const object | `components/ApplePayButton.tsx` |
+| `ApplePayButtonType` | const object | `components/ApplePayButton.tsx` |
+| `GooglePayButton` | React component | `components/GooglePayButton.tsx` |
+| `GooglePayButtonProps` | interface | `components/GooglePayButton.tsx` |
+| `GooglePayButtonTheme` | const object | `components/GooglePayButton.tsx` |
+| `GooglePayButtonType` | const object | `components/GooglePayButton.tsx` |
+| `CardView` | React component | `components/CardView.tsx` |
+| `CardViewProps` | interface | `components/CardView.tsx` |
+
+## Hooks
+
+Re-exported from `src/hooks/index.ts`.
+
+| Symbol | Kind | Source |
+| --- | --- | --- |
+| `useAdyenCheckout` | function (hook) | `hooks/useAdyenCheckout.ts` |
+| `AdyenCheckoutContextType` | type | `hooks/useAdyenCheckout.ts` |
+
+## Core Types & Interfaces
+
+Re-exported (as types) from `src/core/types.ts` via `src/core/index.ts`.
+
+| Symbol | Kind |
+| --- | --- |
+| `PaymentAction` | interface |
+| `PaymentMethod` | interface |
+| `PaymentMethodGroup` | interface |
+| `StoredPaymentMethod` | interface |
+| `PaymentMethodsResponse` | interface |
+| `PaymentAmount` | interface |
+| `PaymentMethodData` | interface |
+| `PaymentDetailsData` | interface |
+| `SessionConfiguration` | interface |
+| `AdyenError` | interface |
+| `SubmitModel` | interface |
+| `Balance` | interface |
+| `Order` | interface |
+| `SessionsResult` | type |
+| `HideOption` | interface |
+| `AdyenComponent` | interface |
+| `AdyenActionComponent` | interface |
+| `ConditionalPaymentComponent` | interface |
+
+## Configurations
+
+Re-exported (as types) from `src/core/configurations/` via `src/core/index.ts`.
+
+| Symbol | Kind | Source |
+| --- | --- | --- |
+| `Configuration` | interface | `configurations/Configuration.ts` |
+| `BaseConfiguration` | interface | `configurations/Configuration.ts` |
+| `EnvironmentConfiguration` | interface | `configurations/Configuration.ts` |
+| `Environment` | type | `configurations/Configuration.ts` |
+| `AnalyticsOptions` | interface | `configurations/Configuration.ts` |
+| `ApplePayConfiguration` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayShippingType` | type | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayAddressFields` | type | `configurations/ApplePayConfiguration.ts` |
+| `ApplePaySummaryItem` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayShippingMethod` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayPaymentContact` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayRecurringPaymentRequest` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayRecurringSummaryItem` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayCalendarUnit` | type | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayError` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayShippingContactUpdateRequest` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayCouponCodeEvent` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayCouponCodeUpdateRequest` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayShippingMethodUpdateRequest` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayAuthorizationActions` | interface | `configurations/ApplePayConfiguration.ts` |
+| `ApplePayPaymentAuthorization` | interface | `configurations/ApplePayConfiguration.ts` |
+| `CardsConfiguration` | interface | `configurations/CardsConfiguration.ts` |
+| `BinLookupData` | interface | `configurations/CardsConfiguration.ts` |
+| `InstallmentPlan` | type | `configurations/CardsConfiguration.ts` |
+| `InstallmentOption` | interface | `configurations/CardsConfiguration.ts` |
+| `InstallmentOptions` | interface | `configurations/CardsConfiguration.ts` |
+| `AddressMode` | type | `configurations/CardsConfiguration.ts` |
+| `FieldVisibility` | type | `configurations/CardsConfiguration.ts` |
+| `GooglePayConfiguration` | interface | `configurations/GooglePayConfiguration.ts` |
+| `GooglePayShippingAddressParameters` | interface | `configurations/GooglePayConfiguration.ts` |
+| `GooglePayBillingAddressParameters` | interface | `configurations/GooglePayConfiguration.ts` |
+| `GooglePayBillingAddressFormat` | type | `configurations/GooglePayConfiguration.ts` |
+| `TotalPriceStatus` | type | `configurations/GooglePayConfiguration.ts` |
+| `CardAuthMethod` | type | `configurations/GooglePayConfiguration.ts` |
+| `GooglePayEnvironment` | enum | `configurations/GooglePayConfiguration.ts` |
+| `DropInConfiguration` | interface | `configurations/DropInConfiguration.ts` |
+| `ThreeDSConfiguration` | interface | `configurations/ThreeDSConfiguration.ts` |
+| `PartialPaymentConfiguration` | interface | `configurations/PartialPaymentConfiguration.ts` |
+| `PartialPaymentComponent` | interface | `configurations/PartialPaymentConfiguration.ts` |
+| `AddressLookup` | interface | `configurations/AddressLookup.ts` |
+| `PostalAddress` | interface | `configurations/AddressLookup.ts` |
+| `AddressLookupItem` | interface | `configurations/AddressLookup.ts` |
+
+## Constants & Enums
+
+Re-exported from `src/core/constants.ts` and `src/core/components.ts` via `src/core/index.ts`.
+
+| Symbol | Kind | Source |
+| --- | --- | --- |
+| `Event` | enum | `core/constants.ts` |
+| `ErrorCode` | enum | `core/constants.ts` |
+| `ResultCode` | enum | `core/constants.ts` |
+| `BalanceResultCode` | enum | `core/constants.ts` |
+| `UNSUPPORTED_PAYMENT_METHODS` | const array | `core/components.ts` |
+| `ADDRESS_COMPONENTS` | const array | `core/components.ts` |
+| `NATIVE_COMPONENTS` | const array | `core/components.ts` |
+
+## Module Wrappers
+
+Re-exported from `src/modules/index.ts`.
+
+| Symbol | Kind | Source |
+| --- | --- | --- |
+| `AdyenApplePay` | const (`ApplePayModule`) | `modules/applepay/AdyenApplePay.ts` |
+| `ApplePayModule` | interface | `modules/applepay/AdyenApplePay.ts` |
+| `AdyenGooglePay` | const (`GooglePayModule`) | `modules/googlepay/AdyenGooglePay.ts` |
+| `GooglePayModule` | interface | `modules/googlepay/AdyenGooglePay.ts` |
+| `AdyenInstant` | const (`InstantModule`) | `modules/instant/AdyenInstant.ts` |
+| `InstantModule` | interface | `modules/instant/AdyenInstant.ts` |
+| `AdyenDropIn` | const (`DropInModule`) | `modules/dropin/AdyenDropIn.ts` |
+| `DropInModule` | interface | `modules/dropin/AdyenDropIn.ts` |
+| `AdyenAction` | const (`ActionModule`) | `modules/action/AdyenAction.ts` |
+| `ActionModule` | interface | `modules/action/AdyenAction.ts` |
+| `AdyenCSE` | const (`AdyenCSEModule`) | `modules/cse/AdyenCSEModule.ts` |
+| `AdyenCSEModule` | interface | `modules/cse/AdyenCSEModule.ts` |
+| `Card` | class | `modules/cse/types.ts` |
+
+## Internal (not exported)
+
+The following are intentionally **not** part of the public API and must not be re-exported through `src/index.ts`:
+
+- `modules/session/*` — `SessionHelper`, `SessionWrapper`, `SessionHelperModule`, `SessionContext` (used internally by `AdyenCheckout`).
+- `modules/embedded/*` — `EmbeddedComponentBus`, `EmbeddedComponentBusWrapper`, `EmbeddedComponentProxy`, `EmbeddedNativeModule` (used internally by `CardView`).
+- `modules/base/*` — `EventListenerWrapper`, `ModuleWrapper`, `PaymentComponentWrapper`, `ActionHandlingComponentWrapper`, `AddressLookupModule`, `ModuleMock`, `getWrapper`, `find`, and base constants.
+- `modules/applepay/ApplePayInternalTypes.ts` — `ApplePayAuthorizationResult`.
+- `components/utils/*`, `components/common/*` — internal helpers and styles.

--- a/docs/PublicAPI.md
+++ b/docs/PublicAPI.md
@@ -59,52 +59,52 @@ Re-exported (as types) from `src/core/types.ts` via `src/core/index.ts`.
 
 ## Configurations
 
-Re-exported (as types) from `src/core/configurations/` via `src/core/index.ts`.
+Re-exported (as types) from `src/core/configurations/` via `src/core/index.ts`. The configurations barrel uses `export type *`, so all symbols below are **type-only** — they can be used in type annotations but not as runtime values.
 
 | Symbol | Kind | Source |
 | --- | --- | --- |
-| `Configuration` | interface | `configurations/Configuration.ts` |
-| `BaseConfiguration` | interface | `configurations/Configuration.ts` |
-| `EnvironmentConfiguration` | interface | `configurations/Configuration.ts` |
-| `Environment` | type | `configurations/Configuration.ts` |
-| `AnalyticsOptions` | interface | `configurations/Configuration.ts` |
-| `ApplePayConfiguration` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayShippingType` | type | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayAddressFields` | type | `configurations/ApplePayConfiguration.ts` |
-| `ApplePaySummaryItem` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayShippingMethod` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayPaymentContact` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayRecurringPaymentRequest` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayRecurringSummaryItem` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayCalendarUnit` | type | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayError` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayShippingContactUpdateRequest` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayCouponCodeEvent` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayCouponCodeUpdateRequest` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayShippingMethodUpdateRequest` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayAuthorizationActions` | interface | `configurations/ApplePayConfiguration.ts` |
-| `ApplePayPaymentAuthorization` | interface | `configurations/ApplePayConfiguration.ts` |
-| `CardsConfiguration` | interface | `configurations/CardsConfiguration.ts` |
-| `BinLookupData` | interface | `configurations/CardsConfiguration.ts` |
-| `InstallmentPlan` | type | `configurations/CardsConfiguration.ts` |
-| `InstallmentOption` | interface | `configurations/CardsConfiguration.ts` |
-| `InstallmentOptions` | interface | `configurations/CardsConfiguration.ts` |
-| `AddressMode` | type | `configurations/CardsConfiguration.ts` |
-| `FieldVisibility` | type | `configurations/CardsConfiguration.ts` |
-| `GooglePayConfiguration` | interface | `configurations/GooglePayConfiguration.ts` |
-| `GooglePayShippingAddressParameters` | interface | `configurations/GooglePayConfiguration.ts` |
-| `GooglePayBillingAddressParameters` | interface | `configurations/GooglePayConfiguration.ts` |
-| `GooglePayBillingAddressFormat` | type | `configurations/GooglePayConfiguration.ts` |
-| `TotalPriceStatus` | type | `configurations/GooglePayConfiguration.ts` |
-| `CardAuthMethod` | type | `configurations/GooglePayConfiguration.ts` |
-| `GooglePayEnvironment` | enum | `configurations/GooglePayConfiguration.ts` |
-| `DropInConfiguration` | interface | `configurations/DropInConfiguration.ts` |
-| `ThreeDSConfiguration` | interface | `configurations/ThreeDSConfiguration.ts` |
-| `PartialPaymentConfiguration` | interface | `configurations/PartialPaymentConfiguration.ts` |
-| `PartialPaymentComponent` | interface | `configurations/PartialPaymentConfiguration.ts` |
-| `AddressLookup` | interface | `configurations/AddressLookup.ts` |
-| `PostalAddress` | interface | `configurations/AddressLookup.ts` |
-| `AddressLookupItem` | interface | `configurations/AddressLookup.ts` |
+| `Configuration` | interface | `core/configurations/Configuration.ts` |
+| `BaseConfiguration` | interface | `core/configurations/Configuration.ts` |
+| `EnvironmentConfiguration` | interface | `core/configurations/Configuration.ts` |
+| `Environment` | type | `core/configurations/Configuration.ts` |
+| `AnalyticsOptions` | interface | `core/configurations/Configuration.ts` |
+| `ApplePayConfiguration` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayShippingType` | type | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayAddressFields` | type | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePaySummaryItem` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayShippingMethod` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayPaymentContact` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayRecurringPaymentRequest` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayRecurringSummaryItem` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayCalendarUnit` | type | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayError` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayShippingContactUpdateRequest` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayCouponCodeEvent` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayCouponCodeUpdateRequest` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayShippingMethodUpdateRequest` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayAuthorizationActions` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `ApplePayPaymentAuthorization` | interface | `core/configurations/ApplePayConfiguration.ts` |
+| `CardsConfiguration` | interface | `core/configurations/CardsConfiguration.ts` |
+| `BinLookupData` | interface | `core/configurations/CardsConfiguration.ts` |
+| `InstallmentPlan` | type | `core/configurations/CardsConfiguration.ts` |
+| `InstallmentOption` | interface | `core/configurations/CardsConfiguration.ts` |
+| `InstallmentOptions` | interface | `core/configurations/CardsConfiguration.ts` |
+| `AddressMode` | type | `core/configurations/CardsConfiguration.ts` |
+| `FieldVisibility` | type | `core/configurations/CardsConfiguration.ts` |
+| `GooglePayConfiguration` | interface | `core/configurations/GooglePayConfiguration.ts` |
+| `GooglePayShippingAddressParameters` | interface | `core/configurations/GooglePayConfiguration.ts` |
+| `GooglePayBillingAddressParameters` | interface | `core/configurations/GooglePayConfiguration.ts` |
+| `GooglePayBillingAddressFormat` | type | `core/configurations/GooglePayConfiguration.ts` |
+| `TotalPriceStatus` | type | `core/configurations/GooglePayConfiguration.ts` |
+| `CardAuthMethod` | type | `core/configurations/GooglePayConfiguration.ts` |
+| `GooglePayEnvironment` | enum (type-only) | `core/configurations/GooglePayConfiguration.ts` |
+| `DropInConfiguration` | interface | `core/configurations/DropInConfiguration.ts` |
+| `ThreeDSConfiguration` | interface | `core/configurations/ThreeDSConfiguration.ts` |
+| `PartialPaymentConfiguration` | interface | `core/configurations/PartialPaymentConfiguration.ts` |
+| `PartialPaymentComponent` | interface | `core/configurations/PartialPaymentConfiguration.ts` |
+| `AddressLookup` | interface | `core/configurations/AddressLookup.ts` |
+| `PostalAddress` | interface | `core/configurations/AddressLookup.ts` |
+| `AddressLookupItem` | interface | `core/configurations/AddressLookup.ts` |
 
 ## Constants & Enums
 


### PR DESCRIPTION
## Summary
- Strengthen `AGENTS.md` so `docs/Architecture.md` is kept in sync with code (not just reviewed before refactoring): added an "update in the same PR" rule for directory structure, class hierarchies, core interfaces, configuration hierarchy, embedded bus contracts, and event/error/result codes, plus an integrity-validation step (grep every documented symbol, remove stale entries).
- Add a new `## Public API` section to `AGENTS.md` declaring `src/index.ts` re-exports as the contractual API and governing add/remove/rename of exports as breaking changes.
- Add a standalone `docs/PublicAPI.md` enumerating every symbol re-exported through the four barrels (`components`, `core`, `hooks`, `modules`), grouped by category, with an "Internal (not exported)" section listing symbols that must stay internal (session, embedded bus, base wrappers, internal helpers).
- Update the Verification Checklist: item 7 now requires `docs/PublicAPI.md` to be updated and `example/` usages fixed on public API changes; new item 8 requires `docs/Architecture.md` update + integrity validation when structure/hierarchy/interfaces/configs/codes change.

No ticket — docs-only change to agent guidance and API documentation.

#### Test plan
- [ ] `docs/PublicAPI.md` cross-checked against `src/index.ts` and the four barrels (`src/components/index.ts`, `src/core/index.ts`, `src/hooks/index.ts`, `src/modules/index.ts`) — every listed export resolves, and internal symbols (session, embedded, base) are correctly excluded.
- [ ] `AGENTS.md` renders correctly (markdown structure, no broken references).
- [ ] No code or test changes — `yarn test` / `yarn lint` / `yarn typecheck` not affected.