### PR TITLE
refactor: move onDisableStoredPaymentMethod to AdvancedCheckout

### DIFF
--- a/example/src/components/Checkout/AdvancedCheckout.tsx
+++ b/example/src/components/Checkout/AdvancedCheckout.tsx
@@ -8,6 +8,7 @@ import type {
   PaymentDetailsData,
   AdyenError,
   AdyenComponent,
+  StoredPaymentMethod,
 } from '@adyen/react-native';
 import Styles from '../common/Styles';
 import TopView from './components/TopView';
@@ -92,6 +93,25 @@ const AdvancedCheckout = () => {
     [processResult]
   );
 
+  const onDisableStoredPaymentMethod = useCallback(
+    async (
+      storedPaymentMethod: StoredPaymentMethod,
+      resolve: () => void,
+      reject: () => void
+    ) => {
+      const success = await ApiClient.tryRemoveStoredCard(
+        storedPaymentMethod.id,
+        configuration
+      );
+      if (success) {
+        resolve();
+      } else {
+        reject();
+      }
+    },
+    [configuration]
+  );
+
   if (loading) {
     return (
       <View style={Styles.centeredContent}>
@@ -108,11 +128,20 @@ const AdvancedCheckout = () => {
     );
   }
 
+  const baseConfig = checkoutConfiguration(configuration);
+  const checkoutConfig = {
+    ...baseConfig,
+    dropin: {
+      ...baseConfig.dropin,
+      onDisableStoredPaymentMethod,
+    },
+  };
+
   return (
     <View style={Styles.page}>
       <TopView />
       <AdyenCheckout
-        config={checkoutConfiguration(configuration)}
+        config={checkoutConfig}
         paymentMethods={paymentMethods}
         onSubmit={didSubmit}
         onAdditionalDetails={didProvide}

--- a/example/src/settings/checkoutConfiguration.ts
+++ b/example/src/settings/checkoutConfiguration.ts
@@ -4,10 +4,8 @@ import type {
   ApplePayRecurringPaymentRequest,
   BinLookupData,
   Configuration,
-  StoredPaymentMethod,
 } from '@adyen/react-native';
 import { ENVIRONMENT } from '../Configuration';
-import ApiClient from '../api/APIClient';
 import type { AppConfiguration } from './types';
 
 export const checkoutConfiguration = (config: AppConfiguration) => {
@@ -33,21 +31,6 @@ export const checkoutConfiguration = (config: AppConfiguration) => {
       showRemovePaymentMethodButton:
         config.dropInSettings?.showRemovePaymentMethodButton ?? true,
       title: config.dropInSettings?.title,
-      onDisableStoredPaymentMethod: async (
-        storedPaymentMethod: StoredPaymentMethod,
-        resolve: () => void,
-        reject: () => void
-      ) => {
-        const success = await ApiClient.tryRemoveStoredCard(
-          storedPaymentMethod.id,
-          config
-        );
-        if (success) {
-          resolve();
-        } else {
-          reject();
-        }
-      },
     },
     card: {
       holderNameRequired: config.cardSettings?.holderNameRequired,


### PR DESCRIPTION
## Summary
- Moved the `onDisableStoredPaymentMethod` callback implementation from the shared `checkoutConfiguration` helper into `AdvancedCheckout.tsx`, where it is wired up as a `useCallback` and merged into the dropin config.
- Removed the now-unused `StoredPaymentMethod` type import and `ApiClient` import from `checkoutConfiguration.ts`.

## Why
The stored-payment-method removal handler is component-specific behavior (it depends on the live `configuration` from `useAppContext` and triggers an API call). Keeping it in the shared config helper coupled it to all consumers of `checkoutConfiguration`, even those that do not need it. Co-locating it with `AdvancedCheckout` makes the ownership clear and keeps the shared config purely declarative.

Ticket: COSDK-672

## Notes
- `SessionsDropInCheckout` and `SessionsComponentsCheckout` do not need the handler — the SDK handles `onDisableStoredPaymentMethod` behind the scenes in session flows (same as `onSubmit`, `onAdditionalDetails`, etc.).
- `PartialPaymentCheckout` is not a session flow, but the handler can be omitted there since that screen is intended to showcase the partial payment scenario.

#### Test plan
- [ ] Verify stored payment method removal still works in the Advanced checkout flow (remove button resolves/rejects correctly based on API response).
- [ ] Confirm no regressions in Sessions/Partial payment checkouts.