### PR TITLE
refactor: replace Android fragment constructors with Bundle arguments

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
@@ -39,12 +39,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.coroutines.launch
 
 /**
- * Base class for all instant/component bottom sheets.
- *
- * Kept to a no-argument constructor on purpose: [FragmentManager] recreates fragments via
- * reflection on config changes and process restoration, and only ever calls the no-arg
- * constructor before restoring [getArguments]. All payment state is therefore passed through
- * [arguments] instead of the constructor.
+ * Base class for all instant/component bottom sheets. Payment state is passed through [arguments].
  */
 abstract class BaseComponentFragment<TComponent, TState : PaymentComponentState<*>> :
   BottomSheetDialogFragment() where TComponent : Component,
@@ -142,9 +137,8 @@ abstract class BaseComponentFragment<TComponent, TState : PaymentComponentState<
     private const val KEY_SESSION_CLIENT_KEY = "KEY_SESSION_CLIENT_KEY"
 
     /**
-     * Builds the [Bundle] carrying the payment state as [android.os.Parcelable] arguments so it
-     * survives fragment re-creation. [CheckoutSession] itself isn't Parcelable, so it's split into
-     * its Parcelable parts and reassembled by [sessionFromArguments].
+     * Builds the [Bundle] of payment-state arguments. [CheckoutSession] is split into its
+     * Parcelable parts and reassembled by [sessionFromArguments].
      */
     fun buildArguments(
       configuration: CheckoutConfiguration,

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
@@ -13,17 +13,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
+import androidx.core.os.BundleCompat
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.adyen.checkout.action.core.internal.ActionHandlingComponent
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import com.adyen.checkout.components.core.Order
 import com.adyen.checkout.components.core.PaymentComponentState
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.components.core.internal.Component
+import com.adyen.checkout.core.Environment
 import com.adyen.checkout.sessions.core.CheckoutSession
+import com.adyen.checkout.sessions.core.SessionSetupResponse
 import com.adyenreactnativesdk.R
 import com.adyenreactnativesdk.component.base.ComponentData
 import com.adyenreactnativesdk.component.base.ComponentEvent
@@ -33,12 +38,31 @@ import com.adyenreactnativesdk.component.base.viewmodel.ViewModelInterface
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.coroutines.launch
 
-abstract class BaseComponentFragment<TComponent, TState : PaymentComponentState<*>>(
-  private val paymentMethod: PaymentMethod,
-  protected var session: CheckoutSession? = null,
-) : BottomSheetDialogFragment() where TComponent : Component,
+/**
+ * Base class for all instant/component bottom sheets.
+ *
+ * Kept to a no-argument constructor on purpose: [FragmentManager] recreates fragments via
+ * reflection on config changes and process restoration, and only ever calls the no-arg
+ * constructor before restoring [getArguments]. All payment state is therefore passed through
+ * [arguments] instead of the constructor.
+ */
+abstract class BaseComponentFragment<TComponent, TState : PaymentComponentState<*>> :
+  BottomSheetDialogFragment() where TComponent : Component,
         TComponent : ActionHandlingComponent {
   var component: TComponent? = null
+
+  protected val configuration: CheckoutConfiguration
+    get() =
+      BundleCompat.getParcelable(requireArguments(), KEY_CONFIGURATION, CheckoutConfiguration::class.java)
+        ?: throw IllegalStateException("Missing $KEY_CONFIGURATION argument")
+
+  protected val paymentMethod: PaymentMethod
+    get() =
+      BundleCompat.getParcelable(requireArguments(), KEY_PAYMENT_METHOD, PaymentMethod::class.java)
+        ?: throw IllegalStateException("Missing $KEY_PAYMENT_METHOD argument")
+
+  protected val session: CheckoutSession?
+    get() = sessionFromArguments(requireArguments())
 
   private val advancedViewModel: AdvancedComponentViewModel<TState> by viewModels()
   private val sessionViewModel: SessionsComponentViewModel<TState> by viewModels()
@@ -108,6 +132,46 @@ abstract class BaseComponentFragment<TComponent, TState : PaymentComponentState<
   companion object {
     const val FRAGMENT_ERROR =
       "Not able to find AdyenComponentView in `component_view` fragment"
+
+    private const val KEY_CONFIGURATION = "KEY_CONFIGURATION"
+    private const val KEY_PAYMENT_METHOD = "KEY_PAYMENT_METHOD"
+    private const val KEY_SESSION_SETUP_RESPONSE = "KEY_SESSION_SETUP_RESPONSE"
+    private const val KEY_SESSION_ORDER = "KEY_SESSION_ORDER"
+    private const val KEY_SESSION_ENVIRONMENT = "KEY_SESSION_ENVIRONMENT"
+    private const val KEY_SESSION_CLIENT_KEY = "KEY_SESSION_CLIENT_KEY"
+
+    /**
+     * Builds the [Bundle] carrying the payment state as [android.os.Parcelable] arguments so it
+     * survives fragment re-creation. [CheckoutSession] itself isn't Parcelable, so it's split into
+     * its Parcelable parts and reassembled by [sessionFromArguments].
+     */
+    fun buildArguments(
+      configuration: CheckoutConfiguration,
+      paymentMethod: PaymentMethod,
+      session: CheckoutSession?,
+    ): Bundle =
+      Bundle().apply {
+        putParcelable(KEY_CONFIGURATION, configuration)
+        putParcelable(KEY_PAYMENT_METHOD, paymentMethod)
+        session?.let {
+          putParcelable(KEY_SESSION_SETUP_RESPONSE, it.sessionSetupResponse)
+          putParcelable(KEY_SESSION_ORDER, it.order)
+          putParcelable(KEY_SESSION_ENVIRONMENT, it.environment)
+          putString(KEY_SESSION_CLIENT_KEY, it.clientKey)
+        }
+      }
+
+    private fun sessionFromArguments(arguments: Bundle): CheckoutSession? {
+      val sessionSetupResponse =
+        BundleCompat.getParcelable(arguments, KEY_SESSION_SETUP_RESPONSE, SessionSetupResponse::class.java)
+          ?: return null
+      val environment =
+        BundleCompat.getParcelable(arguments, KEY_SESSION_ENVIRONMENT, Environment::class.java)
+          ?: return null
+      val clientKey = arguments.getString(KEY_SESSION_CLIENT_KEY) ?: return null
+      val order = BundleCompat.getParcelable(arguments, KEY_SESSION_ORDER, Order::class.java)
+      return CheckoutSession(sessionSetupResponse, order, environment, clientKey)
+    }
 
     fun handle(
       fragmentManager: FragmentManager,

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseComponentFragment.kt
@@ -51,18 +51,19 @@ abstract class BaseComponentFragment<TComponent, TState : PaymentComponentState<
         TComponent : ActionHandlingComponent {
   var component: TComponent? = null
 
-  protected val configuration: CheckoutConfiguration
-    get() =
-      BundleCompat.getParcelable(requireArguments(), KEY_CONFIGURATION, CheckoutConfiguration::class.java)
-        ?: throw IllegalStateException("Missing $KEY_CONFIGURATION argument")
+  protected val configuration: CheckoutConfiguration by lazy {
+    BundleCompat.getParcelable(requireArguments(), KEY_CONFIGURATION, CheckoutConfiguration::class.java)
+      ?: throw IllegalStateException("Missing $KEY_CONFIGURATION argument")
+  }
 
-  protected val paymentMethod: PaymentMethod
-    get() =
-      BundleCompat.getParcelable(requireArguments(), KEY_PAYMENT_METHOD, PaymentMethod::class.java)
-        ?: throw IllegalStateException("Missing $KEY_PAYMENT_METHOD argument")
+  protected val paymentMethod: PaymentMethod by lazy {
+    BundleCompat.getParcelable(requireArguments(), KEY_PAYMENT_METHOD, PaymentMethod::class.java)
+      ?: throw IllegalStateException("Missing $KEY_PAYMENT_METHOD argument")
+  }
 
-  protected val session: CheckoutSession?
-    get() = sessionFromArguments(requireArguments())
+  protected val session: CheckoutSession? by lazy {
+    sessionFromArguments(requireArguments())
+  }
 
   private val advancedViewModel: AdvancedComponentViewModel<TState> by viewModels()
   private val sessionViewModel: SessionsComponentViewModel<TState> by viewModels()

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseInstantComponentFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/instant/BaseInstantComponentFragment.kt
@@ -16,14 +16,12 @@ import com.adyenreactnativesdk.R
 import com.adyenreactnativesdk.component.base.ComponentData
 import com.adyenreactnativesdk.component.base.ModuleException
 
-abstract class BaseInstantComponentFragment<TComponent, TState : PaymentComponentState<*>>(
-  private val configuration: CheckoutConfiguration,
-  paymentMethod: PaymentMethod,
-  session: CheckoutSession?,
-) : BaseComponentFragment<TComponent, TState>(paymentMethod, session) where TComponent : Component,
+abstract class BaseInstantComponentFragment<TComponent, TState : PaymentComponentState<*>> :
+  BaseComponentFragment<TComponent, TState>() where TComponent : Component,
         TComponent : ActionHandlingComponent,
         TComponent : ViewableComponent {
-  protected abstract val logTag: String
+  protected open val logTag: String
+    get() = javaClass.simpleName
 
   protected abstract fun createComponent(
     paymentMethod: PaymentMethod,

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/instant/InstantFragmentDelegate.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/instant/InstantFragmentDelegate.kt
@@ -8,10 +8,12 @@ import com.adyen.checkout.sessions.core.CheckoutSession
 
 /**
  * Builds an [IInstantFragment] whose tag is derived from [T], so fragments don't need to declare
- * their class name as a string twice (once for the tag, once for logging).
+ * their class name as a string twice (once for the tag, once for logging). Uses the fully
+ * qualified class name rather than the simple name: under R8/ProGuard obfuscation, simple names
+ * of unrelated classes can collide, but fully qualified names are always unique.
  */
 internal inline fun <reified T : BaseComponentFragment<*, *>> instantFragmentDelegate(noinline factory: () -> T): IInstantFragment =
-  InstantFragmentDelegate(T::class.java.simpleName, factory)
+  InstantFragmentDelegate(T::class.java.name, factory)
 
 internal class InstantFragmentDelegate(
   private val tag: String,

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/instant/InstantFragmentDelegate.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/instant/InstantFragmentDelegate.kt
@@ -6,12 +6,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.sessions.core.CheckoutSession
 
-/**
- * Builds an [IInstantFragment] whose tag is derived from [T], so fragments don't need to declare
- * their class name as a string twice (once for the tag, once for logging). Uses the fully
- * qualified class name rather than the simple name: under R8/ProGuard obfuscation, simple names
- * of unrelated classes can collide, but fully qualified names are always unique.
- */
+/** Builds an [IInstantFragment] tagged with [T]'s fully qualified class name. */
 internal inline fun <reified T : BaseComponentFragment<*, *>> instantFragmentDelegate(noinline factory: () -> T): IInstantFragment =
   InstantFragmentDelegate(T::class.java.name, factory)
 

--- a/android/src/main/java/com/adyenreactnativesdk/component/base/instant/InstantFragmentDelegate.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/base/instant/InstantFragmentDelegate.kt
@@ -6,13 +6,16 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.sessions.core.CheckoutSession
 
+/**
+ * Builds an [IInstantFragment] whose tag is derived from [T], so fragments don't need to declare
+ * their class name as a string twice (once for the tag, once for logging).
+ */
+internal inline fun <reified T : BaseComponentFragment<*, *>> instantFragmentDelegate(noinline factory: () -> T): IInstantFragment =
+  InstantFragmentDelegate(T::class.java.simpleName, factory)
+
 internal class InstantFragmentDelegate(
   private val tag: String,
-  private val fragmentFactory: (
-    configuration: CheckoutConfiguration,
-    paymentMethod: PaymentMethod,
-    session: CheckoutSession?,
-  ) -> BaseComponentFragment<*, *>,
+  private val fragmentFactory: () -> BaseComponentFragment<*, *>,
 ) : IInstantFragment {
   override fun show(
     fragmentManager: FragmentManager,
@@ -20,7 +23,9 @@ internal class InstantFragmentDelegate(
     paymentMethod: PaymentMethod,
     session: CheckoutSession?,
   ) {
-    fragmentFactory(configuration, paymentMethod, session).show(fragmentManager, tag)
+    fragmentFactory()
+      .apply { arguments = BaseComponentFragment.buildArguments(configuration, paymentMethod, session) }
+      .show(fragmentManager, tag)
   }
 
   override fun handle(

--- a/android/src/main/java/com/adyenreactnativesdk/component/googlepay/GooglePayFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/googlepay/GooglePayFragment.kt
@@ -6,11 +6,10 @@
 
 package com.adyenreactnativesdk.component.googlepay
 
-import androidx.fragment.app.FragmentManager
+import android.os.Bundle
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.ComponentCallback
 import com.adyen.checkout.components.core.PaymentMethod
-import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.googlepay.GooglePayComponent
 import com.adyen.checkout.googlepay.GooglePayComponentState
 import com.adyen.checkout.sessions.core.CheckoutSession
@@ -18,16 +17,20 @@ import com.adyen.checkout.sessions.core.SessionComponentCallback
 import com.adyenreactnativesdk.component.base.ComponentData
 import com.adyenreactnativesdk.component.base.instant.BaseInstantComponentFragment
 import com.adyenreactnativesdk.component.base.instant.IInstantFragment
-import com.adyenreactnativesdk.component.base.instant.InstantFragmentDelegate
+import com.adyenreactnativesdk.component.base.instant.instantFragmentDelegate
 
-class GooglePayFragment(
-  configuration: CheckoutConfiguration,
-  paymentMethod: PaymentMethod,
-  session: CheckoutSession?,
-) : BaseInstantComponentFragment<GooglePayComponent, GooglePayComponentState>(configuration, paymentMethod, session) {
-  override val logTag: String = TAG
-
+class GooglePayFragment : BaseInstantComponentFragment<GooglePayComponent, GooglePayComponentState>() {
   private var googlePayScreenVisible = false
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    googlePayScreenVisible = savedInstanceState?.getBoolean(KEY_GOOGLE_PAY_SCREEN_VISIBLE) ?: false
+  }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    outState.putBoolean(KEY_GOOGLE_PAY_SCREEN_VISIBLE, googlePayScreenVisible)
+  }
 
   override fun createComponent(
     paymentMethod: PaymentMethod,
@@ -67,10 +70,7 @@ class GooglePayFragment(
     }
   }
 
-  companion object : IInstantFragment by InstantFragmentDelegate(
-    "GooglePayFragment",
-    ::GooglePayFragment,
-  ) {
-    internal const val TAG = "GooglePayFragment"
+  companion object : IInstantFragment by instantFragmentDelegate(::GooglePayFragment) {
+    private const val KEY_GOOGLE_PAY_SCREEN_VISIBLE = "KEY_GOOGLE_PAY_SCREEN_VISIBLE"
   }
 }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/IdealFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/IdealFragment.kt
@@ -16,15 +16,9 @@ import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionComponentCallback
 import com.adyenreactnativesdk.component.base.instant.BaseInstantComponentFragment
 import com.adyenreactnativesdk.component.base.instant.IInstantFragment
-import com.adyenreactnativesdk.component.base.instant.InstantFragmentDelegate
+import com.adyenreactnativesdk.component.base.instant.instantFragmentDelegate
 
-class IdealFragment(
-  configuration: CheckoutConfiguration,
-  paymentMethod: PaymentMethod,
-  session: CheckoutSession?,
-) : BaseInstantComponentFragment<IdealComponent, IdealComponentState>(configuration, paymentMethod, session) {
-  override val logTag: String = TAG
-
+class IdealFragment : BaseInstantComponentFragment<IdealComponent, IdealComponentState>() {
   override fun createComponent(
     paymentMethod: PaymentMethod,
     configuration: CheckoutConfiguration,
@@ -51,10 +45,5 @@ class IdealFragment(
       callback,
     )
 
-  companion object : IInstantFragment by InstantFragmentDelegate(
-    "IdealFragment",
-    ::IdealFragment,
-  ) {
-    internal const val TAG = "IdealFragment"
-  }
+  companion object : IInstantFragment by instantFragmentDelegate(::IdealFragment)
 }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/InstantFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/InstantFragment.kt
@@ -7,27 +7,18 @@
 
 package com.adyenreactnativesdk.component.instant.fragment
 
-import androidx.core.os.bundleOf
-import androidx.fragment.app.FragmentManager
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.ComponentCallback
 import com.adyen.checkout.components.core.PaymentMethod
-import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.instant.InstantComponentState
 import com.adyen.checkout.instant.InstantPaymentComponent
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionComponentCallback
 import com.adyenreactnativesdk.component.base.instant.BaseInstantComponentFragment
 import com.adyenreactnativesdk.component.base.instant.IInstantFragment
-import com.adyenreactnativesdk.component.base.instant.InstantFragmentDelegate
+import com.adyenreactnativesdk.component.base.instant.instantFragmentDelegate
 
-class InstantFragment(
-  configuration: CheckoutConfiguration,
-  paymentMethod: PaymentMethod,
-  session: CheckoutSession?,
-) : BaseInstantComponentFragment<InstantPaymentComponent, InstantComponentState>(configuration, paymentMethod, session) {
-  override val logTag: String = TAG
-
+class InstantFragment : BaseInstantComponentFragment<InstantPaymentComponent, InstantComponentState>() {
   override fun createComponent(
     paymentMethod: PaymentMethod,
     configuration: CheckoutConfiguration,
@@ -54,26 +45,5 @@ class InstantFragment(
       callback,
     )
 
-  companion object : IInstantFragment by InstantFragmentDelegate(
-    "InstantFragment",
-    ::InstantFragment,
-  ) {
-    private const val PAYMENT_METHOD_TYPE_EXTRA = "PAYMENT_METHOD_TYPE_EXTRA"
-    internal const val TAG = "InstantFragment"
-
-    override fun show(
-      fragmentManager: FragmentManager,
-      configuration: CheckoutConfiguration,
-      paymentMethod: PaymentMethod,
-      session: CheckoutSession?,
-    ) {
-      InstantFragment(configuration, paymentMethod, session)
-        .apply {
-          arguments =
-            bundleOf(
-              PAYMENT_METHOD_TYPE_EXTRA to paymentMethod.type,
-            )
-        }.show(fragmentManager, TAG)
-    }
-  }
+  companion object : IInstantFragment by instantFragmentDelegate(::InstantFragment)
 }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/PayByBankGlobalFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/PayByBankGlobalFragment.kt
@@ -16,15 +16,9 @@ import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionComponentCallback
 import com.adyenreactnativesdk.component.base.instant.BaseInstantComponentFragment
 import com.adyenreactnativesdk.component.base.instant.IInstantFragment
-import com.adyenreactnativesdk.component.base.instant.InstantFragmentDelegate
+import com.adyenreactnativesdk.component.base.instant.instantFragmentDelegate
 
-class PayByBankGlobalFragment(
-  configuration: CheckoutConfiguration,
-  paymentMethod: PaymentMethod,
-  session: CheckoutSession?,
-) : BaseInstantComponentFragment<PayByBankComponent, PayByBankComponentState>(configuration, paymentMethod, session) {
-  override val logTag: String = TAG
-
+class PayByBankGlobalFragment : BaseInstantComponentFragment<PayByBankComponent, PayByBankComponentState>() {
   override fun createComponent(
     paymentMethod: PaymentMethod,
     configuration: CheckoutConfiguration,
@@ -51,10 +45,5 @@ class PayByBankGlobalFragment(
       callback,
     )
 
-  companion object : IInstantFragment by InstantFragmentDelegate(
-    "PayByBankGlobalFragment",
-    ::PayByBankGlobalFragment,
-  ) {
-    internal const val TAG = "PayByBankGlobalFragment"
-  }
+  companion object : IInstantFragment by instantFragmentDelegate(::PayByBankGlobalFragment)
 }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/PayByBankUSFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/PayByBankUSFragment.kt
@@ -16,15 +16,9 @@ import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionComponentCallback
 import com.adyenreactnativesdk.component.base.instant.BaseInstantComponentFragment
 import com.adyenreactnativesdk.component.base.instant.IInstantFragment
-import com.adyenreactnativesdk.component.base.instant.InstantFragmentDelegate
+import com.adyenreactnativesdk.component.base.instant.instantFragmentDelegate
 
-class PayByBankUSFragment(
-  configuration: CheckoutConfiguration,
-  paymentMethod: PaymentMethod,
-  session: CheckoutSession?,
-) : BaseInstantComponentFragment<PayByBankUSComponent, PayByBankUSComponentState>(configuration, paymentMethod, session) {
-  override val logTag: String = TAG
-
+class PayByBankUSFragment : BaseInstantComponentFragment<PayByBankUSComponent, PayByBankUSComponentState>() {
   override fun createComponent(
     paymentMethod: PaymentMethod,
     configuration: CheckoutConfiguration,
@@ -51,10 +45,5 @@ class PayByBankUSFragment(
       callback,
     )
 
-  companion object : IInstantFragment by InstantFragmentDelegate(
-    "PayByBankUSFragment",
-    ::PayByBankUSFragment,
-  ) {
-    internal const val TAG = "PayByBankUSFragment"
-  }
+  companion object : IInstantFragment by instantFragmentDelegate(::PayByBankUSFragment)
 }

--- a/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/TwintFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/instant/fragment/TwintFragment.kt
@@ -16,15 +16,9 @@ import com.adyen.checkout.twint.TwintComponent
 import com.adyen.checkout.twint.TwintComponentState
 import com.adyenreactnativesdk.component.base.instant.BaseInstantComponentFragment
 import com.adyenreactnativesdk.component.base.instant.IInstantFragment
-import com.adyenreactnativesdk.component.base.instant.InstantFragmentDelegate
+import com.adyenreactnativesdk.component.base.instant.instantFragmentDelegate
 
-class TwintFragment(
-  configuration: CheckoutConfiguration,
-  paymentMethod: PaymentMethod,
-  session: CheckoutSession?,
-) : BaseInstantComponentFragment<TwintComponent, TwintComponentState>(configuration, paymentMethod, session) {
-  override val logTag: String = TAG
-
+class TwintFragment : BaseInstantComponentFragment<TwintComponent, TwintComponentState>() {
   override fun createComponent(
     paymentMethod: PaymentMethod,
     configuration: CheckoutConfiguration,
@@ -51,10 +45,5 @@ class TwintFragment(
       callback,
     )
 
-  companion object : IInstantFragment by InstantFragmentDelegate(
-    "TwintFragment",
-    ::TwintFragment,
-  ) {
-    internal const val TAG = "TwintFragment"
-  }
+  companion object : IInstantFragment by instantFragmentDelegate(::TwintFragment)
 }

--- a/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
@@ -27,15 +27,15 @@ class ActionFragment : BottomSheetDialogFragment() {
   private var actionHandled: Boolean = false
   var component: GenericActionComponent? = null
 
-  private val configuration: CheckoutConfiguration
-    get() =
-      BundleCompat.getParcelable(requireArguments(), KEY_CONFIGURATION, CheckoutConfiguration::class.java)
-        ?: throw IllegalStateException("Missing $KEY_CONFIGURATION argument")
+  private val configuration: CheckoutConfiguration by lazy {
+    BundleCompat.getParcelable(requireArguments(), KEY_CONFIGURATION, CheckoutConfiguration::class.java)
+      ?: throw IllegalStateException("Missing $KEY_CONFIGURATION argument")
+  }
 
-  private val action: Action
-    get() =
-      BundleCompat.getParcelable(requireArguments(), KEY_ACTION, Action::class.java)
-        ?: throw IllegalStateException("Missing $KEY_ACTION argument")
+  private val action: Action by lazy {
+    BundleCompat.getParcelable(requireArguments(), KEY_ACTION, Action::class.java)
+      ?: throw IllegalStateException("Missing $KEY_ACTION argument")
+  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -45,6 +45,13 @@ class ActionFragment : BottomSheetDialogFragment() {
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
     outState.putBoolean(KEY_ACTION_HANDLED, actionHandled)
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    if (activity?.isChangingConfigurations == false) {
+      ActionModule.currentCallback = null
+    }
   }
 
   override fun onCreateView(

--- a/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
@@ -17,11 +17,10 @@ import com.adyenreactnativesdk.R
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 /**
- * Kept to a no-argument constructor on purpose: [FragmentManager] recreates fragments via
- * reflection on config changes and process restoration, and only ever calls the no-arg
- * constructor before restoring [getArguments]. [configuration] and [action] are Parcelable and
- * travel through [arguments]. [callback] is a live RN module reference and can't be serialized,
- * so it's re-sourced from [ActionModule.currentCallback] instead.
+ * Bottom sheet fragment that hosts the action component (3DS2, redirect, etc.).
+ *
+ * [configuration] and [action] are restored from [arguments]; the callback is re-sourced from
+ * [ActionModule.currentCallback].
  */
 class ActionFragment : BottomSheetDialogFragment() {
   private var actionHandled: Boolean = false

--- a/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/cse/ActionFragment.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.BundleCompat
 import androidx.fragment.app.FragmentManager
 import com.adyen.checkout.action.core.GenericActionComponent
 import com.adyen.checkout.components.core.ActionComponentCallback
@@ -15,13 +16,42 @@ import com.adyenreactnativesdk.AdyenCheckout
 import com.adyenreactnativesdk.R
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class ActionFragment(
-  private val configuration: CheckoutConfiguration,
-  private val callback: ActionComponentCallback,
-  private val action: Action,
-) : BottomSheetDialogFragment() {
+/**
+ * Kept to a no-argument constructor on purpose: [FragmentManager] recreates fragments via
+ * reflection on config changes and process restoration, and only ever calls the no-arg
+ * constructor before restoring [getArguments]. [configuration] and [action] are Parcelable and
+ * travel through [arguments]. [callback] is a live RN module reference and can't be serialized,
+ * so it's re-sourced from [ActionModule.currentCallback] instead.
+ */
+class ActionFragment : BottomSheetDialogFragment() {
   private var actionHandled: Boolean = false
   var component: GenericActionComponent? = null
+
+  private val configuration: CheckoutConfiguration
+    get() =
+      BundleCompat.getParcelable(requireArguments(), KEY_CONFIGURATION, CheckoutConfiguration::class.java)
+        ?: throw IllegalStateException("Missing $KEY_CONFIGURATION argument")
+
+  private val action: Action
+    get() =
+      BundleCompat.getParcelable(requireArguments(), KEY_ACTION, Action::class.java)
+        ?: throw IllegalStateException("Missing $KEY_ACTION argument")
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    actionHandled = savedInstanceState?.getBoolean(KEY_ACTION_HANDLED) ?: false
+  }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    outState.putBoolean(KEY_ACTION_HANDLED, actionHandled)
+  }
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?,
+  ): View = inflater.inflate(R.layout.fragment_instant, container)
 
   override fun onStart() {
     super.onStart()
@@ -30,6 +60,12 @@ class ActionFragment(
   }
 
   private fun setupComponent() {
+    val callback = ActionModule.currentCallback
+    if (callback == null) {
+      dismiss()
+      return
+    }
+
     val component =
       GenericActionComponent.PROVIDER.get(
         this,
@@ -62,18 +98,27 @@ class ActionFragment(
   }
 
   companion object {
-    private const val PAYMENT_METHOD_TYPE_EXTRA = "PAYMENT_METHOD_TYPE_EXTRA"
     internal const val TAG = "ActionFragment"
     const val FRAGMENT_ERROR =
       "Not able to find AdyenComponentView in `component_view` fragment"
 
+    private const val KEY_CONFIGURATION = "KEY_CONFIGURATION"
+    private const val KEY_ACTION = "KEY_ACTION"
+    private const val KEY_ACTION_HANDLED = "KEY_ACTION_HANDLED"
+
     fun show(
       fragmentManager: FragmentManager,
       configuration: CheckoutConfiguration,
-      callback: ActionComponentCallback,
       action: Action,
     ) {
-      ActionFragment(configuration, callback, action).show(fragmentManager, TAG)
+      ActionFragment()
+        .apply {
+          arguments =
+            Bundle().apply {
+              putParcelable(KEY_CONFIGURATION, configuration)
+              putParcelable(KEY_ACTION, action)
+            }
+        }.show(fragmentManager, TAG)
     }
 
     fun hide(fragmentManager: FragmentManager) {

--- a/android/src/main/java/com/adyenreactnativesdk/cse/ActionModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/cse/ActionModule.kt
@@ -46,10 +46,10 @@ class ActionModule(
       promise.reject(PARSING_ERROR, e.message, e)
       return
     }
+    currentCallback = this
     ActionFragment.show(
       appCompatActivity.supportFragmentManager,
       checkoutConfiguration,
-      this,
       action,
     )
   }
@@ -57,6 +57,7 @@ class ActionModule(
   @ReactMethod
   fun hide(success: Boolean?) {
     ActionFragment.hide(appCompatActivity.supportFragmentManager)
+    currentCallback = null
     promise = null
   }
 
@@ -66,6 +67,12 @@ class ActionModule(
     private const val THREEDS_VERSION_NAME = "threeDS2SdkVersion"
     private const val COMPONENT_ERROR = "actionError"
     private const val PARSING_ERROR = "parsingError"
+
+    /**
+     * [ActionComponentCallback] can't be put into [ActionFragment]'s arguments Bundle, so
+     * [ActionFragment] re-sources it from here after fragment re-creation (e.g. config changes).
+     */
+    internal var currentCallback: ActionComponentCallback? = null
   }
 
   override fun onAdditionalDetails(actionComponentData: ActionComponentData) {

--- a/android/src/main/java/com/adyenreactnativesdk/cse/ActionModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/cse/ActionModule.kt
@@ -68,10 +68,7 @@ class ActionModule(
     private const val COMPONENT_ERROR = "actionError"
     private const val PARSING_ERROR = "parsingError"
 
-    /**
-     * [ActionComponentCallback] can't be put into [ActionFragment]'s arguments Bundle, so
-     * [ActionFragment] re-sources it from here after fragment re-creation (e.g. config changes).
-     */
+    /** Live callback re-sourced by [ActionFragment] after re-creation. */
     internal var currentCallback: ActionComponentCallback? = null
   }
 


### PR DESCRIPTION
## Summary
Fixes an Android guideline violation where all instant/action bottom-sheet fragments used parameterized constructors. `FragmentManager` recreates fragments on config changes / process restoration via reflection on the **no-arg constructor**, then restores `arguments()`; fragments without one either throw at recreation time or silently lose state.

- Converted `BaseComponentFragment`, `BaseInstantComponentFragment`, `InstantFragment`, `IdealFragment`, `TwintFragment`, `PayByBankGlobalFragment`, `PayByBankUSFragment`, `GooglePayFragment`, and `ActionFragment` to no-arg constructors.
- Payment state (`PaymentMethod`, `CheckoutConfiguration`, `Action`) is passed through `arguments` as Parcelables. `CheckoutSession` (not itself Parcelable) is reconstructed from its 4 Parcelable parts (`SessionSetupResponse`, `Order`, `Environment`, `clientKey`).
- `ActionFragment`'s `ActionComponentCallback` cannot be serialized (it's a live RN module reference), so it's re-sourced from a new `ActionModule.currentCallback` holder after recreation, with a null-guard that dismisses the sheet if it can't be recovered (e.g. process death).
- `GooglePayFragment.googlePayScreenVisible` and `ActionFragment.actionHandled` are now persisted via `onSaveInstanceState` so recreation doesn't re-trigger the payment/action.
- Simplified `InstantFragmentDelegate`: added a `reified` `instantFragmentDelegate<T>(factory)` helper that derives the fragment-manager tag from the class name, removing per-fragment `TAG` constants that duplicated the class name as a string.

## Testing
- `ktlint android -F` — clean
- `./gradlew :adyen_react-native:compileDebugKotlin` — passes
- `./gradlew :adyen_react-native:testDebugUnitTest` — passes
- `./gradlew :adyen_react-native:lintDebug` — passes
- `yarn typecheck` — passes (no JS/TS changed)

No ticket reference (internal chore).
