### PR TITLE
feat: adopt UIScene lifecycle for iOS 27 SDK compatibility

### DIFF
--- a/example/ios/AdyenExample.xcodeproj/project.pbxproj
+++ b/example/ios/AdyenExample.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		E70D4FB42FF77A5D00C09021 /* ThreadingSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70D4FB32FF77A5D00C09021 /* ThreadingSafetyTests.swift */; };
 		E732B0CD2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E732B0CC2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift */; };
 		E741F0FE2E38DECD000D0F42 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E741F0FD2E38DEC6000D0F42 /* AppDelegate.swift */; };
+		E741F2012E38DECD000D0F42 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E741F2002E38DEC6000D0F42 /* SceneDelegate.swift */; };
 		E745059C2FF3C380009FC440 /* InstantModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E745059B2FF3C380009FC440 /* InstantModuleTests.swift */; };
 		E745059D2FF3C380009FC440 /* BaseModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E745059A2FF3C380009FC440 /* BaseModuleTests.swift */; };
 		E773B1092BE3B48900638431 /* DropInConfigurationParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E773B1082BE3B48900638431 /* DropInConfigurationParserTests.swift */; };
@@ -65,6 +66,7 @@
 		E70D4FB32FF77A5D00C09021 /* ThreadingSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadingSafetyTests.swift; sourceTree = "<group>"; };
 		E732B0CC2FB37E0400EBF477 /* ApplePayModuleUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayModuleUtilitiesTests.swift; sourceTree = "<group>"; };
 		E741F0FD2E38DEC6000D0F42 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E741F2002E38DEC6000D0F42 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E745059A2FF3C380009FC440 /* BaseModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseModuleTests.swift; sourceTree = "<group>"; };
 		E745059B2FF3C380009FC440 /* InstantModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantModuleTests.swift; sourceTree = "<group>"; };
 		E757C9D727737E6700B62256 /* AdyenExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = AdyenExample.entitlements; path = AdyenExample/AdyenExample.entitlements; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 			isa = PBXGroup;
 			children = (
 				E741F0FD2E38DEC6000D0F42 /* AppDelegate.swift */,
+				E741F2002E38DEC6000D0F42 /* SceneDelegate.swift */,
 				E757C9D727737E6700B62256 /* AdyenExample.entitlements */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
@@ -496,6 +499,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E741F0FE2E38DECD000D0F42 /* AppDelegate.swift in Sources */,
+				E741F2012E38DECD000D0F42 /* SceneDelegate.swift in Sources */,
 				F5C555F429F6C9F5008E7AA8 /* AdyenAppearance.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/example/ios/AdyenExample/Info.plist
+++ b/example/ios/AdyenExample/Info.plist
@@ -60,6 +60,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>RCTNewArchEnabled</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -71,6 +73,8 @@
 				<dict>
 					<key>UISceneConfigurationName</key>
 					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 				</dict>
 			</array>
 		</dict>

--- a/example/ios/AppDelegate.swift
+++ b/example/ios/AppDelegate.swift
@@ -6,10 +6,10 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow?
-
     var reactNativeDelegate: ReactNativeDelegate?
     var reactNativeFactory: RCTReactNativeFactory?
+
+    private var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
 
     func application(
         _ application: UIApplication,
@@ -21,16 +21,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         reactNativeDelegate = delegate
         reactNativeFactory = factory
+        self.launchOptions = launchOptions
 
-        window = UIWindow(frame: UIScreen.main.bounds)
+        return true
+    }
 
-        factory.startReactNative(
+    func startReactNative(in window: UIWindow) {
+        reactNativeFactory?.startReactNative(
             withModuleName: "AdyenExample",
             in: window,
             launchOptions: launchOptions
         )
-
-        return true
     }
 
     func application(

--- a/example/ios/SceneDelegate.swift
+++ b/example/ios/SceneDelegate.swift
@@ -1,0 +1,26 @@
+import UIKit
+import Adyen
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+
+        let sceneWindow = UIWindow(windowScene: windowScene)
+        window = sceneWindow
+
+        appDelegate.startReactNative(in: sceneWindow)
+    }
+
+  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+      guard let url = URLContexts.first?.url else { return }
+      RedirectComponent.applicationDidOpen(from: url)
+  }
+}


### PR DESCRIPTION
## Summary

- Add `SceneDelegate` implementing `UIWindowSceneDelegate` that creates the `UIWindow` from the `UIWindowScene` and starts React Native in it
- Move `UIWindow` creation and `factory.startReactNative` out of `AppDelegate.didFinishLaunchingWithOptions` into the scene delegate, storing `launchOptions` on the AppDelegate for deferred use
- Add `UISceneDelegateClassName` to the "Default Configuration" in `Info.plist` so iOS instantiates the `SceneDelegate`
- Register `SceneDelegate.swift` in the Xcode project

## Why

Apps built with the iOS 27 SDK that do not adopt the scene-based lifecycle will **fail to launch** (per Apple TN3187 / WWDC session 278). The existing `Info.plist` already declared a `UIApplicationSceneManifest` but had no scene delegate, causing the scene's window to be empty (black screen) while the React Native window was orphaned on the AppDelegate.

#### Test plan

- [ ] Example app builds against the iOS 27 SDK
- [ ] App launches without black screen — React Native content visible
- [ ] Deep link / URL opening still works (`RedirectComponent.applicationDidOpen`)
