### PR TITLE
chore: add Gradle-based ktlint setup for example app

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,4 +15,4 @@ run_check yarn test
 run_check yarn lint
 run_check yarn typecheck
 run_check swiftformat --lint ios
-run_check ktlint android
+run_check ./example/android/gradlew -p example/android ktlint

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -19,3 +19,4 @@ buildscript {
 }
 
 apply plugin: "com.facebook.react.rootproject"
+apply from: "ktlint.gradle"

--- a/example/android/ktlint.gradle
+++ b/example/android/ktlint.gradle
@@ -1,0 +1,71 @@
+apply plugin: "base"
+
+configurations {
+    ktlint
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    ktlint("com.pinterest.ktlint:ktlint-cli:1.8.0") {
+        attributes {
+            attribute(
+                org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE,
+                objects.named(org.gradle.api.attributes.Bundling, org.gradle.api.attributes.Bundling.EXTERNAL)
+            )
+        }
+    }
+}
+
+def ktlintInputFiles = files(
+    fileTree("../../android/src") {
+        include "**/*.kt", "**/*.kts"
+        exclude "**/build/**", "**/.gradle/**"
+    },
+    fileTree("app/src") {
+        include "**/*.kt", "**/*.kts"
+        exclude "**/build/**", "**/.gradle/**"
+    }
+)
+
+def ktlintTask = tasks.register("ktlint", JavaExec) {
+    description = "Check Kotlin code style."
+    group = "verification"
+    inputs.files(ktlintInputFiles)
+
+    def outputFile = layout.buildDirectory.file("reports/ktlint/ktlint-report.txt")
+    outputs.file(outputFile)
+
+    classpath = configurations.ktlint
+    mainClass.set("com.pinterest.ktlint.Main")
+    args(
+        "--reporter=plain",
+        "--reporter=plain,output=${outputFile.get().asFile}",
+        "../../android/src/**/*.kt",
+        "../../android/src/**/*.kts",
+        "app/src/**/*.kt",
+        "app/src/**/*.kts",
+        "!**/build/**"
+    )
+}
+
+tasks.named("check") {
+    dependsOn(ktlintTask)
+}
+
+tasks.register("ktlintFormat", JavaExec) {
+    description = "Fix Kotlin code style deviations."
+    group = "formatting"
+    classpath = configurations.ktlint
+    mainClass.set("com.pinterest.ktlint.Main")
+    args(
+        "-F",
+        "../../android/src/**/*.kt",
+        "../../android/src/**/*.kts",
+        "app/src/**/*.kt",
+        "app/src/**/*.kts",
+        "!**/build/**"
+    )
+}

--- a/example/android/ktlint.gradle
+++ b/example/android/ktlint.gradle
@@ -42,7 +42,7 @@ def ktlintTask = tasks.register("ktlint", JavaExec) {
     mainClass.set("com.pinterest.ktlint.Main")
     args(
         "--reporter=plain",
-        "--reporter=plain,output=${outputFile.get().asFile}",
+        outputFile.map { "--reporter=plain,output=${it.asFile}" },
         "../../android/src/**/*.kt",
         "../../android/src/**/*.kts",
         "app/src/**/*.kt",


### PR DESCRIPTION
## Summary
- Extracts the ktlint configuration into a dedicated `example/android/ktlint.gradle` file to keep `example/android/build.gradle` close to the React Native template.
- Adds a Gradle-based `ktlint` verification task and a `ktlintFormat` formatting task for both the SDK (`android/src`) and example app (`example/android/app/src`) Kotlin sources.
- Updates the Husky pre-commit hook to run `./example/android/gradlew -p example/android ktlint` instead of relying on the global `ktlint` CLI.

This addresses the review comment on #1173 suggesting the ktlint setup be moved out of the main `build.gradle` and into a separate PR.

## Test plan
- Ran `./gradlew ktlint` successfully.
- Ran `./gradlew ktlintFormat` successfully.
- Verified that `example/android/build.gradle` remains minimal and applies the setup via `apply from: "ktlint.gradle"`.