### PR TITLE
fix: run embedded CardView native lifecycle on main thread

### DIFF
--- a/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
@@ -168,6 +168,57 @@ final class ThreadingSafetyTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func test_cardComponentViewProxyDispose_fromBackgroundThread_doesNotCrash() {
+        let bus = EmbeddedComponentBusModule()
+        EmbeddedComponentBusModule.shared = bus
+        bus.createActionHandlerIfNeeded(context: Self.context, locale: nil)
+        _ = bus.register(viewId: "card-view")
+
+        let proxy = CardComponentViewProxy(frame: .zero)
+        proxy.viewId = "card-view"
+
+        let disposeExpectation = expectation(description: "Dispose should complete")
+        DispatchQueue.global().async {
+            proxy.dispose()
+            DispatchQueue.main.async {
+                disposeExpectation.fulfill()
+            }
+        }
+
+        wait(for: [disposeExpectation], timeout: 1.0)
+
+        // Bus should still be usable afterwards, proving state wasn't corrupted.
+        let newProxy = bus.register(viewId: "card-view-2")
+        XCTAssertNotNil(newProxy)
+    }
+
+    func test_cardComponentViewProxyInitialize_fromBackgroundThread_reportsErrorOnMainThread() {
+        let bus = EmbeddedComponentBusModule()
+        EmbeddedComponentBusModule.shared = bus
+        let emitter = ThreadTrackingEmitter()
+        bus.emitterOverride = emitter
+
+        let proxy = CardComponentViewProxy(frame: .zero)
+        proxy.viewId = "card-view"
+
+        let expectation = expectation(description: "Error should be reported on main thread")
+
+        DispatchQueue.global().async {
+            proxy.setPaymentMethod(Self.invalidCardPaymentMethodJSON)
+            proxy.setConfiguration("{}")
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            // Each failed attempt resets `hasComponent`, so both setters can independently
+            // re-trigger initialization; what matters is that every emission is main-thread.
+            XCTAssertGreaterThanOrEqual(emitter.eventCount, 1)
+            XCTAssertTrue(emitter.sentOnMainThread)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func test_embeddedComponentBusHide_fromBackgroundThread_dismissesPresenterOnMainThread() {
         let expectation = expectation(description: "Presenter should be dismissed")
         let sut = EmbeddedComponentBusModule()
@@ -279,6 +330,10 @@ final class ThreadingSafetyTests: XCTestCase {
         apiContext: try! APIContext(environment: Environment.test, clientKey: "local_DUMMYKEYFORTESTING"),
         payment: nil
     )
+
+    /// "type" has the wrong JSON type (number instead of string), guaranteeing
+    /// `CardPaymentMethod` decoding fails and `createCardComponent` takes its error path.
+    private static let invalidCardPaymentMethodJSON = #"{"type":123}"#
 }
 
 private final class TestableBaseModule: BaseModule {
@@ -289,6 +344,16 @@ private final class TestableBaseModule: BaseModule {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private final class ThreadTrackingEmitter: EventEmitter {
+    private(set) var eventCount = 0
+    private(set) var sentOnMainThread = false
+
+    func send(event: EventName, body: Any?) {
+        eventCount += 1
+        sentOnMainThread = Thread.isMainThread
     }
 }
 

--- a/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
@@ -20,6 +20,7 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_baseModuleCleanUp_fromBackgroundThread_dismissesPresenterOnMainThread() {
+        // GIVEN a BaseModule with a presented view controller
         let expectation = expectation(description: "Presenter should be dismissed")
         let sut = TestableBaseModule()
         let presenter = MockPresenterViewController()
@@ -28,10 +29,12 @@ final class ThreadingSafetyTests: XCTestCase {
         }
         BaseModule.presenterStack = [presenter]
 
+        // WHEN cleanUp() is called from a background thread
         DispatchQueue.global().async {
             sut.cleanUp()
         }
 
+        // THEN the presenter is dismissed on the main thread
         wait(for: [expectation], timeout: 1.0)
         XCTAssertTrue(presenter.dismissCalled)
         XCTAssertTrue(presenter.dismissCalledOnMainThread)
@@ -39,6 +42,7 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_embeddedComponentBusUnsubscribe_fromBackgroundThread_dismissesPresenterOnMainThread() {
+        // GIVEN an EmbeddedComponentBusModule with a subscribed, presented view
         let expectation = expectation(description: "Presenter should be dismissed")
         let sut = EmbeddedComponentBusModule()
         let presenter = MockPresenterViewController()
@@ -49,10 +53,12 @@ final class ThreadingSafetyTests: XCTestCase {
 
         sut.subscribe("card-view")
 
+        // WHEN unsubscribe() is called from a background thread
         DispatchQueue.global().async {
             sut.unsubscribe("card-view")
         }
 
+        // THEN the presenter is dismissed on the main thread
         wait(for: [expectation], timeout: 1.0)
         XCTAssertTrue(presenter.dismissCalled)
         XCTAssertTrue(presenter.dismissCalledOnMainThread)
@@ -60,16 +66,19 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_ensureMainThread_runsImmediately_whenAlreadyOnMainThread() {
+        // GIVEN we are already running on the main thread
         let expectation = expectation(description: "Work should run immediately")
 
         DispatchQueue.main.async {
             var didRun = false
 
+            // WHEN ensureMainThread is called
             ensureMainThread {
                 didRun = true
                 XCTAssertTrue(Thread.isMainThread)
             }
 
+            // THEN the work runs synchronously, without an extra dispatch
             XCTAssertTrue(didRun)
             expectation.fulfill()
         }
@@ -78,10 +87,13 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_ensureMainThread_dispatchesWorkToMainThread_fromBackgroundThread() {
+        // GIVEN we are running on a background thread
         let expectation = expectation(description: "Work should run on main thread")
 
+        // WHEN ensureMainThread is called
         DispatchQueue.global().async {
             ensureMainThread {
+                // THEN the work is dispatched to and executed on the main thread
                 XCTAssertTrue(Thread.isMainThread)
                 expectation.fulfill()
             }
@@ -91,14 +103,17 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_baseModuleCleanUp_withoutPresentedViewController_clearsPresenter() {
+        // GIVEN a BaseModule with a presenter that has no presented view controller
         let expectation = expectation(description: "Presenter should be cleared")
 
         DispatchQueue.main.async {
             let sut = TestableBaseModule()
             BaseModule.presenterStack = [UIViewController()]
 
+            // WHEN cleanUp() is called
             sut.cleanUp()
 
+            // THEN the presenter stack is cleared
             XCTAssertNil(BaseModule.currentPresenter)
             expectation.fulfill()
         }
@@ -107,16 +122,19 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_embeddedComponentBusUpdate_fromBackgroundThread_callsLookupHandlerOnMainThread() {
+        // GIVEN an EmbeddedComponentBusModule with a registered lookup handler
         let expectation = expectation(description: "Lookup handler should be called")
         let sut = EmbeddedComponentBusModule()
 
         sut.storeLookupHandler(for: "card-view") { addresses in
+            // THEN the handler is invoked on the main thread with the decoded addresses
             XCTAssertTrue(Thread.isMainThread)
             XCTAssertEqual(addresses.count, 1)
             XCTAssertEqual(addresses.first?.postalAddress.street, "Main St")
             expectation.fulfill()
         }
 
+        // WHEN update() is called from a background thread
         DispatchQueue.global().async {
             sut.update("card-view", results: [Self.lookupAddress] as NSArray)
         }
@@ -125,10 +143,12 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_embeddedComponentBusConfirmSuccess_fromBackgroundThread_callsCompletionOnMainThread() {
+        // GIVEN an EmbeddedComponentBusModule with a registered completion handler
         let expectation = expectation(description: "Completion handler should receive success")
         let sut = EmbeddedComponentBusModule()
 
         sut.storeLookupCompletionHandler(for: "card-view") { result in
+            // THEN the handler is invoked on the main thread with a success result
             XCTAssertTrue(Thread.isMainThread)
             guard case let .success(address) = result else {
                 return XCTFail("Expected success result")
@@ -137,6 +157,7 @@ final class ThreadingSafetyTests: XCTestCase {
             expectation.fulfill()
         }
 
+        // WHEN confirm() is called with a successful address from a background thread
         DispatchQueue.global().async {
             sut.confirm("card-view", success: NSNumber(value: true), address: Self.lookupAddress)
         }
@@ -145,10 +166,12 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_embeddedComponentBusConfirmFailure_fromBackgroundThread_callsCompletionOnMainThread() {
+        // GIVEN an EmbeddedComponentBusModule with a registered completion handler
         let expectation = expectation(description: "Completion handler should receive failure")
         let sut = EmbeddedComponentBusModule()
 
         sut.storeLookupCompletionHandler(for: "card-view") { result in
+            // THEN the handler is invoked on the main thread with a failure result
             XCTAssertTrue(Thread.isMainThread)
             guard case let .failure(error) = result else {
                 return XCTFail("Expected failure result")
@@ -157,6 +180,7 @@ final class ThreadingSafetyTests: XCTestCase {
             expectation.fulfill()
         }
 
+        // WHEN confirm() is called with a failed address from a background thread
         DispatchQueue.global().async {
             sut.confirm(
                 "card-view",
@@ -169,6 +193,7 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_cardComponentViewProxyDispose_fromBackgroundThread_doesNotCrash() {
+        // GIVEN a CardComponentViewProxy registered with the component bus
         let bus = EmbeddedComponentBusModule()
         EmbeddedComponentBusModule.shared = bus
         bus.createActionHandlerIfNeeded(context: Self.context, locale: nil)
@@ -177,6 +202,7 @@ final class ThreadingSafetyTests: XCTestCase {
         let proxy = CardComponentViewProxy(frame: .zero)
         proxy.viewId = "card-view"
 
+        // WHEN dispose() is called from a background thread
         let disposeExpectation = expectation(description: "Dispose should complete")
         DispatchQueue.global().async {
             proxy.dispose()
@@ -185,14 +211,15 @@ final class ThreadingSafetyTests: XCTestCase {
             }
         }
 
+        // THEN dispose completes without crashing and the bus state is not corrupted
         wait(for: [disposeExpectation], timeout: 1.0)
 
-        // Bus should still be usable afterwards, proving state wasn't corrupted.
         let newProxy = bus.register(viewId: "card-view-2")
         XCTAssertNotNil(newProxy)
     }
 
     func test_cardComponentViewProxyInitialize_fromBackgroundThread_reportsErrorOnMainThread() {
+        // GIVEN a CardComponentViewProxy that will fail to decode its payment method
         let bus = EmbeddedComponentBusModule()
         EmbeddedComponentBusModule.shared = bus
         let emitter = ThreadTrackingEmitter()
@@ -209,17 +236,20 @@ final class ThreadingSafetyTests: XCTestCase {
             expectation.fulfill()
         }
 
+        // WHEN the payment method and configuration are set from a background thread
         DispatchQueue.global().async {
             proxy.setPaymentMethod(Self.invalidCardPaymentMethodJSON)
             proxy.setConfiguration("{}")
         }
 
+        // THEN the resulting error is emitted on the main thread
         wait(for: [expectation], timeout: 1.0)
         XCTAssertGreaterThanOrEqual(emitter.eventCount, 1)
         XCTAssertTrue(emitter.sentOnMainThread)
     }
 
     func test_embeddedComponentBusHide_fromBackgroundThread_dismissesPresenterOnMainThread() {
+        // GIVEN an EmbeddedComponentBusModule with a registered, presented view
         let expectation = expectation(description: "Presenter should be dismissed")
         let sut = EmbeddedComponentBusModule()
         let presenter = MockPresenterViewController()
@@ -230,10 +260,12 @@ final class ThreadingSafetyTests: XCTestCase {
 
         _ = sut.register(viewId: "card-view")
 
+        // WHEN hide() is called from a background thread
         DispatchQueue.global().async {
             sut.hide("card-view", success: NSNumber(value: true), event: [:])
         }
 
+        // THEN the presenter is dismissed on the main thread
         wait(for: [expectation], timeout: 1.0)
         XCTAssertTrue(presenter.dismissCalled)
         XCTAssertTrue(presenter.dismissCalledOnMainThread)
@@ -241,15 +273,18 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_embeddedComponentBusHandle_withNilAction_doesNotEmitError() {
+        // GIVEN an EmbeddedComponentBusModule with a mock emitter
         let expectation = expectation(description: "No error should be emitted")
         let sut = EmbeddedComponentBusModule()
         let emitter = MockEmitter()
         sut.emitterOverride = emitter
 
+        // WHEN handle() is called with a nil action from a background thread
         DispatchQueue.global().async {
             sut.handle("card-view", action: nil)
         }
 
+        // THEN no error event is emitted
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             XCTAssertEqual(emitter.events.count, 0)
             expectation.fulfill()
@@ -259,15 +294,18 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_embeddedComponentBusHandle_withoutActionHandler_emitsError() {
+        // GIVEN an EmbeddedComponentBusModule without an action handler set up
         let expectation = expectation(description: "Error should be emitted")
         let sut = EmbeddedComponentBusModule()
         let emitter = MockEmitter()
         sut.emitterOverride = emitter
 
+        // WHEN handle() is called from a background thread
         DispatchQueue.global().async {
             sut.handle("card-view", action: [:])
         }
 
+        // THEN a failure event is emitted
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             XCTAssertEqual(emitter.eventCount(named: EventName.fail.rawValue), 1)
             expectation.fulfill()
@@ -277,16 +315,19 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_embeddedComponentBusHandle_withoutRegisteredProxy_emitsError() {
+        // GIVEN an EmbeddedComponentBusModule with an action handler but no registered proxy
         let expectation = expectation(description: "Error should be emitted")
         let sut = EmbeddedComponentBusModule()
         let emitter = MockEmitter()
         sut.emitterOverride = emitter
         sut.createActionHandlerIfNeeded(context: Self.context, locale: nil)
 
+        // WHEN handle() is called from a background thread
         DispatchQueue.global().async {
             sut.handle("card-view", action: [:])
         }
 
+        // THEN a failure event is emitted
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             XCTAssertEqual(emitter.eventCount(named: EventName.fail.rawValue), 1)
             expectation.fulfill()
@@ -296,6 +337,7 @@ final class ThreadingSafetyTests: XCTestCase {
     }
 
     func test_embeddedComponentBusHandle_withInvalidAction_emitsError() {
+        // GIVEN an EmbeddedComponentBusModule with a registered proxy and an invalid action
         let expectation = expectation(description: "Invalid action error should be emitted")
         let sut = EmbeddedComponentBusModule()
         let emitter = MockEmitter()
@@ -303,10 +345,12 @@ final class ThreadingSafetyTests: XCTestCase {
         sut.createActionHandlerIfNeeded(context: Self.context, locale: nil)
         _ = sut.register(viewId: "card-view")
 
+        // WHEN handle() is called from a background thread
         DispatchQueue.global().async {
             sut.handle("card-view", action: [:])
         }
 
+        // THEN a failure event is emitted
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             XCTAssertEqual(emitter.eventCount(named: EventName.fail.rawValue), 1)
             expectation.fulfill()

--- a/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
@@ -202,21 +202,21 @@ final class ThreadingSafetyTests: XCTestCase {
         proxy.viewId = "card-view"
 
         let expectation = expectation(description: "Error should be reported on main thread")
+        // Each failed attempt resets `hasComponent`, so both setters can independently
+        // re-trigger initialization; both emissions call fulfill(), so over-fulfillment is expected.
+        expectation.assertForOverFulfill = false
+        emitter.onSend = {
+            expectation.fulfill()
+        }
 
         DispatchQueue.global().async {
             proxy.setPaymentMethod(Self.invalidCardPaymentMethodJSON)
             proxy.setConfiguration("{}")
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            // Each failed attempt resets `hasComponent`, so both setters can independently
-            // re-trigger initialization; what matters is that every emission is main-thread.
-            XCTAssertGreaterThanOrEqual(emitter.eventCount, 1)
-            XCTAssertTrue(emitter.sentOnMainThread)
-            expectation.fulfill()
-        }
-
         wait(for: [expectation], timeout: 1.0)
+        XCTAssertGreaterThanOrEqual(emitter.eventCount, 1)
+        XCTAssertTrue(emitter.sentOnMainThread)
     }
 
     func test_embeddedComponentBusHide_fromBackgroundThread_dismissesPresenterOnMainThread() {
@@ -350,10 +350,12 @@ private final class TestableBaseModule: BaseModule {
 private final class ThreadTrackingEmitter: EventEmitter {
     private(set) var eventCount = 0
     private(set) var sentOnMainThread = false
+    var onSend: (() -> Void)?
 
     func send(event: EventName, body: Any?) {
         eventCount += 1
         sentOnMainThread = Thread.isMainThread
+        onSend?()
     }
 }
 

--- a/ios/Views/CardView/CardComponentViewProxy.swift
+++ b/ios/Views/CardView/CardComponentViewProxy.swift
@@ -60,8 +60,8 @@ public final class CardComponentViewProxy: UIStackView {
     }
 
     @objc public func dispose() {
-        ensureMainThread { [weak self] in
-            self?.disposeOnMainThread()
+        ensureMainThread {
+            self.disposeOnMainThread()
         }
     }
 

--- a/ios/Views/CardView/CardComponentViewProxy.swift
+++ b/ios/Views/CardView/CardComponentViewProxy.swift
@@ -60,6 +60,12 @@ public final class CardComponentViewProxy: UIStackView {
     }
 
     @objc public func dispose() {
+        ensureMainThread { [weak self] in
+            self?.disposeOnMainThread()
+        }
+    }
+
+    private func disposeOnMainThread() {
         if let childVC = cardComponent?.viewController {
             childVC.willMove(toParent: nil)
             childVC.view.removeFromSuperview()
@@ -81,6 +87,12 @@ public final class CardComponentViewProxy: UIStackView {
     // MARK: - Component initialization
 
     private func initializeComponentIfNeeded() {
+        ensureMainThread { [weak self] in
+            self?.initializeComponentIfNeededOnMainThread()
+        }
+    }
+
+    private func initializeComponentIfNeededOnMainThread() {
         guard !hasComponent,
               let paymentMethodJSON,
               let configurationJSON,


### PR DESCRIPTION
## Summary
Fixes a residual iOS crash: `C++ Exception: AdyenComponentBus.unsubscribe raised an exception: Call must be made on main thread`, still occurring on 2.11.1 despite the earlier fix in c143c2707.

## Root cause
The 2.11.1 fix hardened only the `AdyenComponentBus` module's JS-facing entry points (`subscribe`/`unsubscribe`/`handle`etc.) with `ensureMainThread`. It did not cover the native Fabric view path: `CardComponentViewProxy` (backing `ADYCardView`) still called Adyen SDK APIs directly from `dispose()` (`cancelIfNeeded()`, `EmbeddedComponentBusModule.unregister`) and `initializeComponentIfNeeded()` (`CardComponent`/`AdyenActionComponent` construction) with no main-thread guarantee. When Fabric drives view teardown/mount off the main thread, the Adyen SDK's main-thread assertion fires.

## Fix
Wrap `dispose()` and `initializeComponentIfNeeded()` in `CardComponentViewProxy` with the existing `ensureMainThread(_:)` helper, matching the pattern already used in `EmbeddedComponentBusModule`.

## Tests
Added two regression tests to `ThreadingSafetyTests.swift`:
- `test_cardComponentViewProxyDispose_fromBackgroundThread_doesNotCrash`
- `test_cardComponentViewProxyInitialize_fromBackgroundThread_reportsErrorOnMainThread`

## Ticket
COSDK-1355