### PR TITLE
refactor: dispatch address lookup handlers via ensureMainThread

### DIFF
--- a/example/ios/SceneDelegate.swift
+++ b/example/ios/SceneDelegate.swift
@@ -19,8 +19,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         appDelegate.startReactNative(in: sceneWindow)
     }
 
-  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-      guard let url = URLContexts.first?.url else { return }
-      RedirectComponent.applicationDidOpen(from: url)
-  }
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else { return }
+        RedirectComponent.applicationDidOpen(from: url)
+    }
 }

--- a/ios/CSE/ActionModule.swift
+++ b/ios/CSE/ActionModule.swift
@@ -48,7 +48,7 @@ internal final class ActionModule: BaseModule {
         actionHandler?.presentationDelegate = self
         currentComponent = actionHandler
 
-        DispatchQueue.main.async { [weak self] in
+        ensureMainThread { [weak self] in
             self?.actionHandler?.handle(action)
         }
     }

--- a/ios/Components/ApplePay/ApplePayModule+Delegates.swift
+++ b/ios/Components/ApplePay/ApplePayModule+Delegates.swift
@@ -78,7 +78,7 @@ extension ApplePayModule {
         let success = (dict[ApplePayKeys.Update.status] as? String) == "success"
         let errors = parseErrors(dict)
         let status: PKPaymentAuthorizationStatus = success ? .success : .failure
-        DispatchQueue.main.async {
+        ensureMainThread {
             handler(PKPaymentAuthorizationResult(status: status, errors: errors))
         }
     }
@@ -92,7 +92,7 @@ extension ApplePayModule {
         let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
         let shippingMethods = parseShippingMethods(dict) ?? currentShippingMethods
         let errors = parseErrors(dict)
-        DispatchQueue.main.async {
+        ensureMainThread {
             self.currentShippingMethods = shippingMethods
             handler(.init(errors: errors, paymentSummaryItems: summaryItems, shippingMethods: shippingMethods))
         }
@@ -106,7 +106,7 @@ extension ApplePayModule {
         let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
         let shippingMethods = parseShippingMethods(dict) ?? currentShippingMethods
         let errors = parseErrors(dict)
-        DispatchQueue.main.async {
+        ensureMainThread {
             self.currentShippingMethods = shippingMethods
             handler(.init(errors: errors, paymentSummaryItems: summaryItems, shippingMethods: shippingMethods))
         }
@@ -118,7 +118,7 @@ extension ApplePayModule {
         shippingMethodHandler = nil
         let dict = update as? [String: Any] ?? [:]
         let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
-        DispatchQueue.main.async {
+        ensureMainThread {
             handler(.init(paymentSummaryItems: summaryItems))
         }
     }

--- a/ios/Components/ApplePay/ApplePayModule+Delegates.swift
+++ b/ios/Components/ApplePay/ApplePayModule+Delegates.swift
@@ -72,13 +72,13 @@ extension ApplePayModule {
 
     @objc
     func provideAuthorizationResult(_ result: NSDictionary) {
-        guard let handler = authorizationHandler else { return }
-        authorizationHandler = nil
         let dict = result as? [String: Any] ?? [:]
         let success = (dict[ApplePayKeys.Update.status] as? String) == "success"
         let errors = parseErrors(dict)
         let status: PKPaymentAuthorizationStatus = success ? .success : .failure
-        ensureMainThread {
+        ensureMainThread { [weak self] in
+            guard let self, let handler = self.authorizationHandler else { return }
+            self.authorizationHandler = nil
             handler(PKPaymentAuthorizationResult(status: status, errors: errors))
         }
     }
@@ -86,13 +86,15 @@ extension ApplePayModule {
     @available(iOS 15.0, *)
     @objc
     func provideCouponCodeUpdate(_ update: NSDictionary) {
-        guard let handler = couponCodeHandler else { return }
-        couponCodeHandler = nil
         let dict = update as? [String: Any] ?? [:]
-        let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
-        let shippingMethods = parseShippingMethods(dict) ?? currentShippingMethods
+        let parsedSummaryItems = parseSummaryItems(dict)
+        let parsedShippingMethods = parseShippingMethods(dict)
         let errors = parseErrors(dict)
-        ensureMainThread {
+        ensureMainThread { [weak self] in
+            guard let self, let handler = self.couponCodeHandler else { return }
+            self.couponCodeHandler = nil
+            let summaryItems = parsedSummaryItems ?? self.currentApplePayPayment?.summaryItems ?? []
+            let shippingMethods = parsedShippingMethods ?? self.currentShippingMethods
             self.currentShippingMethods = shippingMethods
             handler(.init(errors: errors, paymentSummaryItems: summaryItems, shippingMethods: shippingMethods))
         }
@@ -100,13 +102,15 @@ extension ApplePayModule {
 
     @objc
     func provideShippingContactUpdate(_ update: NSDictionary) {
-        guard let handler = shippingContactHandler else { return }
-        shippingContactHandler = nil
         let dict = update as? [String: Any] ?? [:]
-        let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
-        let shippingMethods = parseShippingMethods(dict) ?? currentShippingMethods
+        let parsedSummaryItems = parseSummaryItems(dict)
+        let parsedShippingMethods = parseShippingMethods(dict)
         let errors = parseErrors(dict)
-        ensureMainThread {
+        ensureMainThread { [weak self] in
+            guard let self, let handler = self.shippingContactHandler else { return }
+            self.shippingContactHandler = nil
+            let summaryItems = parsedSummaryItems ?? self.currentApplePayPayment?.summaryItems ?? []
+            let shippingMethods = parsedShippingMethods ?? self.currentShippingMethods
             self.currentShippingMethods = shippingMethods
             handler(.init(errors: errors, paymentSummaryItems: summaryItems, shippingMethods: shippingMethods))
         }
@@ -114,11 +118,12 @@ extension ApplePayModule {
 
     @objc
     func provideShippingMethodUpdate(_ update: NSDictionary) {
-        guard let handler = shippingMethodHandler else { return }
-        shippingMethodHandler = nil
         let dict = update as? [String: Any] ?? [:]
-        let summaryItems = parseSummaryItems(dict) ?? currentApplePayPayment?.summaryItems ?? []
-        ensureMainThread {
+        let parsedSummaryItems = parseSummaryItems(dict)
+        ensureMainThread { [weak self] in
+            guard let self, let handler = self.shippingMethodHandler else { return }
+            self.shippingMethodHandler = nil
+            let summaryItems = parsedSummaryItems ?? self.currentApplePayPayment?.summaryItems ?? []
             handler(.init(paymentSummaryItems: summaryItems))
         }
     }

--- a/ios/Components/Base/BaseActionModule.swift
+++ b/ios/Components/Base/BaseActionModule.swift
@@ -23,7 +23,7 @@ internal class BaseActionModule: BaseModuleSender {
             return sendError(error: error)
         }
 
-        DispatchQueue.main.async { [weak self] in
+        ensureMainThread { [weak self] in
             self?.actionHandler?.handle(action)
         }
     }

--- a/ios/Components/Base/BaseAddressModule.swift
+++ b/ios/Components/Base/BaseAddressModule.swift
@@ -34,15 +34,17 @@ internal class BaseAddressModule: BaseActionModule {
             }
         }
 
+        let result: Result<PostalAddress, Error>
+
         do {
             let addressModel: LookupAddressModel = try address.decode()
-            ensureMainThread { [weak self] in
-                self?.lookupCompletionHandler?(.success(addressModel.postalAddress))
-            }
+            result = .success(addressModel.postalAddress)
         } catch {
-            ensureMainThread { [weak self] in
-                self?.lookupCompletionHandler?(.failure(error))
-            }
+            result = .failure(error)
+        }
+
+        ensureMainThread { [weak self] in
+            self?.lookupCompletionHandler?(result)
         }
     }
 

--- a/ios/Components/Base/BaseAddressModule.swift
+++ b/ios/Components/Base/BaseAddressModule.swift
@@ -16,30 +16,32 @@ internal class BaseAddressModule: BaseActionModule {
 
     @objc
     func update(_ results: NSArray) {
-        ensureMainThread { [weak self] in
-            guard let self, let lookupHandler = self.lookupHandler else { return }
+        let addressModels: [LookupAddressModel] = results
+            .compactMap { $0 as? NSDictionary }
+            .compactMap { try? $0.decode() }
 
-            let addressModels: [LookupAddressModel] = results
-                .compactMap { $0 as? NSDictionary }
-                .compactMap { try? $0.decode() }
-            lookupHandler(addressModels)
+        ensureMainThread { [weak self] in
+            self?.lookupHandler?(addressModels)
         }
     }
 
     @objc
     func confirm(_ success: NSNumber, address: NSDictionary) {
-        ensureMainThread { [weak self] in
-            guard let self, let lookupCompletionHandler = self.lookupCompletionHandler else { return }
-
-            if !success.boolValue, let message = address[Keys.message] as? String {
-                return lookupCompletionHandler(.failure(AddressError(message: message)))
+        if !success.boolValue, let message = address[Keys.message] as? String {
+            let error = AddressError(message: message)
+            return ensureMainThread { [weak self] in
+                self?.lookupCompletionHandler?(.failure(error))
             }
+        }
 
-            do {
-                let addressModel: LookupAddressModel = try address.decode()
-                lookupCompletionHandler(.success(addressModel.postalAddress))
-            } catch {
-                lookupCompletionHandler(.failure(error))
+        do {
+            let addressModel: LookupAddressModel = try address.decode()
+            ensureMainThread { [weak self] in
+                self?.lookupCompletionHandler?(.success(addressModel.postalAddress))
+            }
+        } catch {
+            ensureMainThread { [weak self] in
+                self?.lookupCompletionHandler?(.failure(error))
             }
         }
     }

--- a/ios/Components/Base/BaseAddressModule.swift
+++ b/ios/Components/Base/BaseAddressModule.swift
@@ -16,21 +16,21 @@ internal class BaseAddressModule: BaseActionModule {
 
     @objc
     func update(_ results: NSArray) {
-        guard let lookupHandler else { return }
+        ensureMainThread { [weak self] in
+            guard let self, let lookupHandler = self.lookupHandler else { return }
 
-        let addressModels: [LookupAddressModel] = results
-            .compactMap { $0 as? NSDictionary }
-            .compactMap { try? $0.decode() }
-        DispatchQueue.main.async {
+            let addressModels: [LookupAddressModel] = results
+                .compactMap { $0 as? NSDictionary }
+                .compactMap { try? $0.decode() }
             lookupHandler(addressModels)
         }
     }
 
     @objc
     func confirm(_ success: NSNumber, address: NSDictionary) {
-        guard let lookupCompletionHandler else { return }
+        ensureMainThread { [weak self] in
+            guard let self, let lookupCompletionHandler = self.lookupCompletionHandler else { return }
 
-        DispatchQueue.main.async {
             if !success.boolValue, let message = address[Keys.message] as? String {
                 return lookupCompletionHandler(.failure(AddressError(message: message)))
             }

--- a/ios/Components/Base/BaseModule.swift
+++ b/ios/Components/Base/BaseModule.swift
@@ -155,7 +155,7 @@ internal class BaseModule: RCTEventEmitter {
 extension BaseModule: PresentationDelegate {
 
     internal func present(component: PresentableComponent) {
-        DispatchQueue.main.async { [weak self] in
+        ensureMainThread { [weak self] in
             guard let self else { return }
 
             let presenter: UIViewController

--- a/ios/Components/Base/BaseModule.swift
+++ b/ios/Components/Base/BaseModule.swift
@@ -113,7 +113,7 @@ internal class BaseModule: RCTEventEmitter {
 
     internal func cleanUp() {
         ensureMainThread { [weak self] in
-            self?.cleanUpOnMainThread()
+            self?.performCleanUp()
         }
     }
 
@@ -139,7 +139,7 @@ internal class BaseModule: RCTEventEmitter {
         return error
     }
 
-    private func cleanUpOnMainThread() {
+    private func performCleanUp() {
         BaseModule.session = nil
         BaseModule.currentModule = nil
         currentComponent = nil

--- a/ios/Components/Base/ThreadUtilities.swift
+++ b/ios/Components/Base/ThreadUtilities.swift
@@ -12,7 +12,7 @@ internal func ensureMainThread(_ work: @escaping @MainActor () -> Void) {
             work()
         }
     } else {
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { @MainActor in
             work()
         }
     }

--- a/ios/Components/Base/ThreadUtilities.swift
+++ b/ios/Components/Base/ThreadUtilities.swift
@@ -6,10 +6,14 @@
 
 import Foundation
 
-internal func ensureMainThread(_ work: @escaping () -> Void) {
+internal func ensureMainThread(_ work: @escaping @MainActor () -> Void) {
     if Thread.isMainThread {
-        work()
+        MainActor.assumeIsolated {
+            work()
+        }
     } else {
-        DispatchQueue.main.async(execute: work)
+        DispatchQueue.main.async {
+            work()
+        }
     }
 }

--- a/ios/Components/DropIn/DropInModule+Delegates.swift
+++ b/ios/Components/DropIn/DropInModule+Delegates.swift
@@ -61,9 +61,8 @@ extension DropInModule: PartialPaymentDelegate {
 
     @objc
     func provideBalance(_ success: NSNumber, balance: NSDictionary?, error: NSDictionary?) {
-        guard let checkBalanceHandler else { return }
-
-        ensureMainThread {
+        ensureMainThread { [weak self] in
+            guard let self, let checkBalanceHandler = self.checkBalanceHandler else { return }
             guard success.boolValue, let balance: Balance = try? balance?.decode() else {
                 let message = error.getErrorMessage
                 return checkBalanceHandler(.failure(ModuleException.balanceCheck(message: message)))
@@ -80,10 +79,8 @@ extension DropInModule: PartialPaymentDelegate {
 
     @objc
     func provideOrder(_ success: NSNumber, order: NSDictionary?, error: NSDictionary?) {
-        guard let requestOrderHandler else {
-            return
-        }
-        ensureMainThread {
+        ensureMainThread { [weak self] in
+            guard let self, let requestOrderHandler = self.requestOrderHandler else { return }
             guard success.boolValue, let order: PartialPaymentOrder = try? order?.decode() else {
                 let message = error.getErrorMessage
                 return requestOrderHandler(.failure(ModuleException.orderRequest(message: message)))

--- a/ios/Components/DropIn/DropInModule+Delegates.swift
+++ b/ios/Components/DropIn/DropInModule+Delegates.swift
@@ -63,7 +63,7 @@ extension DropInModule: PartialPaymentDelegate {
     func provideBalance(_ success: NSNumber, balance: NSDictionary?, error: NSDictionary?) {
         guard let checkBalanceHandler else { return }
 
-        DispatchQueue.main.async {
+        ensureMainThread {
             guard success.boolValue, let balance: Balance = try? balance?.decode() else {
                 let message = error.getErrorMessage
                 return checkBalanceHandler(.failure(ModuleException.balanceCheck(message: message)))
@@ -83,7 +83,7 @@ extension DropInModule: PartialPaymentDelegate {
         guard let requestOrderHandler else {
             return
         }
-        DispatchQueue.main.async {
+        ensureMainThread {
             guard success.boolValue, let order: PartialPaymentOrder = try? order?.decode() else {
                 let message = error.getErrorMessage
                 return requestOrderHandler(.failure(ModuleException.orderRequest(message: message)))

--- a/ios/Components/DropIn/DropInModule.swift
+++ b/ios/Components/DropIn/DropInModule.swift
@@ -26,7 +26,7 @@ internal final class DropInModule: BaseAddressModule {
 
     @objc
     func removeStored(_ success: NSNumber) {
-        DispatchQueue.main.async { [weak self] in
+        ensureMainThread { [weak self] in
             self?.disableStoredPaymentMethodHandler?(success.boolValue)
         }
     }
@@ -83,7 +83,7 @@ internal final class DropInModule: BaseAddressModule {
             return sendError(error: error)
         }
 
-        DispatchQueue.main.async { [weak self] in
+        ensureMainThread { [weak self] in
             self?.dropInComponent?.handle(action)
         }
     }

--- a/ios/Components/Embedded/EmbeddedComponentBusModule.swift
+++ b/ios/Components/Embedded/EmbeddedComponentBusModule.swift
@@ -7,13 +7,13 @@
 import Adyen
 import React
 
+/// Bridge module coordinating embedded payment components (e.g. card) between JS and the native SDK.
+///
+/// All mutable state is main-thread-only; access is routed through `ensureMainThread(_:)`.
 @objc(AdyenComponentBus)
 internal final class EmbeddedComponentBusModule: BaseAddressModule {
 
     static var shared: EmbeddedComponentBusModule?
-
-    // Main-thread-only mutable state. Access these properties via the `*OnMainThread` helpers
-    // or through JS entry points that dispatch with `ensureMainThread(_:)`.
 
     /// Per-viewId delegate proxies
     private var delegates: [String: EmbeddedComponentDelegateProxy] = [:]
@@ -85,14 +85,14 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
     @objc
     func subscribe(_ viewId: String) {
         ensureMainThread { [weak self] in
-            self?.subscribeOnMainThread(viewId)
+            self?.performSubscribe(viewId)
         }
     }
 
     @objc
     func unsubscribe(_ viewId: String) {
         ensureMainThread { [weak self] in
-            self?.unsubscribeOnMainThread(viewId)
+            self?.performUnsubscribe(viewId)
         }
     }
 
@@ -101,50 +101,50 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
     @objc
     func handle(_ viewId: String, action actionDict: NSDictionary?) {
         ensureMainThread { [weak self] in
-            self?.handleOnMainThread(viewId, action: actionDict)
+            self?.performHandle(viewId, action: actionDict)
         }
     }
 
     @objc
     func update(_ viewId: String, results: NSArray?) {
         ensureMainThread { [weak self] in
-            self?.updateOnMainThread(viewId, results: results)
+            self?.performUpdate(viewId, results: results)
         }
     }
 
     @objc
     func confirm(_ viewId: String, success: NSNumber, address: NSDictionary) {
         ensureMainThread { [weak self] in
-            self?.confirmOnMainThread(viewId, success: success, address: address)
+            self?.performConfirm(viewId, success: success, address: address)
         }
     }
 
     @objc
     func hide(_ viewId: String, success: NSNumber, event _: NSDictionary) {
         ensureMainThread { [weak self] in
-            self?.hideOnMainThread(viewId, success: success)
+            self?.performHide(viewId, success: success)
         }
     }
 
     override func cleanUp() {
         ensureMainThread { [weak self] in
-            self?.cleanUpOnMainThread()
+            self?.performCleanUp()
         }
     }
 
-    private func subscribeOnMainThread(_ viewId: String) {
+    private func performSubscribe(_ viewId: String) {
         subscribedViews.insert(viewId)
     }
 
-    private func unsubscribeOnMainThread(_ viewId: String) {
+    private func performUnsubscribe(_ viewId: String) {
         subscribedViews.remove(viewId)
         unregister(viewId: viewId)
         if subscribedViews.isEmpty {
-            cleanUpOnMainThread()
+            performCleanUp()
         }
     }
 
-    private func handleOnMainThread(_ viewId: String, action actionDict: NSDictionary?) {
+    private func performHandle(_ viewId: String, action actionDict: NSDictionary?) {
         guard let actionDict else { return }
         guard let handler = actionHandler else {
             sendError(error: ModuleException.componentNotRegistered(viewId))
@@ -163,7 +163,7 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
         }
     }
 
-    private func updateOnMainThread(_ viewId: String, results: NSArray?) {
+    private func performUpdate(_ viewId: String, results: NSArray?) {
         guard let lookupHandler = lookupHandlers[viewId] else { return }
 
         let addressModels: [LookupAddressModel] = (results ?? [])
@@ -172,7 +172,7 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
         lookupHandler(addressModels)
     }
 
-    private func confirmOnMainThread(_ viewId: String, success: NSNumber, address: NSDictionary) {
+    private func performConfirm(_ viewId: String, success: NSNumber, address: NSDictionary) {
         guard let lookupCompletionHandler = lookupCompletionHandlers[viewId] else { return }
 
         if !success.boolValue, let message = address[Keys.message] as? String {
@@ -187,14 +187,14 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
         }
     }
 
-    private func hideOnMainThread(_ viewId: String, success: NSNumber) {
+    private func performHide(_ viewId: String, success: NSNumber) {
         unregister(viewId: viewId)
         if delegates.isEmpty {
             dismiss(success.boolValue)
         }
     }
 
-    private func cleanUpOnMainThread() {
+    private func performCleanUp() {
         delegates.removeAll()
         subscribedViews.removeAll()
         actionHandler?.cancelIfNeeded()

--- a/ios/Components/SessionHelperModule.swift
+++ b/ios/Components/SessionHelperModule.swift
@@ -48,7 +48,7 @@ internal final class SessionHelperModule: BaseModule, SessionErrorDelegate {
         }
 
         let config = AdyenSession.Configuration(sessionIdentifier: id, initialSessionData: data, context: context)
-        DispatchQueue.main.async {
+        ensureMainThread {
             AdyenSession.initialize(with: config, delegate: self, presentationDelegate: self) { result in
                 switch result {
                 case let .success(session):

--- a/ios/Views/CardView/CardComponentViewProxy.swift
+++ b/ios/Views/CardView/CardComponentViewProxy.swift
@@ -11,6 +11,12 @@ import UIKit
     func onLayoutChange(width: CGFloat, height: CGFloat)
 }
 
+/// Hosts a native `CardComponent` inside a React Native Fabric view.
+///
+/// Component creation and view-hierarchy attachment are decoupled because Fabric's mount lifecycle
+/// delivers them in either order: props (triggering `performInitialization`) may arrive before or after
+/// the proxy is added to a window. `attachChildViewControllerIfNeeded()` is called from both
+/// `performInitialization` and `didMoveToWindow` to cover both cases; it is idempotent (`childVC.parent == nil` guard).
 @objc(CardComponentViewProxy)
 public final class CardComponentViewProxy: UIStackView {
 
@@ -61,11 +67,11 @@ public final class CardComponentViewProxy: UIStackView {
 
     @objc public func dispose() {
         ensureMainThread {
-            self.disposeOnMainThread()
+            self.performDispose()
         }
     }
 
-    private func disposeOnMainThread() {
+    private func performDispose() {
         if let childVC = cardComponent?.viewController {
             childVC.willMove(toParent: nil)
             childVC.view.removeFromSuperview()
@@ -87,18 +93,18 @@ public final class CardComponentViewProxy: UIStackView {
     // MARK: - Component initialization
 
     private func initializeComponentIfNeeded() {
-        ensureMainThread { [weak self] in
-            self?.initializeComponentIfNeededOnMainThread()
-        }
-    }
-
-    private func initializeComponentIfNeededOnMainThread() {
         guard !hasComponent,
               let paymentMethodJSON,
               let configurationJSON,
               let viewId else {
             return
         }
+        ensureMainThread { [weak self] in
+            self?.performInitialization()
+        }
+    }
+
+    private func performInitialization() {
         self.hasComponent = true
         guard let componentBus = EmbeddedComponentBusModule.shared else {
             assertionFailure("EmbeddedComponentBusModule not initialized")
@@ -113,7 +119,8 @@ public final class CardComponentViewProxy: UIStackView {
                 proxy: proxy
             )
             self.cardComponent = component
-            embedComponentView(component)
+            loadComponentView(component)
+            attachChildViewControllerIfNeeded()
         } catch {
             self.hasComponent = false
             componentBus.sendError(error: error)
@@ -148,22 +155,29 @@ public final class CardComponentViewProxy: UIStackView {
 
     // MARK: - View embedding
 
-    private func embedComponentView(_ component: CardComponent) {
+    private func loadComponentView(_ component: CardComponent) {
         let childVC = component.viewController
         _ = childVC.view // force load view
+        componentView = childVC.view
+        addArrangedSubview(childVC.view)
+        disableNativeScrollingAndBouncing(in: childVC.view)
+    }
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
+    /// Attaches the child view controller to its parent if the proxy is already in the view hierarchy.
+    /// Called both from `performInitialization` and `didMoveToWindow` to handle either ordering:
+    /// component created before or after the proxy is added to the window.
+    private func attachChildViewControllerIfNeeded() {
+        guard let childVC = cardComponent?.viewController, childVC.parent == nil else { return }
+        guard let parentVC = parentViewController else { return }
+        parentVC.addChild(childVC)
+        childVC.didMove(toParent: parentVC)
+        layoutIfNeeded()
+    }
 
-            if let parentVC = self.parentViewController {
-                parentVC.addChild(childVC)
-                childVC.didMove(toParent: parentVC)
-            }
-
-            self.componentView = childVC.view
-            self.addArrangedSubview(childVC.view)
-            self.disableNativeScrollingAndBouncing(in: childVC.view)
-            self.layoutIfNeeded()
+    override public func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil {
+            attachChildViewControllerIfNeeded()
         }
     }
 

--- a/ios/Views/CardView/CardComponentViewProxy.swift
+++ b/ios/Views/CardView/CardComponentViewProxy.swift
@@ -93,18 +93,19 @@ public final class CardComponentViewProxy: UIStackView {
     // MARK: - Component initialization
 
     private func initializeComponentIfNeeded() {
-        guard !hasComponent,
-              let paymentMethodJSON,
-              let configurationJSON,
-              let viewId else {
-            return
-        }
         ensureMainThread { [weak self] in
-            self?.performInitialization()
+            guard let self,
+                  !self.hasComponent,
+                  let paymentMethodJSON = self.paymentMethodJSON,
+                  let configurationJSON = self.configurationJSON,
+                  let viewId = self.viewId else {
+                return
+            }
+            self.performInitialization(paymentMethodJSON, configurationJSON, viewId)
         }
     }
 
-    private func performInitialization() {
+    private func performInitialization(_ paymentMethodJSON: NSDictionary, _ configurationJSON: NSDictionary, _ viewId: String) {
         self.hasComponent = true
         guard let componentBus = EmbeddedComponentBusModule.shared else {
             assertionFailure("EmbeddedComponentBusModule not initialized")


### PR DESCRIPTION
## Summary
Consistency cleanup following the threading validation done for PR #1161.

1. `BaseAddressModule.update(_:)` / `confirm(_:address:)` now use `ensureMainThread(_:)` (matching the pattern used elsewhere, e.g. `EmbeddedComponentBusModule`) instead of a raw `DispatchQueue.main.async` that only wrapped the handler invocation while reading `lookupHandler` / `lookupCompletionHandler` on the caller's thread. Now the whole body (state read + handler invocation) runs on main.

2. `BaseModule.present(component:)` now routes through `ensureMainThread` as well. This required updating `ensureMainThread` to accept a `@MainActor`-isolated closure (`@escaping @MainActor () -> Void`) so it can call `@MainActor`-isolated APIs like `BaseModule.topPresenterProvider`, using `MainActor.assumeIsolated` for the already-on-main branch. This is safe now that the pod compiles at iOS 15.1 (`min_ios_version_supported` via RN 0.85), well above `assumeIsolated`'s iOS 13 floor.
   - Behavioral note: `present` has two call paths. The off-main RN bridge path (ApplePay/DropIn/Instant modules, called from React Native's background queue) is unchanged — still dispatched async to main. The on-main `PresentationDelegate` path (3DS challenge/redirect/voucher/await, already invoked on main by the SDK) changes from always-async (next runloop tick) to synchronous-inline, consistent with how `ensureMainThread` behaves everywhere else in the codebase.

## Tests
Ran the full `AdyenExampleTests` suite via `xcodebuild` on iPhone 17 Pro simulator — all 190 tests pass, including `ThreadingSafetyTests` and `BaseAddressModuleTests`.