### PR TITLE
fix: stabilize Android Appium Settings startup

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate Fixture
         run: |
           bash ./e2e-tests/scripts/setup.sh ${{ env.APP_DIR }} "${{ inputs.platform }}" "${{ inputs.version }}"
-    
+
       - name: Download Library
         uses: actions/download-artifact@v8
         with:
@@ -181,9 +181,6 @@ jobs:
         run: |
           npm i -g appium@${{ env.APPIUM_VERSION }}
           appium driver install uiautomator2@${{ env.APPIUM_UIAUTOMATOR2_VERSION }}
-
-      - name: Start Appium
-        run: bash ./start_appium.sh 4723 30
 
       - name: Inject Secrets
         if: ${{ env.ADYEN_CLIENT_KEY != '' && env.ADYEN_PUBLIC_KEY != '' }}

--- a/e2e-tests/helpers/driver.js
+++ b/e2e-tests/helpers/driver.js
@@ -36,8 +36,9 @@ async function createDriver() {
         'appium:appPackage': androidAppPackage,
         'appium:appActivity': androidAppActivity,
         'appium:newCommandTimeout': 120,
-        'appium:uiautomator2ServerInstallTimeout': 60000,
-        'appium:uiautomator2ServerLaunchTimeout': 60000,
+        'appium:adbExecTimeout': 120000,
+        'appium:uiautomator2ServerInstallTimeout': 120000,
+        'appium:uiautomator2ServerLaunchTimeout': 120000,
       }
     : {
         'platformName': 'iOS',

--- a/e2e-tests/scripts/build-android.sh
+++ b/e2e-tests/scripts/build-android.sh
@@ -7,6 +7,11 @@ APP_PACKAGE=com.$PROJECT_NAME
 
 platform=${1:-}
 
+adb wait-for-device
+until [ "$(adb shell getprop sys.boot_completed | tr -d '\r')" = "1" ]; do
+  sleep 2
+done
+
 if [ "$platform" = "expo" ]; then
   echo "::group::Prebuild Expo Android [$(date '+%H:%M:%S')]"
   npx expo prebuild -p android --clean
@@ -33,13 +38,18 @@ adb shell am start -n "$APP_PACKAGE/.MainActivity"
 echo "::endgroup::"
 
 echo "::group::Pre-install Appium APKs [$(date '+%H:%M:%S')]"
-SETTINGS_APK=$(find ~/.appium -name "settings_apk-debug.apk" 2>/dev/null | head -1)
+SETTINGS_APK=$(find "$HOME/.appium" -name "settings_apk-debug.apk" -print -quit 2>/dev/null)
 if [ -n "$SETTINGS_APK" ]; then
   echo "Installing io.appium.settings from: $SETTINGS_APK"
-  adb install -r -t "$SETTINGS_APK" || echo "Warning: settings APK install failed, Appium will retry"
+  adb install -r -t -g "$SETTINGS_APK"
 else
-  echo "Warning: settings_apk-debug.apk not found under ~/.appium"
+  echo "Error: settings_apk-debug.apk not found under $HOME/.appium"
+  exit 1
 fi
+echo "::endgroup::"
+
+echo "::group::Start Appium [$(date '+%H:%M:%S')]"
+bash ./start_appium.sh 4723 30
 echo "::endgroup::"
 
 echo "::group::Run Appium Tests [$(date '+%H:%M:%S')]"

--- a/e2e-tests/scripts/build-android.sh
+++ b/e2e-tests/scripts/build-android.sh
@@ -48,8 +48,23 @@ else
 fi
 echo "::endgroup::"
 
+cleanup_appium() {
+  if [ -f .appium.pid ]; then
+    APPIUM_PID=$(cat .appium.pid)
+    kill "$APPIUM_PID" 2>/dev/null || true
+    for _ in {1..10}; do
+      kill -0 "$APPIUM_PID" 2>/dev/null || break
+      sleep 1
+    done
+    kill -9 "$APPIUM_PID" 2>/dev/null || true
+    rm -f .appium.pid
+  fi
+}
+
+trap cleanup_appium EXIT
+
 echo "::group::Start Appium [$(date '+%H:%M:%S')]"
-bash ./start_appium.sh 4723 30
+APPIUM_PID_FILE=.appium.pid bash ./start_appium.sh 4723 30
 echo "::endgroup::"
 
 echo "::group::Run Appium Tests [$(date '+%H:%M:%S')]"

--- a/e2e-tests/scripts/build-android.sh
+++ b/e2e-tests/scripts/build-android.sh
@@ -6,11 +6,21 @@ PROJECT_NAME=testproject
 APP_PACKAGE=com.$PROJECT_NAME
 
 platform=${1:-}
+BOOT_TIMEOUT=300
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
+echo "::group::Booting emulator [$(date '+%H:%M:%S')]"
 adb wait-for-device
-until [ "$(adb shell getprop sys.boot_completed | tr -d '\r')" = "1" ]; do
+boot_elapsed=0
+until [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do
+  if [ "$boot_elapsed" -ge "$BOOT_TIMEOUT" ]; then
+    echo "Error: Emulator failed to boot within $BOOT_TIMEOUT seconds"
+    exit 1
+  fi
   sleep 2
+  boot_elapsed=$((boot_elapsed + 2))
 done
+echo "::endgroup::"
 
 if [ "$platform" = "expo" ]; then
   echo "::group::Prebuild Expo Android [$(date '+%H:%M:%S')]"
@@ -38,7 +48,7 @@ adb shell am start -n "$APP_PACKAGE/.MainActivity"
 echo "::endgroup::"
 
 echo "::group::Pre-install Appium APKs [$(date '+%H:%M:%S')]"
-SETTINGS_APK=$(find "$HOME/.appium" -name "settings_apk-debug.apk" -print -quit 2>/dev/null)
+SETTINGS_APK=$(find "$HOME/.appium" -name "settings_apk-debug.apk" 2>/dev/null | head -n 1)
 if [ -n "$SETTINGS_APK" ]; then
   echo "Installing io.appium.settings from: $SETTINGS_APK"
   adb install -r -t -g "$SETTINGS_APK"
@@ -64,7 +74,7 @@ cleanup_appium() {
 trap cleanup_appium EXIT
 
 echo "::group::Start Appium [$(date '+%H:%M:%S')]"
-APPIUM_PID_FILE=.appium.pid bash ./start_appium.sh 4723 30
+APPIUM_PID_FILE=.appium.pid bash "$SCRIPT_DIR/start_appium.sh" 4723 30
 echo "::endgroup::"
 
 echo "::group::Run Appium Tests [$(date '+%H:%M:%S')]"

--- a/e2e-tests/scripts/start_appium.sh
+++ b/e2e-tests/scripts/start_appium.sh
@@ -4,9 +4,12 @@ set -euo pipefail
 
 PORT=${1:-4723}
 TIMEOUT=${2:-90}
+PID_FILE=${APPIUM_PID_FILE:-.appium.pid}
 
 echo "== Starting Appium on port $PORT"
 appium --port "$PORT" --log-level error &
+APPIUM_PID=$!
+printf '%s\n' "$APPIUM_PID" > "$PID_FILE"
 
 for i in $(seq 1 "$TIMEOUT"); do
   if curl -sf "http://127.0.0.1:$PORT/status" >/dev/null 2>&1; then
@@ -17,4 +20,6 @@ for i in $(seq 1 "$TIMEOUT"); do
 done
 
 echo "Error: Appium failed to start within ${TIMEOUT} seconds"
+kill "$APPIUM_PID" 2>/dev/null || true
+rm -f "$PID_FILE"
 exit 1


### PR DESCRIPTION
## Summary
- wait for the Android emulator to finish booting before running the E2E build
- install the Appium Settings helper APK with required permissions
- start Appium after emulator readiness and increase Android startup timeouts

## Test plan
- [x] Bash syntax validation for Android/Appium scripts
- [x] `git diff --check`
- [x] Verify Android E2E workflow passes on CI

Generated with [Devin](https://devin.ai)