### PR TITLE
test: improve iOS test suite quality in AdyenExampleTests

### DIFF
--- a/example/ios/AdyenExampleTests/ApplePayConfigurationTests.swift
+++ b/example/ios/AdyenExampleTests/ApplePayConfigurationTests.swift
@@ -30,7 +30,7 @@ final class ApplePayConfigurationTests: XCTestCase {
         "countryCode": "US"
     ]
 
-    func test_initialization_succeeds_withNewDictionary() throws {
+    func test_initialization_succeeds_withNewDictionary() {
         // GIVEN
         let configDict = NSDictionary()
         
@@ -42,7 +42,7 @@ final class ApplePayConfigurationTests: XCTestCase {
         XCTAssertFalse(sut.allowOnboarding)
     }
 
-    func test_initialization_succeeds_withEmptyDictionary() throws {
+    func test_initialization_succeeds_withEmptyDictionary() {
         // GIVEN
         let configDict: NSDictionary = [:]
         
@@ -62,13 +62,12 @@ final class ApplePayConfigurationTests: XCTestCase {
 
         // THEN
         XCTAssertNotNil(sut)
-        let expectation = self.expectation(description: "Expect throw")
         XCTAssertThrowsError(try sut.buildConfiguration(payment: mockPayment)) { error in
-            XCTAssertEqual(error.localizedDescription, ApplepayConfigurationParser.ApplePayError.invalidMerchantID.localizedDescription)
-            expectation.fulfill()
+            guard let applePayError = error as? ApplepayConfigurationParser.ApplePayError else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+            XCTAssertEqual(applePayError, .invalidMerchantID)
         }
-
-        self.wait(for: [expectation], timeout: 1)
     }
 
     func test_buildConfiguration_throwsInvalidMerchantID_withWrongSubDictionary() throws {
@@ -79,13 +78,12 @@ final class ApplePayConfigurationTests: XCTestCase {
         let sut = ApplepayConfigurationParser(configuration: configDict)
         
         // THEN
-        let expectation = self.expectation(description: "Expect throw")
         XCTAssertThrowsError(try sut.buildConfiguration(payment: mockPayment)) { error in
-            XCTAssertEqual(error.localizedDescription, ApplepayConfigurationParser.ApplePayError.invalidMerchantID.localizedDescription)
-            expectation.fulfill()
+            guard let applePayError = error as? ApplepayConfigurationParser.ApplePayError else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+            XCTAssertEqual(applePayError, .invalidMerchantID)
         }
-
-        self.wait(for: [expectation], timeout: 1)
     }
 
     func test_buildConfiguration_throwsInvalidMerchantName_whenMerchantNameMissing() throws {
@@ -100,13 +98,12 @@ final class ApplePayConfigurationTests: XCTestCase {
         let sut = ApplepayConfigurationParser(configuration: configDict)
 
         // THEN
-        let expectation = self.expectation(description: "Expect throw")
         XCTAssertThrowsError(try sut.buildConfiguration(payment: mockPayment)) { error in
-            XCTAssertEqual(error.localizedDescription, ApplepayConfigurationParser.ApplePayError.invalidMerchantName.localizedDescription)
-            expectation.fulfill()
+            guard let applePayError = error as? ApplepayConfigurationParser.ApplePayError else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+            XCTAssertEqual(applePayError, .invalidMerchantName)
         }
-
-        self.wait(for: [expectation], timeout: 1)
     }
 
     func test_buildPaymentRequest_createsValidRequest_withMinimalValidConfiguration() throws {
@@ -200,16 +197,15 @@ final class ApplePayConfigurationTests: XCTestCase {
         let sut = ApplepayConfigurationParser(configuration: configDict)
         
         // THEN
-        let expectation = self.expectation(description: "Expect throw")
         XCTAssertThrowsError(try sut.buildConfiguration(payment: mockPayment)) { error in
-            XCTAssertEqual(error.localizedDescription, ApplepayConfigurationParser.ApplePayError.invalidMerchantName.localizedDescription)
-            expectation.fulfill()
+            guard let applePayError = error as? ApplepayConfigurationParser.ApplePayError else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+            XCTAssertEqual(applePayError, .invalidMerchantName)
         }
-
-        self.wait(for: [expectation], timeout: 1)
     }
 
-    func test_allowOnboarding_returnsTrue_whenConfiguredWithBoolValue() throws {
+    func test_allowOnboarding_returnsTrue_whenConfiguredWithBoolValue() {
         // GIVEN
         let configDict: NSDictionary = [
             "applepay": [
@@ -226,7 +222,7 @@ final class ApplePayConfigurationTests: XCTestCase {
         XCTAssertTrue(sut.allowOnboarding)
     }
 
-    func test_allowOnboarding_returnsTrue_whenConfiguredWithStringValue() throws {
+    func test_allowOnboarding_returnsTrue_whenConfiguredWithStringValue() {
         // GIVEN
         let configDict: NSDictionary = [
             "applepay": [
@@ -243,7 +239,7 @@ final class ApplePayConfigurationTests: XCTestCase {
         XCTAssertTrue(sut.allowOnboarding)
     }
 
-    func test_allowOnboarding_returnsTrue_whenConfiguredWithNumericValue() throws {
+    func test_allowOnboarding_returnsTrue_whenConfiguredWithNumericValue() {
         // GIVEN
         let configDict: NSDictionary = [
             "applepay": [
@@ -482,7 +478,7 @@ final class ApplePayConfigurationTests: XCTestCase {
         XCTAssertEqual(parser.supportedCountries, Set(["US", "CA"]))
     }
 
-    func test_shippingMethods_parsesCorrectValues_whenConfigured() {
+    func test_shippingMethods_parsesCorrectValues_whenConfigured() throws {
         // GIVEN
         let configDict: NSDictionary = ["applepay": [
             "merchantID": "merchant.com.adyen.test",
@@ -516,7 +512,7 @@ final class ApplePayConfigurationTests: XCTestCase {
         XCTAssertNotNil(shippingMethods)
         XCTAssertEqual(shippingMethods?.count, 2)
 
-        var shippingMethod = shippingMethods![0]
+        var shippingMethod = try XCTUnwrap(shippingMethods?[0])
         XCTAssertEqual(shippingMethod.label, "Label 1")
         XCTAssertEqual(shippingMethod.amount, NSDecimalNumber(string: "10.1"))
         XCTAssertEqual(shippingMethod.type, .pending)
@@ -528,7 +524,7 @@ final class ApplePayConfigurationTests: XCTestCase {
             XCTAssertEqual(shippingMethod.dateComponentsRange?.startDateComponents.day, 1)
         }
 
-        shippingMethod = shippingMethods![1]
+        shippingMethod = try XCTUnwrap(shippingMethods?[1])
         XCTAssertEqual(shippingMethod.label, "Label 2")
         XCTAssertEqual(shippingMethod.amount, NSDecimalNumber(string: "10.1"))
         XCTAssertEqual(shippingMethod.type, .final)

--- a/example/ios/AdyenExampleTests/ApplePayConfigurationTests.swift
+++ b/example/ios/AdyenExampleTests/ApplePayConfigurationTests.swift
@@ -512,7 +512,7 @@ final class ApplePayConfigurationTests: XCTestCase {
         XCTAssertNotNil(shippingMethods)
         XCTAssertEqual(shippingMethods?.count, 2)
 
-        var shippingMethod = try XCTUnwrap(shippingMethods?[0])
+        var shippingMethod = try XCTUnwrap(shippingMethods?.first)
         XCTAssertEqual(shippingMethod.label, "Label 1")
         XCTAssertEqual(shippingMethod.amount, NSDecimalNumber(string: "10.1"))
         XCTAssertEqual(shippingMethod.type, .pending)
@@ -524,7 +524,7 @@ final class ApplePayConfigurationTests: XCTestCase {
             XCTAssertEqual(shippingMethod.dateComponentsRange?.startDateComponents.day, 1)
         }
 
-        shippingMethod = try XCTUnwrap(shippingMethods?[1])
+        shippingMethod = try XCTUnwrap(shippingMethods?.dropFirst().first)
         XCTAssertEqual(shippingMethod.label, "Label 2")
         XCTAssertEqual(shippingMethod.amount, NSDecimalNumber(string: "10.1"))
         XCTAssertEqual(shippingMethod.type, .final)

--- a/example/ios/AdyenExampleTests/ApplePayRecurringConfigurationParserTests.swift
+++ b/example/ios/AdyenExampleTests/ApplePayRecurringConfigurationParserTests.swift
@@ -4,10 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Foundation
-
 import Adyen
 @testable import adyen_react_native
+import Foundation
 import PassKit
 import XCTest
 

--- a/example/ios/AdyenExampleTests/CardConfigurationTests.swift
+++ b/example/ios/AdyenExampleTests/CardConfigurationTests.swift
@@ -20,7 +20,7 @@ final class CardConfigurationTests: XCTestCase {
     let mockAmount = Amount(value: 1000, currencyCode: "USD", localeIdentifier: "en-US")
     let mockAddressLookupProvider = AddressLookupProviderMock()
 
-    func test_initialization_createsConfiguration_withEmptyDictionary() throws {
+    func test_initialization_createsConfiguration_withEmptyDictionary() {
         // GIVEN
         let emptyDict = NSDictionary()
         
@@ -31,7 +31,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertNotNil(sut.configuration)
     }
 
-    func test_initialization_createsConfiguration_withEmptySubDictionary() throws {
+    func test_initialization_createsConfiguration_withEmptySubDictionary() {
         // GIVEN
         let configDict: NSDictionary = ["card": [:]]
         
@@ -42,7 +42,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertNotNil(sut.configuration)
     }
 
-    func test_configuration_setsShowStorePaymentField_whenProvided() throws {
+    func test_configuration_setsShowStorePaymentField_whenProvided() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["showStorePaymentField": false]]
         
@@ -53,7 +53,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertFalse(sut.configuration.showsStorePaymentMethodField)
     }
 
-    func test_configuration_setsShowsHolderNameField_whenHolderNameRequired() throws {
+    func test_configuration_setsShowsHolderNameField_whenHolderNameRequired() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["holderNameRequired": true]]
         
@@ -64,7 +64,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertTrue(sut.configuration.showsHolderNameField)
     }
 
-    func test_configuration_setsShowsSecurityCodeField_forStoredCard() throws {
+    func test_configuration_setsShowsSecurityCodeField_forStoredCard() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["hideCvcStoredCard": false]]
         
@@ -75,7 +75,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertTrue(sut.configuration.stored.showsSecurityCodeField) // inverted
     }
 
-    func test_configuration_setsShowsSecurityCodeField_whenHideCvcIsFalse() throws {
+    func test_configuration_setsShowsSecurityCodeField_whenHideCvcIsFalse() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["hideCvc": false]]
         
@@ -86,7 +86,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertTrue(sut.configuration.showsSecurityCodeField) // inverted
     }
 
-    func test_configuration_setsBillingAddressMode_toFull() throws {
+    func test_configuration_setsBillingAddressMode_toFull() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["addressVisibility": "full"]]
         
@@ -97,7 +97,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertEqual(sut.configuration.billingAddress.mode, .full)
     }
 
-    func test_configuration_setsBillingAddressMode_toPostalCode() throws {
+    func test_configuration_setsBillingAddressMode_toPostalCode() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["addressVisibility": "postal"]]
         
@@ -108,7 +108,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertEqual(sut.configuration.billingAddress.mode, .postalCode)
     }
 
-    func test_configuration_setsKoreanAuthenticationMode_toHide() throws {
+    func test_configuration_setsKoreanAuthenticationMode_toHide() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["kcpVisibility": "hide"]]
         
@@ -119,7 +119,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertEqual(sut.configuration.koreanAuthenticationMode, .hide)
     }
 
-    func test_configuration_setsKoreanAuthenticationMode_toShow() throws {
+    func test_configuration_setsKoreanAuthenticationMode_toShow() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["kcpVisibility": "show"]]
         
@@ -130,7 +130,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertEqual(sut.configuration.koreanAuthenticationMode, .show)
     }
 
-    func test_configuration_setsSocialSecurityNumberMode_toHide() throws {
+    func test_configuration_setsSocialSecurityNumberMode_toHide() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["socialSecurity": "hide"]]
         
@@ -141,7 +141,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertEqual(sut.configuration.socialSecurityNumberMode, .hide)
     }
 
-    func test_configuration_setsSocialSecurityNumberMode_toShow() throws {
+    func test_configuration_setsSocialSecurityNumberMode_toShow() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["socialSecurity": "show"]]
         
@@ -152,7 +152,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertEqual(sut.configuration.socialSecurityNumberMode, .show)
     }
 
-    func test_configuration_setsAllowedCardTypes_whenProvided() throws {
+    func test_configuration_setsAllowedCardTypes_whenProvided() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["supported": ["visa", "mc", "maestro"]]]
         
@@ -163,7 +163,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertEqual(sut.configuration.allowedCardTypes?.count, 3)
     }
 
-    func test_configuration_setsBillingAddressCountryCodes_whenProvided() throws {
+    func test_configuration_setsBillingAddressCountryCodes_whenProvided() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["allowedAddressCountryCodes": ["GB", "US"]]]
         
@@ -174,7 +174,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertEqual(sut.configuration.billingAddress.countryCodes?.count, 2)
     }
 
-    func test_configuration_setsInstallmentConfiguration_withDefaultOptions() throws {
+    func test_configuration_setsInstallmentConfiguration_withDefaultOptions() {
         // GIVEN
         let configDict: NSDictionary = [
             "card": [
@@ -195,7 +195,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertFalse(sut.configuration.installmentConfiguration?.defaultOptions?.includesRevolving ?? true)
     }
 
-    func test_configuration_setsInstallmentConfiguration_withRevolvingPlan() throws {
+    func test_configuration_setsInstallmentConfiguration_withRevolvingPlan() {
         // GIVEN
         let configDict: NSDictionary = [
             "card": [
@@ -216,7 +216,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertTrue(sut.configuration.installmentConfiguration?.defaultOptions?.includesRevolving ?? false)
     }
 
-    func test_configuration_setsInstallmentConfiguration_withCardBasedOptions() throws {
+    func test_configuration_setsInstallmentConfiguration_withCardBasedOptions() {
         // GIVEN
         let configDict: NSDictionary = [
             "card": [
@@ -239,7 +239,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertEqual(sut.configuration.installmentConfiguration?.cardBasedOptions?.count, 2)
     }
 
-    func test_configuration_setsInstallmentConfiguration_withMixedOptions() throws {
+    func test_configuration_setsInstallmentConfiguration_withMixedOptions() {
         // GIVEN
         let configDict: NSDictionary = [
             "card": [
@@ -262,7 +262,7 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertNotNil(sut.configuration.installmentConfiguration)
     }
 
-    func test_configuration_showInstallmentAmount_defaultsToFalse() throws {
+    func test_configuration_showInstallmentAmount_defaultsToFalse() {
         // GIVEN
         let configDict: NSDictionary = [
             "card": [

--- a/example/ios/AdyenExampleTests/DropInConfigurationParserTests.swift
+++ b/example/ios/AdyenExampleTests/DropInConfigurationParserTests.swift
@@ -4,15 +4,14 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Foundation
-
 import Adyen
 @testable import adyen_react_native
+import Foundation
 import XCTest
 
 final class DropInConfigurationParserTests: XCTestCase {
 
-    func test_initialization_usesDefaultValues_withNewDictionary() throws {
+    func test_initialization_usesDefaultValues_withNewDictionary() {
         // GIVEN
         let configDict = NSDictionary()
         
@@ -23,7 +22,7 @@ final class DropInConfigurationParserTests: XCTestCase {
         XCTAssertTrue(sut.showPreselectedStoredPaymentMethod)
     }
 
-    func test_initialization_appliesProvidedSettings_withFullConfiguration() throws {
+    func test_initialization_appliesProvidedSettings_withFullConfiguration() {
         // GIVEN
         let configDict: NSDictionary = [
             "showPreselectedStoredPaymentMethod": false,
@@ -47,7 +46,7 @@ final class DropInConfigurationParserTests: XCTestCase {
         XCTAssertTrue(sut.configuration.paymentMethodsList.allowDisablingStoredPaymentMethods)
     }
 
-    func test_initialization_usesDefaultValues_withEmptySubDictionary() throws {
+    func test_initialization_usesDefaultValues_withEmptySubDictionary() {
         // GIVEN
         let configDict: NSDictionary = ["dropin": [:]]
 
@@ -58,7 +57,7 @@ final class DropInConfigurationParserTests: XCTestCase {
         XCTAssertTrue(sut.showPreselectedStoredPaymentMethod)
     }
 
-    func test_showPreselectedStoredPaymentMethod_returnsFalse_whenExplicitlySet() throws {
+    func test_showPreselectedStoredPaymentMethod_returnsFalse_whenExplicitlySet() {
         // GIVEN
         let configDict: NSDictionary = ["dropin": ["showPreselectedStoredPaymentMethod": false]]
         

--- a/example/ios/AdyenExampleTests/Encoders/EncodablePaymentComponentDataTests.swift
+++ b/example/ios/AdyenExampleTests/Encoders/EncodablePaymentComponentDataTests.swift
@@ -6,7 +6,6 @@
 
 @testable @_spi(AdyenInternal) import Adyen
 @testable import adyen_react_native
-
 import XCTest
 
 class EncodablePaymentComponentDataTests: XCTestCase {
@@ -21,7 +20,7 @@ class EncodablePaymentComponentDataTests: XCTestCase {
 
         // WHEN
         let data = try encoder.encode(encodableData)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         // THEN
         XCTAssertNotNil(json["paymentMethod"])
@@ -31,7 +30,7 @@ class EncodablePaymentComponentDataTests: XCTestCase {
         XCTAssertNil(json["order"])
         XCTAssertNil(json["checkoutAttemptId"])
         XCTAssertNil(json["installments"])
-        XCTAssertTrue(json["supportNativeRedirect"] as! Bool)
+        XCTAssertTrue(try XCTUnwrap(json["supportNativeRedirect"] as? Bool))
         XCTAssertNil(json["delegatedAuthenticationData"])
     }
 
@@ -50,11 +49,11 @@ class EncodablePaymentComponentDataTests: XCTestCase {
 
         // WHEN
         let data = try encoder.encode(encodableData)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         // THEN
         XCTAssertNotNil(json["paymentMethod"])
-        XCTAssertTrue(json["storePaymentMethod"] as! Bool)
+        XCTAssertTrue(try XCTUnwrap(json["storePaymentMethod"] as? Bool))
         XCTAssertNotNil(json["browserInfo"])
         XCTAssertNotNil(json["amount"])
         XCTAssertNotNil(json["order"])
@@ -77,7 +76,7 @@ class EncodablePaymentComponentDataTests: XCTestCase {
 
         // WHEN
         let data = try encoder.encode(encodableData)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         // THEN
         XCTAssertNotNil(json["paymentMethod"])
@@ -99,7 +98,7 @@ class EncodablePaymentComponentDataTests: XCTestCase {
 
         // WHEN
         let data = try encoder.encode(encodableData)
-        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         // THEN
         XCTAssertNotNil(json["paymentMethod"])

--- a/example/ios/AdyenExampleTests/Modules/BaseModuleTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/BaseModuleTests.swift
@@ -94,7 +94,7 @@ final class BaseModuleTests: XCTestCase {
     func test_cleanUp_withMultipleVCsInStack_dismissesOnlyFirstVC() {
         // GIVEN
         let exp = expectation(description: "first VC dismissed")
-        let rootMock = makeMockDismissableVC(onDismiss: exp.fulfill())
+        let rootMock = makeMockDismissableVC(onDismiss: { exp.fulfill() })
         let paymentMock = makeMockDismissableVC()
         BaseModule.presenterStack = [rootMock, paymentMock]
 
@@ -188,7 +188,7 @@ final class BaseModuleTests: XCTestCase {
     func test_hide_success_callsDismiss_andClearsState() {
         // GIVEN
         let exp = expectation(description: "hide clears state")
-        let rootMock = makeMockDismissableVC(onDismiss: exp.fulfill())
+        let rootMock = makeMockDismissableVC(onDismiss: { exp.fulfill() })
         BaseModule.presenterStack = [rootMock]
 
         // WHEN

--- a/example/ios/AdyenExampleTests/Modules/BaseModuleTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/BaseModuleTests.swift
@@ -11,11 +11,11 @@ import UIKit
 
 final class BaseModuleTests: XCTestCase {
 
-    private var sut: TestableModule!
+    private var sut: BaseModuleSender!
 
     override func setUp() {
         super.setUp()
-        sut = TestableModule()
+        sut = BaseModuleSender()
     }
 
     override func tearDown() {
@@ -30,63 +30,80 @@ final class BaseModuleTests: XCTestCase {
     // MARK: - presenterStack / currentPresenter
 
     func test_currentPresenter_isNil_whenStackIsEmpty() {
+        // GIVEN
         XCTAssertTrue(BaseModule.presenterStack.isEmpty)
+
+        // THEN
         XCTAssertNil(BaseModule.currentPresenter)
     }
 
     func test_currentPresenter_returnsSingleEntry() {
+        // GIVEN
         let vc = UIViewController()
         BaseModule.presenterStack = [vc]
+
+        // THEN
         XCTAssertTrue(BaseModule.currentPresenter === vc)
     }
 
     func test_currentPresenter_returnsLastEntry_withMultipleVCs() {
+        // GIVEN
         let first = UIViewController()
         let last = UIViewController()
         BaseModule.presenterStack = [first, UIViewController(), last]
+
+        // THEN
         XCTAssertTrue(BaseModule.currentPresenter === last)
     }
 
     // MARK: - cleanUp — presenterStack state
 
     func test_cleanUp_withEmptyStack_doesNotCrash() {
+        // GIVEN
         let exp = expectation(description: "cleanUp on main thread")
         BaseModule.presenterStack = []
 
+        // WHEN
         DispatchQueue.main.async {
             self.sut.cleanUp()
             exp.fulfill()
         }
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertTrue(BaseModule.presenterStack.isEmpty)
     }
 
     func test_cleanUp_clearsEntireStack() {
+        // GIVEN
         let exp = expectation(description: "cleanUp on main thread")
         BaseModule.presenterStack = [UIViewController(), UIViewController(), UIViewController()]
 
+        // WHEN
         DispatchQueue.main.async {
             self.sut.cleanUp()
             exp.fulfill()
         }
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertTrue(BaseModule.presenterStack.isEmpty)
     }
 
     /// Verifies the linked-list dismissal: only presenterStack.first receives `dismiss`.
     func test_cleanUp_withMultipleVCsInStack_dismissesOnlyFirstVC() {
+        // GIVEN
         let exp = expectation(description: "first VC dismissed")
-        let rootMock = MockDismissableViewController()
-        let paymentMock = MockDismissableViewController()
-        rootMock.onDismiss = { exp.fulfill() }
+        let rootMock = makeMockDismissableVC(onDismiss: exp.fulfill())
+        let paymentMock = makeMockDismissableVC()
         BaseModule.presenterStack = [rootMock, paymentMock]
 
+        // WHEN
         DispatchQueue.main.async {
             self.sut.cleanUp()
         }
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertTrue(rootMock.dismissCalled, "Root (first) VC should be dismissed")
         XCTAssertFalse(paymentMock.dismissCalled, "Payment (last) VC should NOT be dismissed directly")
@@ -96,27 +113,33 @@ final class BaseModuleTests: XCTestCase {
     // MARK: - cleanUp — static state
 
     func test_cleanUp_clearsCurrentModule() {
+        // GIVEN
         let exp = expectation(description: "cleanUp completes")
         BaseModule.currentModule = sut
 
+        // WHEN
         DispatchQueue.main.async {
             self.sut.cleanUp()
             exp.fulfill()
         }
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertNil(BaseModule.currentModule)
     }
 
     func test_cleanUp_clearsCurrentComponent() {
+        // GIVEN
         let exp = expectation(description: "cleanUp completes")
         sut.currentComponent = MockComponent()
 
+        // WHEN
         DispatchQueue.main.async {
             self.sut.cleanUp()
             exp.fulfill()
         }
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertNil(sut.currentComponent)
     }
@@ -124,14 +147,17 @@ final class BaseModuleTests: XCTestCase {
     // MARK: - dismiss
 
     func test_dismiss_withNoCurrentComponent_callsCleanUp() {
+        // GIVEN
         let exp = expectation(description: "dismiss completes")
         BaseModule.currentModule = sut
 
+        // WHEN
         DispatchQueue.global().async {
             self.sut.dismiss(false)
             DispatchQueue.main.async { exp.fulfill() }
         }
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertNil(BaseModule.currentModule)
     }
@@ -139,55 +165,70 @@ final class BaseModuleTests: XCTestCase {
     // MARK: - checkErrorType
 
     func test_checkErrorType_componentCancelled_returnsCanceled() {
+        // WHEN
         let result = sut.checkErrorType(ComponentError.cancelled)
+
+        // THEN
         XCTAssertEqual((result as? KnownError)?.errorCode, "canceledByShopper")
     }
 
     func test_checkErrorType_otherError_returnsOriginalError() {
+        // GIVEN
         let original = NSError(domain: "test.domain", code: 42)
+
+        // WHEN
         let result = sut.checkErrorType(original)
+
+        // THEN
         XCTAssertTrue((result as NSError) === original)
     }
 
     // MARK: - hide
 
     func test_hide_success_callsDismiss_andClearsState() {
+        // GIVEN
         let exp = expectation(description: "hide clears state")
-        let rootMock = MockDismissableViewController()
-        rootMock.onDismiss = { exp.fulfill() }
+        let rootMock = makeMockDismissableVC(onDismiss: exp.fulfill())
         BaseModule.presenterStack = [rootMock]
 
+        // WHEN
         DispatchQueue.main.async {
             self.sut.hide(NSNumber(value: true), event: [:])
         }
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertTrue(rootMock.dismissCalled)
         XCTAssertTrue(BaseModule.presenterStack.isEmpty)
     }
 
     func test_hide_withEmptyStack_doesNotCrash() {
+        // GIVEN
         let exp = expectation(description: "hide completes without crash")
 
+        // WHEN
         DispatchQueue.main.async {
             self.sut.hide(NSNumber(value: false), event: [:])
             DispatchQueue.main.async { exp.fulfill() }
         }
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
     }
 
     // MARK: - present(component:) via PresentationDelegate
 
     func test_present_requiresModal_wrapsComponentInNavigationController() {
+        // GIVEN
         let exp = expectation(description: "presenter.present called")
-        let mockPresenter = MockPresentingViewController()
-        mockPresenter.onPresent = { _ in exp.fulfill() }
-        let mockComponent = MockPresentableComponent(requiresModalPresentation: true)
+        let mockPresenter = makeMockPresenter(onPresent: { _ in exp.fulfill() })
+        let mockComponent = makeMockComponent(requiresModalPresentation: true)
         BaseModule.presenterStack = [mockPresenter]
 
+        // WHEN
         sut.present(component: mockComponent)
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertTrue(mockPresenter.lastPresentedViewController is UINavigationController)
         let nav = mockPresenter.lastPresentedViewController as? UINavigationController
@@ -195,40 +236,46 @@ final class BaseModuleTests: XCTestCase {
     }
 
     func test_present_requiresModal_addsRightCancelBarButton() {
+        // GIVEN
         let exp = expectation(description: "presenter.present called")
-        let mockPresenter = MockPresentingViewController()
-        mockPresenter.onPresent = { _ in exp.fulfill() }
-        let mockComponent = MockPresentableComponent(requiresModalPresentation: true)
+        let mockPresenter = makeMockPresenter(onPresent: { _ in exp.fulfill() })
+        let mockComponent = makeMockComponent(requiresModalPresentation: true)
         BaseModule.presenterStack = [mockPresenter]
 
+        // WHEN
         sut.present(component: mockComponent)
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertNotNil(mockComponent.viewController.navigationItem.rightBarButtonItem)
     }
 
     func test_present_noModalRequired_presentsComponentViewControllerDirectly() {
+        // GIVEN
         let exp = expectation(description: "presenter.present called")
-        let mockPresenter = MockPresentingViewController()
-        mockPresenter.onPresent = { _ in exp.fulfill() }
-        let mockComponent = MockPresentableComponent(requiresModalPresentation: false)
+        let mockPresenter = makeMockPresenter(onPresent: { _ in exp.fulfill() })
+        let mockComponent = makeMockComponent(requiresModalPresentation: false)
         BaseModule.presenterStack = [mockPresenter]
 
+        // WHEN
         sut.present(component: mockComponent)
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertTrue(mockPresenter.lastPresentedViewController === mockComponent.viewController)
     }
 
     func test_present_appendsPresentedViewControllerToStack() {
+        // GIVEN
         let exp = expectation(description: "stack updated")
-        let mockPresenter = MockPresentingViewController()
-        mockPresenter.onPresent = { _ in exp.fulfill() }
-        let mockComponent = MockPresentableComponent(requiresModalPresentation: false)
+        let mockPresenter = makeMockPresenter(onPresent: { _ in exp.fulfill() })
+        let mockComponent = makeMockComponent(requiresModalPresentation: false)
         BaseModule.presenterStack = [mockPresenter]
 
+        // WHEN
         sut.present(component: mockComponent)
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertEqual(BaseModule.presenterStack.count, 2)
         XCTAssertTrue(BaseModule.presenterStack.first === mockPresenter)
@@ -236,27 +283,30 @@ final class BaseModuleTests: XCTestCase {
     }
 
     func test_present_setsCurrentModule() {
+        // GIVEN
         let exp = expectation(description: "present dispatched")
-        let mockPresenter = MockPresentingViewController()
-        mockPresenter.onPresent = { _ in exp.fulfill() }
+        let mockPresenter = makeMockPresenter(onPresent: { _ in exp.fulfill() })
         BaseModule.presenterStack = [mockPresenter]
 
-        sut.present(component: MockPresentableComponent(requiresModalPresentation: false))
+        // WHEN
+        sut.present(component: makeMockComponent(requiresModalPresentation: false))
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertTrue(BaseModule.currentModule === sut)
     }
 
     func test_present_withEmptyStack_usesTopPresenterProvider() {
+        // GIVEN
         let exp = expectation(description: "topPresenter used when stack is empty")
-        let injectedPresenter = MockPresentingViewController()
-        injectedPresenter.onPresent = { _ in exp.fulfill() }
-        // Stack is empty → falls through to topPresenterProvider
+        let injectedPresenter = makeMockPresenter(onPresent: { _ in exp.fulfill() })
         BaseModule.presenterStack = []
         BaseModule.topPresenterProvider = { injectedPresenter }
 
-        sut.present(component: MockPresentableComponent(requiresModalPresentation: false))
+        // WHEN
+        sut.present(component: makeMockComponent(requiresModalPresentation: false))
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertTrue(injectedPresenter.presentCalled)
         // topPresenter itself is pushed as the first stack entry, then the presented VC
@@ -265,46 +315,58 @@ final class BaseModuleTests: XCTestCase {
     }
 
     func test_present_withNoPresenterAndNoTopPresenter_sendsNotKeyWindowError() {
+        // GIVEN
         let exp = expectation(description: "error sent")
         let mockEmitter = MockEmitter()
         sut.emitterOverride = mockEmitter
         BaseModule.presenterStack = []
         BaseModule.topPresenterProvider = { nil }
 
-        sut.present(component: MockPresentableComponent(requiresModalPresentation: false))
+        // WHEN
+        sut.present(component: makeMockComponent(requiresModalPresentation: false))
 
+        // THEN
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { exp.fulfill() }
         wait(for: [exp], timeout: 1.0)
         XCTAssertEqual(mockEmitter.eventCount(named: EventName.fail.rawValue), 1)
     }
 
     func test_present_usesCurrentPresenter_fromStack() {
+        // GIVEN
         let exp = expectation(description: "correct presenter used")
-        let firstPresenter = MockPresentingViewController()
-        let secondPresenter = MockPresentingViewController()
-        secondPresenter.onPresent = { _ in exp.fulfill() }
-        // secondPresenter is last → currentPresenter
+        let firstPresenter = makeMockPresenter()
+        let secondPresenter = makeMockPresenter(onPresent: { _ in exp.fulfill() })
         BaseModule.presenterStack = [firstPresenter, secondPresenter]
 
-        sut.present(component: MockPresentableComponent(requiresModalPresentation: false))
+        // WHEN
+        sut.present(component: makeMockComponent(requiresModalPresentation: false))
 
+        // THEN
         wait(for: [exp], timeout: 1.0)
         XCTAssertFalse(firstPresenter.presentCalled, "First VC should not be used as presenter")
         XCTAssertTrue(secondPresenter.presentCalled, "Last (current) VC should be used as presenter")
     }
-}
 
-// MARK: - Helpers
+    // MARK: - Helpers
 
-private final class TestableModule: BaseModuleSender {
-    override init() {
-        super.init()
+    private func makeMockPresenter(onPresent: ((UIViewController) -> Void)? = nil) -> MockPresentingViewController {
+        let presenter = MockPresentingViewController()
+        presenter.onPresent = onPresent
+        return presenter
     }
 
-    @available(*, unavailable) required init?(coder: NSCoder) {
-        fatalError()
+    private func makeMockComponent(requiresModalPresentation: Bool) -> MockPresentableComponent {
+        MockPresentableComponent(requiresModalPresentation: requiresModalPresentation)
+    }
+
+    private func makeMockDismissableVC(onDismiss: (() -> Void)? = nil) -> MockDismissableViewController {
+        let vc = MockDismissableViewController()
+        vc.onDismiss = onDismiss
+        return vc
     }
 }
+
+// MARK: - Mocks
 
 private final class MockDismissableViewController: UIViewController {
     var dismissCalled = false


### PR DESCRIPTION
## Summary
- Remove unnecessary `throws` from non-throwing test methods across `ApplePayConfigurationTests`, `CardConfigurationTests`, `DropInConfigurationParserTests`, and `EncodablePaymentComponentDataTests`.
- Replace force-unwraps (`!`) with `XCTUnwrap` in `ApplePayConfigurationTests`.
- Replace `expectation`/`wait` patterns with synchronous `XCTAssertThrowsError` and typed error assertions in `ApplePayConfigurationTests`.
- Reorder imports alphabetically in `ApplePayRecurringConfigurationParserTests`.
- Add GIVEN/WHEN/THEN comments and introduce helper factory methods (`makeMockDismissableVC`, `makeMockPresenter`, `makeMockComponent`) in `BaseModuleTests`.

No ticket associated — standalone test cleanup.
