### PR TITLE
chore: improve public API report

### DIFF
--- a/.github/workflows/public_api_check.yml
+++ b/.github/workflows/public_api_check.yml
@@ -56,27 +56,26 @@ jobs:
         if: steps.source-changes.outputs.changed == 'true'
         run: |
           if git show "$BASE_SHA:$API_REPORT" > /tmp/base-api-report.md 2>/dev/null; then
-            if diff -u /tmp/base-api-report.md "$API_REPORT" > /tmp/api-diff.txt; then
-              echo "changed=false" >> "$GITHUB_OUTPUT"
-            else
-              echo "changed=true" >> "$GITHUB_OUTPUT"
-            fi
+            echo "Baseline API report found"
           else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "## New file: $API_REPORT (no baseline on target branch)" > /tmp/api-diff.txt
+            echo "No baseline API report on target branch"
+            : > /tmp/base-api-report.md
           fi
+          node scripts/api-report-summary.js /tmp/base-api-report.md "$API_REPORT"
+          changed=$(cat /tmp/public-api-report/changed.txt)
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
-      - name: Archive API diff
-        if: steps.api-diff.outputs.changed == 'true'
+      - name: Archive API report
+        if: steps.source-changes.outputs.changed == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: public-api-diff
-          path: /tmp/api-diff.txt
+          name: public-api-report
+          path: /tmp/public-api-report/
           retention-days: 1
 
   report-public-api:
     name: Report Public API Changes
-    if: always() && needs.check-public-api.outputs.api-changed == 'true'
+    if: always() && needs.check-public-api.outputs.api-changed != ''
     needs: [check-public-api]
     runs-on: ubuntu-24.04
     permissions:
@@ -85,36 +84,53 @@ jobs:
     steps:
       - uses: actions/download-artifact@v7
         with:
-          name: public-api-diff
-          path: /tmp
+          name: public-api-report
+          path: /tmp/public-api-report
 
       - name: Comment API changes on pull request
         uses: actions/github-script@v8
         env:
-          API_DIFF: /tmp/api-diff.txt
+          SUMMARY: /tmp/public-api-report/summary.md
+          DIFF: /tmp/public-api-report/diff.txt
+          CHANGED: /tmp/public-api-report/changed.txt
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const marker = '<!-- public-api-diff -->';
-            const diff = fs.readFileSync(process.env.API_DIFF, 'utf8');
-            const body = [
-              marker,
-              '## Public API changes detected',
+            const summary = fs.readFileSync(process.env.SUMMARY, 'utf8');
+            const diff = fs.readFileSync(process.env.DIFF, 'utf8');
+            const changed = fs.readFileSync(process.env.CHANGED, 'utf8').trim() === 'true';
+
+            const title = changed
+              ? '## 🟡 Public API changes detected'
+              : '## 🟢 No public API changes';
+
+            const parts = [marker, title, '', summary];
+
+            if (changed && diff.trim()) {
+              const displayDiff =
+                diff.length > 60000 ? diff.slice(0, 60000) + '\n\n... (truncated)' : diff;
+              parts.push(
+                '',
+                '<details>',
+                '<summary>API snapshot diff</summary>',
+                '',
+                '```diff',
+                displayDiff,
+                '```',
+                '</details>',
+              );
+            }
+
+            parts.push(
               '',
-              'The generated Public API snapshot differs from the target branch because files under `src/` changed.',
-              '',
-              '<details>',
-              '<summary>API snapshot diff</summary>',
-              '',
-              '```diff',
-              diff,
-              '```',
-              '</details>',
-              '',
-              'Please review the changes and update `etc/api/adyen-react-native.api.md` if this public API change is intentional.',
-              '',
-            ].join('\n');
+              changed
+                ? 'Please review the changes and update `etc/api/adyen-react-native.api.md` if this public API change is intentional.'
+                : 'No action needed — the public API snapshot matches the target branch.',
+            );
+
+            const body = parts.join('\n');
 
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
@@ -124,8 +140,8 @@ jobs:
               issue_number,
               per_page: 100,
             });
-            const existingComment = comments.find(comment =>
-              comment.user.type === 'Bot' && comment.body.includes(marker)
+            const existingComment = comments.find(
+              (comment) => comment.user.type === 'Bot' && comment.body.includes(marker),
             );
 
             if (existingComment) {

--- a/.github/workflows/public_api_check.yml
+++ b/.github/workflows/public_api_check.yml
@@ -75,7 +75,10 @@ jobs:
 
   report-public-api:
     name: Report Public API Changes
-    if: always() && needs.check-public-api.outputs.api-changed != ''
+    if: >-
+      always() &&
+      needs.check-public-api.outputs.api-changed != '' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     needs: [check-public-api]
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/public_api_check.yml
+++ b/.github/workflows/public_api_check.yml
@@ -62,15 +62,13 @@ jobs:
             : > /tmp/base-api-report.md
           fi
           node scripts/api-report-summary.js /tmp/base-api-report.md "$API_REPORT"
-          changed=$(cat /tmp/public-api-report/changed.txt)
-          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - name: Archive API report
         if: steps.source-changes.outputs.changed == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: public-api-report
-          path: /tmp/public-api-report/
+          path: /tmp/public-api-report/report.json
           retention-days: 1
 
   report-public-api:
@@ -85,6 +83,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v7
+
       - uses: actions/download-artifact@v7
         with:
           name: public-api-report
@@ -93,72 +93,8 @@ jobs:
       - name: Comment API changes on pull request
         uses: actions/github-script@v8
         env:
-          SUMMARY: /tmp/public-api-report/summary.md
-          DIFF: /tmp/public-api-report/diff.txt
-          CHANGED: /tmp/public-api-report/changed.txt
+          REPORT: /tmp/public-api-report/report.json
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
-            const marker = '<!-- public-api-diff -->';
-            const summary = fs.readFileSync(process.env.SUMMARY, 'utf8');
-            const diff = fs.readFileSync(process.env.DIFF, 'utf8');
-            const changed = fs.readFileSync(process.env.CHANGED, 'utf8').trim() === 'true';
-
-            const title = changed
-              ? '## 🟡 Public API changes detected'
-              : '## 🟢 No public API changes';
-
-            const parts = [marker, title, '', summary];
-
-            if (changed && diff.trim()) {
-              const displayDiff =
-                diff.length > 60000 ? diff.slice(0, 60000) + '\n\n... (truncated)' : diff;
-              parts.push(
-                '',
-                '<details>',
-                '<summary>API snapshot diff</summary>',
-                '',
-                '```diff',
-                displayDiff,
-                '```',
-                '</details>',
-              );
-            }
-
-            parts.push(
-              '',
-              changed
-                ? 'Please review the changes and update `etc/api/adyen-react-native.api.md` if this public API change is intentional.'
-                : 'No action needed — the public API snapshot matches the target branch.',
-            );
-
-            const body = parts.join('\n');
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const existingComment = comments.find(
-              (comment) => comment.user.type === 'Bot' && comment.body.includes(marker),
-            );
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existingComment.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body,
-              });
-            }
+            await require(`${process.env.GITHUB_WORKSPACE}/scripts/post-api-report-comment`)({ github, context });

--- a/scripts/__tests__/api-report-summary.test.ts
+++ b/scripts/__tests__/api-report-summary.test.ts
@@ -63,6 +63,19 @@ export interface Existing {
     expect(result.summary).toContain('Public API is unchanged');
   });
 
+  it('normalizes CRLF line endings', () => {
+    const report = `// @public
+export interface Existing {
+    value: string;
+}
+`;
+
+    const result = run(report, report.replace(/\n/g, '\r\n'));
+
+    expect(result.changed).toBe('false');
+    expect(result.summary).toContain('Public API is unchanged');
+  });
+
   it('groups added, removed, modified, and renamed declarations', () => {
     const base = `// @public
 export interface Existing {
@@ -188,6 +201,20 @@ export interface AddedInterface {
     expect(result.summary).toContain('`ExistingEnum.AddedCase`');
     expect(result.summary).toContain('### ❌ Enum cases removed (1)');
     expect(result.summary).toContain('`ExistingEnum.RemovedCase`');
+  });
+
+  it('formats top-level function parameters without an extra dot', () => {
+    const base = `// @public
+export function submit(payment: string): void;
+`;
+    const head = `// @public
+export function submit(payment: string, configuration: string): void;
+`;
+
+    const result = run(base, head);
+
+    expect(result.summary).toContain('`submit(configuration)`');
+    expect(result.summary).not.toContain('`submit.(configuration)`');
   });
 
   it('treats a missing baseline as an empty API report', () => {

--- a/scripts/__tests__/api-report-summary.test.ts
+++ b/scripts/__tests__/api-report-summary.test.ts
@@ -9,21 +9,30 @@ import { spawnSync } from 'child_process';
 const SCRIPT = resolve(__dirname, '../api-report-summary.js');
 
 type Result = {
-  changed: string;
+  changed: boolean;
   diff: string;
+  githubOutput?: string;
   summary: string;
 };
 
-function run(base: string | undefined, head: string): Result {
+function run(
+  base: string | undefined,
+  head: string,
+  includeGithubOutput = false
+): Result {
   const directory = mkdtempSync(join(tmpdir(), 'api-report-summary-'));
   const basePath = join(directory, 'base.md');
   const missingBasePath = join(directory, 'missing-base.md');
   const headPath = join(directory, 'head.md');
   const outputPath = join(directory, 'output');
+  const githubOutputPath = join(directory, 'github-output.txt');
 
   try {
     if (base !== undefined) writeFileSync(basePath, base);
     writeFileSync(headPath, head);
+    const env = { ...process.env };
+    if (includeGithubOutput) env.GITHUB_OUTPUT = githubOutputPath;
+    else delete env.GITHUB_OUTPUT;
 
     const result = spawnSync(
       'node',
@@ -33,15 +42,16 @@ function run(base: string | undefined, head: string): Result {
         headPath,
         outputPath,
       ],
-      { encoding: 'utf8' }
+      { encoding: 'utf8', env }
     );
 
     expect(result.status).toBe(0);
 
     return {
-      changed: readFileSync(join(outputPath, 'changed.txt'), 'utf8'),
-      diff: readFileSync(join(outputPath, 'diff.txt'), 'utf8'),
-      summary: readFileSync(join(outputPath, 'summary.md'), 'utf8'),
+      ...JSON.parse(readFileSync(join(outputPath, 'report.json'), 'utf8')),
+      githubOutput: includeGithubOutput
+        ? readFileSync(githubOutputPath, 'utf8')
+        : undefined,
     };
   } finally {
     rmSync(directory, { force: true, recursive: true });
@@ -58,7 +68,7 @@ export interface Existing {
 
     const result = run(report, report);
 
-    expect(result.changed).toBe('false');
+    expect(result.changed).toBe(false);
     expect(result.diff).toBe('');
     expect(result.summary).toContain('Public API is unchanged');
   });
@@ -72,8 +82,20 @@ export interface Existing {
 
     const result = run(report, report.replace(/\n/g, '\r\n'));
 
-    expect(result.changed).toBe('false');
+    expect(result.changed).toBe(false);
     expect(result.summary).toContain('Public API is unchanged');
+  });
+
+  it('writes the changed state to GITHUB_OUTPUT', () => {
+    const report = `// @public
+export interface Existing {
+    value: string;
+}
+`;
+
+    const result = run(report, report, true);
+
+    expect(result.githubOutput).toBe('changed=false\n');
   });
 
   it('groups added, removed, modified, and renamed declarations', () => {
@@ -110,7 +132,7 @@ export interface NewName {
 
     const result = run(base, head);
 
-    expect(result.changed).toBe('true');
+    expect(result.changed).toBe(true);
     expect(result.summary).toContain('Added (1)');
     expect(result.summary).toContain('`Added`');
     expect(result.summary).toContain('Removed (1)');
@@ -226,7 +248,7 @@ export interface Added {
 
     const result = run(undefined, head);
 
-    expect(result.changed).toBe('true');
+    expect(result.changed).toBe(true);
     expect(result.summary).toContain('Added (1)');
     expect(result.diff).toContain('+// @public');
   });

--- a/scripts/__tests__/api-report-summary.test.ts
+++ b/scripts/__tests__/api-report-summary.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Adyen N.V.
+
+import { describe, expect, it } from '@jest/globals';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { spawnSync } from 'child_process';
+
+const SCRIPT = resolve(__dirname, '../api-report-summary.js');
+
+type Result = {
+  changed: string;
+  diff: string;
+  summary: string;
+};
+
+function run(base: string | undefined, head: string): Result {
+  const directory = mkdtempSync(join(tmpdir(), 'api-report-summary-'));
+  const basePath = join(directory, 'base.md');
+  const headPath = join(directory, 'head.md');
+  const outputPath = join(directory, 'output');
+
+  try {
+    if (base !== undefined) writeFileSync(basePath, base);
+    writeFileSync(headPath, head);
+
+    const result = spawnSync(
+      'node',
+      [SCRIPT, base === undefined ? basePath : basePath, headPath, outputPath],
+      { encoding: 'utf8' }
+    );
+
+    expect(result.status).toBe(0);
+
+    return {
+      changed: readFileSync(join(outputPath, 'changed.txt'), 'utf8'),
+      diff: readFileSync(join(outputPath, 'diff.txt'), 'utf8'),
+      summary: readFileSync(join(outputPath, 'summary.md'), 'utf8'),
+    };
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+describe('api-report-summary.js', () => {
+  it('reports an unchanged API', () => {
+    const report = `// @public
+export interface Existing {
+    value: string;
+}
+`;
+
+    const result = run(report, report);
+
+    expect(result.changed).toBe('false');
+    expect(result.diff).toBe('');
+    expect(result.summary).toContain('Public API is unchanged');
+  });
+
+  it('groups added, removed, modified, and renamed declarations', () => {
+    const base = `// @public
+export interface Existing {
+    value: string;
+}
+
+// @public
+export interface Removed {
+    removed: number;
+}
+
+// @public
+export interface OldName {
+    renamed: boolean;
+}
+`;
+    const head = `// @public
+export interface Existing {
+    value: number;
+}
+
+// @public
+export interface Added {
+    added: string;
+}
+
+// @public
+export interface NewName {
+    renamed: boolean;
+}
+`;
+
+    const result = run(base, head);
+
+    expect(result.changed).toBe('true');
+    expect(result.summary).toContain('Added (1)');
+    expect(result.summary).toContain('`Added`');
+    expect(result.summary).toContain('Removed (1)');
+    expect(result.summary).toContain('`Removed`');
+    expect(result.summary).toContain('Modified (1)');
+    expect(result.summary).toContain('`Existing`');
+    expect(result.summary).toContain('Renamed (1)');
+    expect(result.summary).toContain('`OldName` → `NewName`');
+    expect(result.diff).toContain('-    value: string;');
+    expect(result.diff).toContain('+    value: number;');
+  });
+
+  it('treats a missing baseline as an empty API report', () => {
+    const head = `// @public
+export interface Added {
+    value: string;
+}
+`;
+
+    const result = run(undefined, head);
+
+    expect(result.changed).toBe('true');
+    expect(result.summary).toContain('Added (1)');
+    expect(result.diff).toContain('+// @public');
+  });
+
+  it('fails when report paths are omitted', () => {
+    const result = spawnSync('node', [SCRIPT], { encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Usage: api-report-summary.js');
+  });
+});

--- a/scripts/__tests__/api-report-summary.test.ts
+++ b/scripts/__tests__/api-report-summary.test.ts
@@ -17,6 +17,7 @@ type Result = {
 function run(base: string | undefined, head: string): Result {
   const directory = mkdtempSync(join(tmpdir(), 'api-report-summary-'));
   const basePath = join(directory, 'base.md');
+  const missingBasePath = join(directory, 'missing-base.md');
   const headPath = join(directory, 'head.md');
   const outputPath = join(directory, 'output');
 
@@ -26,7 +27,12 @@ function run(base: string | undefined, head: string): Result {
 
     const result = spawnSync(
       'node',
-      [SCRIPT, base === undefined ? basePath : basePath, headPath, outputPath],
+      [
+        SCRIPT,
+        base === undefined ? missingBasePath : basePath,
+        headPath,
+        outputPath,
+      ],
       { encoding: 'utf8' }
     );
 
@@ -102,6 +108,86 @@ export interface NewName {
     expect(result.summary).toContain('`OldName` → `NewName`');
     expect(result.diff).toContain('-    value: string;');
     expect(result.diff).toContain('+    value: number;');
+  });
+
+  it('identifies class, interface, method, parameter, and enum-case changes', () => {
+    const base = `// @public
+export class ExistingClass {
+    keep(kept: string, removedParameter: number): void;
+    removedMethod(): void;
+}
+
+// @public
+export interface ExistingInterface {
+    existingMethod(): void;
+}
+
+// @public
+export enum ExistingEnum {
+    Existing,
+    RemovedCase
+}
+
+// @public
+export class RemovedClass {
+    removed: string;
+}
+
+// @public
+export interface RemovedInterface {
+    removed: string;
+}
+`;
+    const head = `// @public
+export class ExistingClass {
+    keep(kept: string, addedParameter: boolean): void;
+    addedMethod(): void;
+}
+
+// @public
+export interface ExistingInterface {
+    existingMethod(): void;
+    addedMethod(): void;
+}
+
+// @public
+export enum ExistingEnum {
+    Existing,
+    AddedCase
+}
+
+// @public
+export class AddedClass {
+    added: string;
+}
+
+// @public
+export interface AddedInterface {
+    added: string;
+}
+`;
+
+    const result = run(base, head);
+
+    expect(result.summary).toContain('### 🆕 Added (2)');
+    expect(result.summary).toContain('`AddedClass`');
+    expect(result.summary).toContain('`AddedInterface`');
+    expect(result.summary).toContain('### ❌ Removed (2)');
+    expect(result.summary).toContain('`RemovedClass`');
+    expect(result.summary).toContain('`RemovedInterface`');
+    expect(result.summary).toContain('### 🆕 Methods added (2)');
+    expect(result.summary).toContain('`ExistingClass.addedMethod`');
+    expect(result.summary).toContain('`ExistingInterface.addedMethod`');
+    expect(result.summary).toContain('### ❌ Methods removed (1)');
+    expect(result.summary).toContain('`ExistingClass.removedMethod`');
+    expect(result.summary).toContain('### 🆕 Parameters added (1)');
+    expect(result.summary).toContain('`ExistingClass.keep(addedParameter)`');
+    expect(result.summary).toContain('### ❌ Parameters removed (1)');
+    expect(result.summary).toContain('`ExistingClass.keep(removedParameter)`');
+    expect(result.summary).toContain('### 🆕 Enum cases added (1)');
+    expect(result.summary).toContain('`ExistingEnum.AddedCase`');
+    expect(result.summary).toContain('### ❌ Enum cases removed (1)');
+    expect(result.summary).toContain('`ExistingEnum.RemovedCase`');
   });
 
   it('treats a missing baseline as an empty API report', () => {

--- a/scripts/__tests__/post-api-report-comment.test.ts
+++ b/scripts/__tests__/post-api-report-comment.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Adyen N.V.
+
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const postApiReportComment = require('../post-api-report-comment');
+
+const environmentKeys = ['REPORT'] as const;
+const originalEnvironment = Object.fromEntries(
+  environmentKeys.map((key) => [key, process.env[key]])
+);
+
+function setReportFile(summary: string, diff: string, changed: boolean) {
+  const directory = mkdtempSync(join(tmpdir(), 'api-report-comment-'));
+  const reportPath = join(directory, 'report.json');
+
+  writeFileSync(reportPath, JSON.stringify({ changed, diff, summary }));
+  process.env.REPORT = reportPath;
+
+  return () => rmSync(directory, { force: true, recursive: true });
+}
+
+afterEach(() => {
+  for (const key of environmentKeys) {
+    const value = originalEnvironment[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('post-api-report-comment.js', () => {
+  it('creates a comment with the API summary and diff', async () => {
+    const summary = '## 🟡 Public API changes detected\n\n## Summary';
+    const removeFiles = setReportFile(summary, '@@ -1 +1 @@', true);
+    const createComment = jest.fn().mockResolvedValue(undefined);
+    const github = {
+      paginate: jest.fn().mockResolvedValue([]),
+      rest: {
+        issues: {
+          createComment,
+          listComments: jest.fn(),
+          updateComment: jest.fn(),
+        },
+      },
+    };
+
+    try {
+      await postApiReportComment({
+        github,
+        context: {
+          issue: { number: 42 },
+          repo: { owner: 'Adyen', repo: 'sdk' },
+        },
+      });
+
+      expect(createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('```diff\n@@ -1 +1 @@\n```'),
+          issue_number: 42,
+          owner: 'Adyen',
+          repo: 'sdk',
+        })
+      );
+      expect(
+        createComment.mock.calls[0][0].body.match(
+          /## 🟡 Public API changes detected/g
+        )
+      ).toHaveLength(1);
+    } finally {
+      removeFiles();
+    }
+  });
+
+  it('updates the existing bot comment for an unchanged API', async () => {
+    const removeFiles = setReportFile('## Summary', '', false);
+    const updateComment = jest.fn().mockResolvedValue(undefined);
+    const github = {
+      paginate: jest
+        .fn()
+        .mockResolvedValue([
+          { body: '<!-- public-api-diff -->', id: 7, user: { type: 'Bot' } },
+        ]),
+      rest: {
+        issues: {
+          createComment: jest.fn(),
+          listComments: jest.fn(),
+          updateComment,
+        },
+      },
+    };
+
+    try {
+      await postApiReportComment({
+        github,
+        context: {
+          issue: { number: 42 },
+          repo: { owner: 'Adyen', repo: 'sdk' },
+        },
+      });
+
+      expect(updateComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.not.stringContaining('```diff'),
+          comment_id: 7,
+        })
+      );
+      expect(github.rest.issues.createComment).not.toHaveBeenCalled();
+    } finally {
+      removeFiles();
+    }
+  });
+
+  it('rejects an invalid report payload', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'api-report-comment-'));
+    const reportPath = join(directory, 'report.json');
+    writeFileSync(reportPath, JSON.stringify({ changed: 'false' }));
+    process.env.REPORT = reportPath;
+
+    try {
+      await expect(
+        postApiReportComment({ github: {}, context: {} })
+      ).rejects.toThrow('Invalid API report payload');
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+});

--- a/scripts/api-report-summary.js
+++ b/scripts/api-report-summary.js
@@ -28,7 +28,7 @@ function normalizeBody(body, name) {
 
 function splitBlocks(text) {
   const blocks = [];
-  const lines = text.split('\n');
+  const lines = text.split(/\r?\n/);
   let i = 0;
 
   while (i < lines.length) {
@@ -184,13 +184,19 @@ function collectMemberChanges(base, head, changes) {
     changes.addedParameters,
     baseMembers.parameters,
     headMembers.parameters,
-    (parameter) => `${declarationName}.${parameter}`
+    (parameter) =>
+      parameter.startsWith('(')
+        ? `${declarationName}${parameter}`
+        : `${declarationName}.${parameter}`
   );
   addSetDifference(
     changes.removedParameters,
     headMembers.parameters,
     baseMembers.parameters,
-    (parameter) => `${declarationName}.${parameter}`
+    (parameter) =>
+      parameter.startsWith('(')
+        ? `${declarationName}${parameter}`
+        : `${declarationName}.${parameter}`
   );
   addSetDifference(
     changes.addedEnumCases,

--- a/scripts/api-report-summary.js
+++ b/scripts/api-report-summary.js
@@ -7,6 +7,10 @@ const ts = require('typescript');
 
 const REPORT_DIR = '/tmp/public-api-report';
 
+/*
+ * Usage: node api-report-summary.js <base-report> <head-report> [out-dir]
+ * Writes summary.md, diff.txt, and changed.txt to out-dir.
+ */
 function readFile(path) {
   try {
     return fs.readFileSync(path, 'utf8');

--- a/scripts/api-report-summary.js
+++ b/scripts/api-report-summary.js
@@ -3,6 +3,7 @@
 
 const fs = require('fs');
 const { spawnSync } = require('child_process');
+const ts = require('typescript');
 
 const REPORT_DIR = '/tmp/public-api-report';
 
@@ -106,6 +107,105 @@ function readReport(path) {
   return declarations;
 }
 
+function addSetDifference(target, base, head, format) {
+  for (const value of head) {
+    if (!base.has(value)) target.push(format(value));
+  }
+}
+
+function declarationMembers(body) {
+  const sourceFile = ts.createSourceFile(
+    'api-report.d.ts',
+    body,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const declaration = sourceFile.statements.find(
+    (statement) =>
+      ts.isClassDeclaration(statement) ||
+      ts.isEnumDeclaration(statement) ||
+      ts.isFunctionDeclaration(statement) ||
+      ts.isInterfaceDeclaration(statement)
+  );
+  const methods = new Map();
+  const parameters = new Set();
+  const enumCases = new Set();
+
+  if (!declaration) return { enumCases, methods, parameters };
+
+  const addParameters = (methodName, methodParameters) => {
+    const names = new Set(
+      methodParameters.map((parameter) => parameter.name.getText(sourceFile))
+    );
+    methods.set(methodName, names);
+    for (const parameterName of names) {
+      parameters.add(`${methodName}(${parameterName})`);
+    }
+  };
+
+  if (
+    ts.isClassDeclaration(declaration) ||
+    ts.isInterfaceDeclaration(declaration)
+  ) {
+    for (const member of declaration.members) {
+      if (ts.isMethodDeclaration(member) || ts.isMethodSignature(member)) {
+        addParameters(member.name.getText(sourceFile), member.parameters);
+      }
+    }
+  } else if (ts.isFunctionDeclaration(declaration)) {
+    addParameters('', declaration.parameters);
+  } else if (ts.isEnumDeclaration(declaration)) {
+    for (const member of declaration.members) {
+      enumCases.add(member.name.getText(sourceFile));
+    }
+  }
+
+  return { enumCases, methods, parameters };
+}
+
+function collectMemberChanges(base, head, changes) {
+  const baseMembers = declarationMembers(base.body);
+  const headMembers = declarationMembers(head.body);
+  const declarationName = head.name;
+
+  addSetDifference(
+    changes.addedMethods,
+    new Set(baseMembers.methods.keys()),
+    new Set(headMembers.methods.keys()),
+    (methodName) => `${declarationName}.${methodName}`
+  );
+  addSetDifference(
+    changes.removedMethods,
+    new Set(headMembers.methods.keys()),
+    new Set(baseMembers.methods.keys()),
+    (methodName) => `${declarationName}.${methodName}`
+  );
+  addSetDifference(
+    changes.addedParameters,
+    baseMembers.parameters,
+    headMembers.parameters,
+    (parameter) => `${declarationName}.${parameter}`
+  );
+  addSetDifference(
+    changes.removedParameters,
+    headMembers.parameters,
+    baseMembers.parameters,
+    (parameter) => `${declarationName}.${parameter}`
+  );
+  addSetDifference(
+    changes.addedEnumCases,
+    baseMembers.enumCases,
+    headMembers.enumCases,
+    (enumCase) => `${declarationName}.${enumCase}`
+  );
+  addSetDifference(
+    changes.removedEnumCases,
+    headMembers.enumCases,
+    baseMembers.enumCases,
+    (enumCase) => `${declarationName}.${enumCase}`
+  );
+}
+
 function classify(base, head) {
   const baseMap = new Map(base.map((d) => [d.name, d]));
   const headMap = new Map(head.map((d) => [d.name, d]));
@@ -114,6 +214,14 @@ function classify(base, head) {
   const removed = [];
   const modified = [];
   const renamed = [];
+  const memberChanges = {
+    addedEnumCases: [],
+    addedMethods: [],
+    addedParameters: [],
+    removedEnumCases: [],
+    removedMethods: [],
+    removedParameters: [],
+  };
   const usedAdded = new Set();
   const usedRemoved = new Set();
 
@@ -145,7 +253,10 @@ function classify(base, head) {
     if (b) {
       const fullB = `${b.releaseTag}\n${b.body}`;
       const fullH = `${h.releaseTag}\n${h.body}`;
-      if (fullB !== fullH) modified.push({ base: b, head: h });
+      if (fullB !== fullH) {
+        modified.push({ base: b, head: h });
+        collectMemberChanges(b, h, memberChanges);
+      }
     }
   }
 
@@ -156,6 +267,12 @@ function classify(base, head) {
     removed: finalRemoved.sort(byName),
     modified: modified.sort((a, b) => a.head.name.localeCompare(b.head.name)),
     renamed: renamed.sort((a, b) => a.old.name.localeCompare(b.old.name)),
+    ...Object.fromEntries(
+      Object.entries(memberChanges).map(([key, value]) => [
+        key,
+        value.sort((a, b) => a.localeCompare(b)),
+      ])
+    ),
   };
 }
 
@@ -173,12 +290,25 @@ function renderCategory(title, items, transform) {
   return `### ${title} (${items.length})\n\n${list}`;
 }
 
+function renderNamesCategory(title, names) {
+  if (names.length === 0) return '';
+  return `### ${title} (${names.length})\n\n${names
+    .map((name) => `- \`${name}\``)
+    .join('\n')}`;
+}
+
 function renderSummary(changes) {
   const changed =
     changes.added.length +
       changes.removed.length +
       changes.modified.length +
-      changes.renamed.length >
+      changes.renamed.length +
+      changes.addedMethods.length +
+      changes.removedMethods.length +
+      changes.addedParameters.length +
+      changes.removedParameters.length +
+      changes.addedEnumCases.length +
+      changes.removedEnumCases.length >
     0;
 
   if (!changed) {
@@ -203,6 +333,12 @@ function renderSummary(changes) {
       changes.modified.map((m) => m.head)
     ),
     renderCategory('🏷️ Renamed', renamedItems, (d) => d.oldName),
+    renderNamesCategory('🆕 Methods added', changes.addedMethods),
+    renderNamesCategory('❌ Methods removed', changes.removedMethods),
+    renderNamesCategory('🆕 Parameters added', changes.addedParameters),
+    renderNamesCategory('❌ Parameters removed', changes.removedParameters),
+    renderNamesCategory('🆕 Enum cases added', changes.addedEnumCases),
+    renderNamesCategory('❌ Enum cases removed', changes.removedEnumCases),
   ];
 
   return { changed: true, markdown: parts.filter(Boolean).join('\n\n') };

--- a/scripts/api-report-summary.js
+++ b/scripts/api-report-summary.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Adyen N.V.
+
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+const REPORT_DIR = '/tmp/public-api-report';
+
+function readFile(path) {
+  try {
+    return fs.readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeBody(body, name) {
+  return body.replace(
+    new RegExp(`\\b${escapeRegExp(name)}\\b`, 'g'),
+    '__NAME__'
+  );
+}
+
+function splitBlocks(text) {
+  const blocks = [];
+  const lines = text.split('\n');
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i].trimStart();
+    if (line.startsWith('// @public')) {
+      const releaseTag = line;
+      i += 1;
+      const start = i;
+      while (i < lines.length) {
+        const t = lines[i].trimStart();
+        if (t.startsWith('// @public')) break;
+        if (t === '```') break;
+        i += 1;
+      }
+      const bodyLines = lines.slice(start, i);
+      while (
+        bodyLines.length > 0 &&
+        bodyLines[bodyLines.length - 1].trim() === ''
+      ) {
+        bodyLines.pop();
+      }
+      blocks.push({ releaseTag, bodyLines });
+    } else {
+      i += 1;
+    }
+  }
+
+  return blocks;
+}
+
+function parsePublicNames(releaseTag, bodyLines) {
+  const body = bodyLines.join('\n');
+  const results = [];
+  const aliases = [];
+
+  for (const match of body.matchAll(/export\s*\{\s*([^}\n]+)\s*\}/g)) {
+    for (const pair of match[1].split(',')) {
+      const trimmed = pair.trim();
+      const m = trimmed.match(/^(\w+)\s+as\s+(\w+)$/);
+      if (m) aliases.push({ local: m[1], public: m[2] });
+    }
+  }
+
+  const directMatch = body.match(
+    /^export\s+(interface|type|const|class|function|enum)\s+(\w+)/m
+  );
+
+  if (aliases.length > 0) {
+    for (const { local, public: publicName } of aliases) {
+      const localKindMatch = body.match(
+        new RegExp(
+          `^(interface|type|const|class|function|enum)\\s+${local}\\b`,
+          'm'
+        )
+      );
+      const kind = localKindMatch ? localKindMatch[1] : 'declaration';
+      results.push({ releaseTag, kind, name: publicName, body });
+    }
+  } else if (directMatch) {
+    results.push({
+      releaseTag,
+      kind: directMatch[1],
+      name: directMatch[2],
+      body,
+    });
+  }
+
+  return results;
+}
+
+function readReport(path) {
+  const declarations = [];
+  for (const { releaseTag, bodyLines } of splitBlocks(readFile(path))) {
+    declarations.push(...parsePublicNames(releaseTag, bodyLines));
+  }
+  return declarations;
+}
+
+function classify(base, head) {
+  const baseMap = new Map(base.map((d) => [d.name, d]));
+  const headMap = new Map(head.map((d) => [d.name, d]));
+
+  const added = [];
+  const removed = [];
+  const modified = [];
+  const renamed = [];
+  const usedAdded = new Set();
+  const usedRemoved = new Set();
+
+  for (const [name, h] of headMap) {
+    if (!baseMap.has(name)) added.push(h);
+  }
+  for (const [name, b] of baseMap) {
+    if (!headMap.has(name)) removed.push(b);
+  }
+
+  for (const r of removed) {
+    for (const a of added) {
+      if (usedAdded.has(a.name)) continue;
+      if (r.releaseTag !== a.releaseTag) continue;
+      if (normalizeBody(r.body, r.name) === normalizeBody(a.body, a.name)) {
+        renamed.push({ old: r, new: a });
+        usedAdded.add(a.name);
+        usedRemoved.add(r.name);
+        break;
+      }
+    }
+  }
+
+  const finalAdded = added.filter((a) => !usedAdded.has(a.name));
+  const finalRemoved = removed.filter((r) => !usedRemoved.has(r.name));
+
+  for (const [name, h] of headMap) {
+    const b = baseMap.get(name);
+    if (b) {
+      const fullB = `${b.releaseTag}\n${b.body}`;
+      const fullH = `${h.releaseTag}\n${h.body}`;
+      if (fullB !== fullH) modified.push({ base: b, head: h });
+    }
+  }
+
+  const byName = (a, b) => a.name.localeCompare(b.name);
+
+  return {
+    added: finalAdded.sort(byName),
+    removed: finalRemoved.sort(byName),
+    modified: modified.sort((a, b) => a.head.name.localeCompare(b.head.name)),
+    renamed: renamed.sort((a, b) => a.old.name.localeCompare(b.old.name)),
+  };
+}
+
+function renderItem(item, oldName) {
+  return oldName
+    ? `- \`${oldName}\` → \`${item.name}\` — ${item.kind}`
+    : `- \`${item.name}\` — ${item.kind}`;
+}
+
+function renderCategory(title, items, transform) {
+  if (items.length === 0) return '';
+  const list = items
+    .map((d) => renderItem(d, transform ? transform(d) : undefined))
+    .join('\n');
+  return `### ${title} (${items.length})\n\n${list}`;
+}
+
+function renderSummary(changes) {
+  const changed =
+    changes.added.length +
+      changes.removed.length +
+      changes.modified.length +
+      changes.renamed.length >
+    0;
+
+  if (!changed) {
+    return {
+      changed: false,
+      markdown:
+        '## 🟢 Public API is unchanged\n\nNo public declarations were added, removed, or modified.',
+    };
+  }
+
+  const renamedItems = changes.renamed.map((r) => ({
+    ...r.new,
+    oldName: r.old.name,
+  }));
+
+  const parts = [
+    '## 🟡 Public API changes detected',
+    renderCategory('🆕 Added', changes.added),
+    renderCategory('❌ Removed', changes.removed),
+    renderCategory(
+      '✏️ Modified',
+      changes.modified.map((m) => m.head)
+    ),
+    renderCategory('🏷️ Renamed', renamedItems, (d) => d.oldName),
+  ];
+
+  return { changed: true, markdown: parts.filter(Boolean).join('\n\n') };
+}
+
+function produceDiff(basePath, headPath, outPath) {
+  const result = spawnSync('diff', ['-u', basePath, headPath], {
+    encoding: 'utf8',
+  });
+  if (result.status === 0) {
+    fs.writeFileSync(outPath, '');
+  } else if (result.status === 1) {
+    fs.writeFileSync(outPath, result.stdout);
+  } else {
+    fs.writeFileSync(
+      outPath,
+      `diff failed (status ${result.status}):\n${result.stderr || ''}`
+    );
+  }
+}
+
+function main() {
+  const [basePath, headPath, outDir = REPORT_DIR] = process.argv.slice(2);
+
+  if (!basePath || !headPath) {
+    console.error(
+      'Usage: api-report-summary.js <base-report> <head-report> [out-dir]'
+    );
+    process.exit(1);
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+
+  let baseReportPath = basePath;
+  if (!fs.existsSync(baseReportPath)) {
+    baseReportPath = `${outDir}/base-api-report.md`;
+    fs.writeFileSync(baseReportPath, '');
+  }
+
+  const base = readReport(baseReportPath);
+  const head = readReport(headPath);
+  const changes = classify(base, head);
+  const { changed, markdown } = renderSummary(changes);
+
+  produceDiff(baseReportPath, headPath, `${outDir}/diff.txt`);
+  fs.writeFileSync(`${outDir}/summary.md`, markdown);
+  fs.writeFileSync(`${outDir}/changed.txt`, changed ? 'true' : 'false');
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n\n`);
+  }
+}
+
+main();

--- a/scripts/api-report-summary.js
+++ b/scripts/api-report-summary.js
@@ -9,7 +9,7 @@ const REPORT_DIR = '/tmp/public-api-report';
 
 /*
  * Usage: node api-report-summary.js <base-report> <head-report> [out-dir]
- * Writes summary.md, diff.txt, and changed.txt to out-dir.
+ * Writes report.json to out-dir.
  */
 function readFile(path) {
   try {
@@ -354,20 +354,17 @@ function renderSummary(changes) {
   return { changed: true, markdown: parts.filter(Boolean).join('\n\n') };
 }
 
-function produceDiff(basePath, headPath, outPath) {
+function produceDiff(basePath, headPath) {
   const result = spawnSync('diff', ['-u', basePath, headPath], {
     encoding: 'utf8',
   });
   if (result.status === 0) {
-    fs.writeFileSync(outPath, '');
+    return '';
   } else if (result.status === 1) {
-    fs.writeFileSync(outPath, result.stdout);
-  } else {
-    fs.writeFileSync(
-      outPath,
-      `diff failed (status ${result.status}):\n${result.stderr || ''}`
-    );
+    return result.stdout;
   }
+
+  return `diff failed (status ${result.status}):\n${result.stderr || ''}`;
 }
 
 function main() {
@@ -392,13 +389,17 @@ function main() {
   const head = readReport(headPath);
   const changes = classify(base, head);
   const { changed, markdown } = renderSummary(changes);
-
-  produceDiff(baseReportPath, headPath, `${outDir}/diff.txt`);
-  fs.writeFileSync(`${outDir}/summary.md`, markdown);
-  fs.writeFileSync(`${outDir}/changed.txt`, changed ? 'true' : 'false');
+  const diff = produceDiff(baseReportPath, headPath);
+  fs.writeFileSync(
+    `${outDir}/report.json`,
+    JSON.stringify({ changed, diff, summary: markdown })
+  );
 
   if (process.env.GITHUB_STEP_SUMMARY) {
     fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n\n`);
+  }
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `changed=${changed}\n`);
   }
 }
 

--- a/scripts/post-api-report-comment.js
+++ b/scripts/post-api-report-comment.js
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Adyen N.V.
+
+const fs = require('fs');
+
+const MARKER = '<!-- public-api-diff -->';
+
+function createCommentBody(summary, diff, changed) {
+  const parts = [MARKER, summary];
+
+  if (changed && diff.trim()) {
+    const displayDiff =
+      diff.length > 60000 ? diff.slice(0, 60000) + '\n\n... (truncated)' : diff;
+    parts.push(
+      '',
+      '<details>',
+      '<summary>API snapshot diff</summary>',
+      '',
+      '```diff',
+      displayDiff,
+      '```',
+      '</details>'
+    );
+  }
+
+  parts.push(
+    '',
+    changed
+      ? 'Please review the changes and update `etc/api/adyen-react-native.api.md` if this public API change is intentional.'
+      : 'No action needed — the public API snapshot matches the target branch.'
+  );
+
+  return parts.join('\n');
+}
+
+function readReport(path) {
+  const report = JSON.parse(fs.readFileSync(path, 'utf8'));
+  if (
+    typeof report.changed !== 'boolean' ||
+    typeof report.diff !== 'string' ||
+    typeof report.summary !== 'string'
+  ) {
+    throw new Error('Invalid API report payload');
+  }
+
+  return report;
+}
+
+async function postApiReportComment({ github, context }) {
+  const { changed, diff, summary } = readReport(process.env.REPORT);
+  const body = createCommentBody(summary, diff, changed);
+  const { owner, repo } = context.repo;
+  const issue_number = context.issue.number;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number,
+    per_page: 100,
+  });
+  const existingComment = comments.find(
+    (comment) => comment.user.type === 'Bot' && comment.body.includes(MARKER)
+  );
+
+  if (existingComment) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existingComment.id,
+      body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number,
+      body,
+    });
+  }
+}
+
+module.exports = postApiReportComment;


### PR DESCRIPTION
## Summary
- Generate a categorized public API report summary for pull requests.
- Detect declaration, method, parameter, and enum-case changes, with automated coverage.
- Publish one validated JSON report artifact for the comment publisher.
- Skip PR comment writes for fork branches, where the GitHub token is read-only.

## Using `api-report-summary.js`

```sh
node scripts/api-report-summary.js <base-report> <head-report> [out-dir]
```

`out-dir` defaults to `/tmp/public-api-report`. The script writes `report.json`, containing `changed`, `summary`, and `diff`. When run in GitHub Actions, it also writes `changed` to `GITHUB_OUTPUT`.

## Ticket
COSDK-1382

## Testing
- yarn test --runInBand
- yarn lint
- yarn typecheck
- git diff --check