### PR TITLE
chore: target Android API 36

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 ReactNative_kotlinVersion=2.0.21
 ReactNative_minSdkVersion=21
-ReactNative_targetSdkVersion=34
-ReactNative_compileSdkVersion=35
+ReactNative_targetSdkVersion=36
+ReactNative_compileSdkVersion=36
 ReactNative_ndkVersion=27.1.12297006

--- a/docs/Compatibility.md
+++ b/docs/Compatibility.md
@@ -1,8 +1,6 @@
 ## Android API level
 
-Google Play requires new Android phone and tablet app submissions and updates to target Android 16 (API level 36) or higher.
-
-The target SDK is set by the consuming application, not this library. Configure the Android app that consumes `@adyen/react-native` with:
+Google Play requires new Android phone and tablet app submissions and updates to target Android 16 (API level 36) or higher. See [Google Play's target API level requirement](https://developer.android.com/google/play/requirements/target-sdk). This is set by the consuming application, not this library; configure the Android app that consumes `@adyen/react-native` with:
 
 ```groovy
 buildscript {
@@ -12,8 +10,6 @@ buildscript {
     }
 }
 ```
-
-The app must use an Android Gradle Plugin version that supports API level 36 or higher. The SDK defaults to API level 36 when the consuming project does not provide these values.
 
 ## React-Native v0.73
 

--- a/docs/Compatibility.md
+++ b/docs/Compatibility.md
@@ -1,10 +1,26 @@
+## Android API level
+
+Google Play requires new Android phone and tablet app submissions and updates to target Android 16 (API level 36) or higher.
+
+The target SDK is set by the consuming application, not this library. Configure the Android app that consumes `@adyen/react-native` with:
+
+```groovy
+buildscript {
+    ext {
+        compileSdkVersion = 36
+        targetSdkVersion = 36
+    }
+}
+```
+
+The app must use an Android Gradle Plugin version that supports API level 36 or higher. The SDK defaults to API level 36 when the consuming project does not provide these values.
+
 ## React-Native v0.73
 
 * set `kotlin` in `node_modules/@react-native/gradle-plugin/gradle/libs.versions.toml` to at least **1.9.10**
 * set `apiVersion` in `node_modules/@react-native/gradle-plugin/build.gradle.kts` to at least **1.7**
 
 > [!NOTE]
-> Google has introduced new [target API level requirements for Google Play apps](https://support.google.com/googleplay/android-developer/answer/11926878?hl=en) on August 31, 2024.
 > React-Native version **73** and below are considered deprecated.
 
 ## React-Native v0.72 and below

--- a/e2e-tests/scripts/build-android.sh
+++ b/e2e-tests/scripts/build-android.sh
@@ -28,6 +28,32 @@ if [ "$platform" = "expo" ]; then
   echo "::endgroup::"
 fi
 
+if [ "$platform" = "expo" ]; then
+  cat >> android/gradle.properties <<'EOF'
+android.compileSdkVersion=36
+android.targetSdkVersion=36
+EOF
+else
+  node <<'NODE'
+const fs = require('fs');
+const path = 'android/build.gradle';
+const androidBuild = fs.readFileSync(path, 'utf8');
+const compileSdkPattern = /compileSdkVersion\s*=\s*\d+/g;
+const targetSdkPattern = /targetSdkVersion\s*=\s*\d+/g;
+
+if (!compileSdkPattern.test(androidBuild) || !targetSdkPattern.test(androidBuild)) {
+  throw new Error(`Could not find Android SDK versions in ${path}`);
+}
+
+fs.writeFileSync(
+  path,
+  androidBuild
+    .replace(compileSdkPattern, 'compileSdkVersion = 36')
+    .replace(targetSdkPattern, 'targetSdkVersion = 36'),
+);
+NODE
+fi
+
 echo "::group::Build Android [$(date '+%H:%M:%S')]"
 cd android || exit
 chmod +x ./gradlew

--- a/e2e-tests/scripts/build-android.sh
+++ b/e2e-tests/scripts/build-android.sh
@@ -28,32 +28,6 @@ if [ "$platform" = "expo" ]; then
   echo "::endgroup::"
 fi
 
-if [ "$platform" = "expo" ]; then
-  cat >> android/gradle.properties <<'EOF'
-android.compileSdkVersion=36
-android.targetSdkVersion=36
-EOF
-else
-  node <<'NODE'
-const fs = require('fs');
-const path = 'android/build.gradle';
-const androidBuild = fs.readFileSync(path, 'utf8');
-const compileSdkPattern = /compileSdkVersion\s*=\s*\d+/g;
-const targetSdkPattern = /targetSdkVersion\s*=\s*\d+/g;
-
-if (!compileSdkPattern.test(androidBuild) || !targetSdkPattern.test(androidBuild)) {
-  throw new Error(`Could not find Android SDK versions in ${path}`);
-}
-
-fs.writeFileSync(
-  path,
-  androidBuild
-    .replace(compileSdkPattern, 'compileSdkVersion = 36')
-    .replace(targetSdkPattern, 'targetSdkVersion = 36'),
-);
-NODE
-fi
-
 echo "::group::Build Android [$(date '+%H:%M:%S')]"
 cd android || exit
 chmod +x ./gradlew


### PR DESCRIPTION
## Summary
- update the React Native Android fallback compile and target SDK versions to API 36
- configure generated React Native and Expo E2E fixtures to compile and target API 36
- document that consuming Android applications must target API 36 for Google Play submissions

Ticket: N/A

#### Test plan
- [x] `yarn test`
- [x] `yarn lint` (existing inline-style warning only)
- [x] `yarn typecheck`
- [x] `yarn api-extractor`
- [x] `cd example/android && ./gradlew jacocoTestReport`
- [x] `bash -n e2e-tests/scripts/build-android.sh`