### PR TITLE
chore: Include bundle install in iOS SDK update workflow

### DIFF
--- a/.github/workflows/update_sdk_versions.yml
+++ b/.github/workflows/update_sdk_versions.yml
@@ -71,6 +71,7 @@ jobs:
       run: |
         rm -f example/ios/Podfile.lock
         yarn
+        bundle install
         yarn app pod
 
     - uses: actions/cache@v5


### PR DESCRIPTION
## Changes

* add `bundle install` to prevent version conflicts