### PR TITLE
chore: make public API report non-blocking

### DIFF
--- a/.github/workflows/public_api_check.yml
+++ b/.github/workflows/public_api_check.yml
@@ -143,8 +143,3 @@ jobs:
                 body,
               });
             }
-
-      - name: Fail when Public API differs
-        run: |
-          echo 'The generated Public API snapshot differs from the target branch.'
-          exit 1


### PR DESCRIPTION
## Summary
- keep the Public API diff comment on pull requests
- allow the workflow to succeed when the generated API report differs

## Ticket
COSDK-1382

#### Test plan
- [x] Parsed `.github/workflows/public_api_check.yml` as YAML
- [x] Ran `git diff --check`

Generated with [Devin](https://devin.ai)