### PR TITLE
fix: ignore API report comments

### DIFF
--- a/scripts/__tests__/api-report-summary.test.ts
+++ b/scripts/__tests__/api-report-summary.test.ts
@@ -86,6 +86,26 @@ export interface Existing {
     expect(result.summary).toContain('Public API is unchanged');
   });
 
+  it('ignores API Extractor comments when comparing declarations', () => {
+    const base = `// @public
+export interface ApplePayModule {
+    // Warning: (ae-forgotten-export) The symbol "ApplePayAuthorizationResult" needs to be exported
+    //
+    provideAuthorizationResult(result: ApplePayAuthorizationResult): void;
+}
+`;
+    const head = `// @public
+export interface ApplePayModule {
+    provideAuthorizationResult(result: ApplePayAuthorizationResult): void;
+}
+`;
+
+    const result = run(base, head);
+
+    expect(result.changed).toBe(false);
+    expect(result.summary).toContain('Public API is unchanged');
+  });
+
   it('writes the changed state to GITHUB_OUTPUT', () => {
     const report = `// @public
 export interface Existing {

--- a/scripts/__tests__/api-report-summary.test.ts
+++ b/scripts/__tests__/api-report-summary.test.ts
@@ -89,7 +89,7 @@ export interface Existing {
   it('ignores API Extractor comments when comparing declarations', () => {
     const base = `// @public
 export interface ApplePayModule {
-    // Warning: (ae-forgotten-export) The symbol "ApplePayAuthorizationResult" needs to be exported
+    // Warning: (generated-warning) The declaration needs to be updated
     //
     provideAuthorizationResult(result: ApplePayAuthorizationResult): void;
 }

--- a/scripts/__tests__/api-report-summary.test.ts
+++ b/scripts/__tests__/api-report-summary.test.ts
@@ -106,6 +106,25 @@ export interface ApplePayModule {
     expect(result.summary).toContain('Public API is unchanged');
   });
 
+  it('retains non-generated comments when comparing declarations', () => {
+    const base = `// @public
+export interface ApplePayModule {
+    // This comment is part of the declaration contract.
+    provideAuthorizationResult(result: ApplePayAuthorizationResult): void;
+}
+`;
+    const head = `// @public
+export interface ApplePayModule {
+    provideAuthorizationResult(result: ApplePayAuthorizationResult): void;
+}
+`;
+
+    const result = run(base, head);
+
+    expect(result.changed).toBe(true);
+    expect(result.summary).toContain('Modified (1)');
+  });
+
   it('writes the changed state to GITHUB_OUTPUT', () => {
     const report = `// @public
 export interface Existing {

--- a/scripts/api-report-summary.js
+++ b/scripts/api-report-summary.js
@@ -34,7 +34,7 @@ function isNonSemanticApiExtractorComment(line) {
   return (
     line === '//' ||
     line === '// (undocumented)' ||
-    line.startsWith('// Warning: (ae-')
+    line.startsWith('// Warning: (')
   );
 }
 

--- a/scripts/api-report-summary.js
+++ b/scripts/api-report-summary.js
@@ -24,10 +24,20 @@ function escapeRegExp(string) {
 }
 
 function normalizeBody(body, name) {
-  return body.replace(
+  return normalizeDeclarationBody(body).replace(
     new RegExp(`\\b${escapeRegExp(name)}\\b`, 'g'),
     '__NAME__'
   );
+}
+
+function normalizeDeclarationBody(body) {
+  return body
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trim();
+      return trimmed !== '' && !trimmed.startsWith('//');
+    })
+    .join('\n');
 }
 
 function splitBlocks(text) {
@@ -261,8 +271,8 @@ function classify(base, head) {
   for (const [name, h] of headMap) {
     const b = baseMap.get(name);
     if (b) {
-      const fullB = `${b.releaseTag}\n${b.body}`;
-      const fullH = `${h.releaseTag}\n${h.body}`;
+      const fullB = `${b.releaseTag}\n${normalizeDeclarationBody(b.body)}`;
+      const fullH = `${h.releaseTag}\n${normalizeDeclarationBody(h.body)}`;
       if (fullB !== fullH) {
         modified.push({ base: b, head: h });
         collectMemberChanges(b, h, memberChanges);

--- a/scripts/api-report-summary.js
+++ b/scripts/api-report-summary.js
@@ -30,12 +30,20 @@ function normalizeBody(body, name) {
   );
 }
 
+function isNonSemanticApiExtractorComment(line) {
+  return (
+    line === '//' ||
+    line === '// (undocumented)' ||
+    line.startsWith('// Warning: (ae-')
+  );
+}
+
 function normalizeDeclarationBody(body) {
   return body
     .split('\n')
     .filter((line) => {
       const trimmed = line.trim();
-      return trimmed !== '' && !trimmed.startsWith('//');
+      return trimmed !== '' && !isNonSemanticApiExtractorComment(trimmed);
     })
     .join('\n');
 }


### PR DESCRIPTION
## Summary
- Ignore non-public API Extractor comments when comparing declaration bodies.
- Prevent removed `ae-forgotten-export` warnings from being reported as declaration modifications.
- Add regression coverage for comment-only report changes.

## Ticket
COSDK-1382

## Testing
- yarn test --runInBand
- yarn lint
- yarn typecheck
- git diff --check