### PR TITLE
feat: add Netlify client to example app

### DIFF
--- a/example/index.netlify.js
+++ b/example/index.netlify.js
@@ -1,0 +1,37 @@
+/**
+ * @format
+ */
+
+import React, { useMemo } from 'react';
+import { AppRegistry } from 'react-native';
+import App from './src/App';
+import { ExternalConfigProvider } from './src/config/ExternalConfigProvider';
+import { DEFAULT_CONFIGURATION, ENVIRONMENT } from './src/Configuration';
+import NetlifyApiClient from './src/api/NetlifyApiClient';
+import { netlifyClientKey } from '../secrets.json';
+import { name as appName } from './app.json';
+
+ENVIRONMENT.clientKey = netlifyClientKey;
+
+const NETLIFY_CONFIGURATION = {
+  ...DEFAULT_CONFIGURATION,
+  cardSettings: { addressVisibility: 'none' },
+};
+
+const NetlifyApp = (props) => {
+  const externalProvider = useMemo(
+    () =>
+      new ExternalConfigProvider(NETLIFY_CONFIGURATION, props.externalConfig),
+    [props.externalConfig]
+  );
+
+  return (
+    <App
+      {...props}
+      configProvider={externalProvider}
+      apiClient={NetlifyApiClient}
+    />
+  );
+};
+
+AppRegistry.registerComponent(appName, () => NetlifyApp);

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "android": "react-native run-android",
+    "android:netlify": "cd android && ENTRY_FILE=index.netlify.js ./gradlew assembleRelease",
     "ios": "react-native run-ios",
+    "ios:netlify": "cd ios && ENTRY_FILE=index.netlify.js xcodebuild -workspace AdyenExample.xcworkspace -scheme AdyenExample -configuration Release -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/netlify CODE_SIGNING_ALLOWED=NO ENABLE_USER_SCRIPT_SANDBOXING=NO",
     "lint": "eslint .",
     "start": "react-native start",
     "test": "jest",

--- a/example/src/api/NetlifyApiClient.ts
+++ b/example/src/api/NetlifyApiClient.ts
@@ -1,0 +1,119 @@
+import type {
+  PaymentMethodsResponse,
+  PaymentMethodData,
+  PaymentDetailsData,
+  Order,
+  SessionConfiguration,
+} from '@adyen/react-native';
+import type {
+  PaymentConfiguration,
+  PaymentResponse,
+  BalanceResponse,
+  OrderResponse,
+} from './types';
+import type { ApiService } from './ApiService';
+import { CHANNEL } from '../Configuration';
+
+const BASE_URL = 'https://www.mystoredemo.io/.netlify/functions';
+
+class NetlifyApiClient implements ApiService {
+  readonly usesDirectSessionResult = true;
+
+  private async makeRequest(url: string, body: object): Promise<any> {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      let errorMessage = response.statusText;
+      try {
+        const errorJson = await response.json();
+        if (errorJson && errorJson.message) {
+          errorMessage = errorJson.message;
+        } else if (typeof errorJson === 'string') {
+          errorMessage = errorJson;
+        }
+      } catch {
+        // Fall back to statusText if the response is not JSON.
+      }
+      throw new Error(`Network Error ${response.status}: ${errorMessage}`);
+    }
+    return response.json();
+  }
+
+  async payments(
+    data: PaymentMethodData,
+    _configuration: PaymentConfiguration,
+    _returnUrl?: string
+  ): Promise<PaymentResponse> {
+    return this.makeRequest(`${BASE_URL}/payments`, data);
+  }
+
+  async paymentDetails(data: PaymentDetailsData): Promise<PaymentResponse> {
+    return this.makeRequest(`${BASE_URL}/payments/details`, data);
+  }
+
+  async requestSession(
+    configuration: PaymentConfiguration,
+    returnUrl: string
+  ): Promise<SessionConfiguration> {
+    const body = {
+      merchantAccount: configuration.merchantAccount,
+      countryCode: configuration.countryCode,
+      amount: { value: configuration.amount, currency: configuration.currency },
+      returnUrl,
+      channel: CHANNEL,
+      reference: 'React Native',
+    };
+    return this.makeRequest(`${BASE_URL}/sessions`, body);
+  }
+
+  async paymentMethods(
+    configuration: PaymentConfiguration,
+    _order?: Order
+  ): Promise<PaymentMethodsResponse> {
+    const body = {
+      merchantAccount: configuration.merchantAccount,
+      countryCode: configuration.countryCode,
+      amount: { value: configuration.amount, currency: configuration.currency },
+    };
+    return this.makeRequest(`${BASE_URL}/paymentMethods`, body);
+  }
+
+  async requestSessionResult(
+    _sessionId: string,
+    _sessionResult: string
+  ): Promise<PaymentResponse> {
+    throw new Error('requestSessionResult not supported via Netlify');
+  }
+
+  async tryRemoveStoredCard(
+    _id: string,
+    _configuration: PaymentConfiguration
+  ): Promise<boolean> {
+    throw new Error('tryRemoveStoredCard not supported via Netlify');
+  }
+
+  async checkBalance(
+    _paymentData: PaymentMethodData,
+    _configuration: PaymentConfiguration
+  ): Promise<BalanceResponse> {
+    throw new Error('checkBalance not supported via Netlify');
+  }
+
+  async requestOrder(
+    _configuration: PaymentConfiguration
+  ): Promise<OrderResponse> {
+    throw new Error('requestOrder not supported via Netlify');
+  }
+
+  async cancelOrder(
+    _order: Order,
+    _configuration: PaymentConfiguration
+  ): Promise<OrderResponse> {
+    throw new Error('cancelOrder not supported via Netlify');
+  }
+}
+
+export default new NetlifyApiClient();


### PR DESCRIPTION
## Summary
- add a Netlify-backed example app entry point (`index.netlify.js`) for cross-platform E2E testing
- inject `NetlifyApiClient` through `AppContextProvider` as the API client for the Netlify entry point, as introduced in #1176
- add explicit Android and iOS Netlify release scripts in `example/package.json`
- this PR depends on #1176

Ticket: COSDK-1373

#### Test plan
- [x] `yarn test`
- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn app android:netlify`
- [x] `yarn app ios:netlify`
