### PR TITLE
fix: generate native SDK version from build output

### DIFF
--- a/adyen-react-native.podspec
+++ b/adyen-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.public_header_files = "ios/ADYRedirectComponent.h"
 
   s.dependency "Adyen", '5.25.1'
-  s.resource_bundles = { 'adyen-react-native' => [ 'ios/PrivacyInfo.xcprivacy' ] }
+  s.resource_bundles = { 'adyen-react-native' => [ 'ios/PrivacyInfo.xcprivacy', 'lib/Version.ts' ] }
 
   install_modules_dependencies(s)
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,16 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["ReactNative_" + name]).toInteger()
 }
 
+def versionFile = file("../lib/Version.ts")
+if (!versionFile.exists()) {
+  throw new GradleException("Missing generated version file: ${versionFile}. Run yarn prepare first.")
+}
+def versionMatcher = versionFile.getText("UTF-8") =~ /export const adyenSDKVersion = '([^']+)';/
+if (!versionMatcher.find()) {
+  throw new GradleException("Unable to read the SDK version from ${versionFile}.")
+}
+def checkoutVersion = versionMatcher.group(1)
+
 android {
   namespace "com.adyenreactnativesdk"
 
@@ -34,7 +44,7 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
-    buildConfigField "String", "CHECKOUT_VERSION", "\"{SDK_VERSION}\""
+    buildConfigField "String", "CHECKOUT_VERSION", "\"${checkoutVersion}\""
   }
 
   buildFeatures {

--- a/example/ios/AdyenExampleTests/AnalyticsParserTests.swift
+++ b/example/ios/AdyenExampleTests/AnalyticsParserTests.swift
@@ -66,4 +66,16 @@ class AnalyticsParserTests: XCTestCase {
         // THEN
         XCTAssertFalse(sut.verboseLogsOn)
     }
+
+    func test_sdkVersion_readsGeneratedVersionFile() {
+        XCTAssertFalse(SDKVersion.current.isEmpty)
+    }
+
+    func test_sdkVersion_parsesGeneratedVersionFile() {
+        XCTAssertEqual(SDKVersion.parse("export const adyenSDKVersion = '2.0.0-local.1';\n"), "2.0.0-local.1")
+    }
+
+    func test_sdkVersion_returnsNil_forInvalidGeneratedVersionFile() {
+        XCTAssertNil(SDKVersion.parse("export const sdkVersion = '2.0.0-local.1';\n"))
+    }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2186,7 +2186,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Adyen: bfb5baaf4dded13ec151d336368ac1c26e9a99b4
-  adyen-react-native: 3b3ce2d7486adedd59f2339c3df5df10827f0735
+  adyen-react-native: 7af7d67561bbd6ee270e33b2c3f4a50537b1fb5c
   Adyen3DS2: 45cc4a1f5ca2081e987bfa5bceaa986ba95c289b
   AdyenNetworking: eb6196954566a5b3e0c3c56fa12d8d69948603dc
   FBLazyVector: c00c20551d40126351a6783c47ce75f5b374851b

--- a/ios/Version.swift
+++ b/ios/Version.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal enum SDKVersion {
+internal final class SDKVersion: NSObject {
     private static let fileName = "Version"
     private static let fileExtension = "ts"
     private static let resourceBundleName = "adyen-react-native"
@@ -31,7 +31,7 @@ internal enum SDKVersion {
         return String(source[versionRange])
     }
 
-    private static let bundles = [Bundle.main, Bundle(for: BundleToken.self)]
+    private static let bundles = [Bundle.main, Bundle(for: SDKVersion.self)]
 
     private static func resourceBundle(in bundle: Bundle) -> Bundle? {
         guard let url = bundle.url(forResource: resourceBundleName, withExtension: "bundle") else {
@@ -48,7 +48,5 @@ internal enum SDKVersion {
         return parse(source)
     }
 }
-
-private final class BundleToken {}
 
 internal let adyenSDKVersion = SDKVersion.current

--- a/ios/Version.swift
+++ b/ios/Version.swift
@@ -6,4 +6,49 @@
 
 import Foundation
 
-internal let adyenSDKVersion = "{SDK_VERSION}"
+internal enum SDKVersion {
+    private static let fileName = "Version"
+    private static let fileExtension = "ts"
+    private static let resourceBundleName = "adyen-react-native"
+    private static let pattern = "export const adyenSDKVersion = '([^']+)';"
+
+    static var current: String {
+        bundles.lazy
+            .compactMap { resourceBundle(in: $0) }
+            .compactMap { version(in: $0) }
+            .first ?? ""
+    }
+
+    static func parse(_ source: String) -> String? {
+        guard let expression = try? NSRegularExpression(pattern: pattern) else {
+            return nil
+        }
+        let range = NSRange(source.startIndex..., in: source)
+        guard let match = expression.firstMatch(in: source, range: range),
+              let versionRange = Range(match.range(at: 1), in: source) else {
+            return nil
+        }
+        return String(source[versionRange])
+    }
+
+    private static let bundles = [Bundle.main, Bundle(for: BundleToken.self)]
+
+    private static func resourceBundle(in bundle: Bundle) -> Bundle? {
+        guard let url = bundle.url(forResource: resourceBundleName, withExtension: "bundle") else {
+            return nil
+        }
+        return Bundle(url: url)
+    }
+
+    private static func version(in bundle: Bundle) -> String? {
+        guard let url = bundle.url(forResource: fileName, withExtension: fileExtension),
+              let source = try? String(contentsOf: url) else {
+            return nil
+        }
+        return parse(source)
+    }
+}
+
+private final class BundleToken {}
+
+internal let adyenSDKVersion = SDKVersion.current

--- a/ios/Version.swift
+++ b/ios/Version.swift
@@ -42,7 +42,7 @@ internal enum SDKVersion {
 
     private static func version(in bundle: Bundle) -> String? {
         guard let url = bundle.url(forResource: fileName, withExtension: fileExtension),
-              let source = try? String(contentsOf: url) else {
+              let source = try? String(contentsOf: url, encoding: .utf8) else {
             return nil
         }
         return parse(source)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "clean": "git clean -fxd",
-    "prepare": "./scripts/set-version.sh && bob build",
+    "prepare": "bob build && ./scripts/set-version.sh",
     "start": "rm yarn.lock && yarn && yarn prepare && husky && bash ./scripts/credentials.sh",
     "api-extractor": "api-extractor run",
     "api-extractor:update": "api-extractor run --local"

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,16 +1,7 @@
 #!/bin/bash
 
-VERSION=$(cat package.json | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])")
-echo "Set Version"
-echo $VERSION
+set -euo pipefail
 
-IOS_PATH="ios/Version.swift"
-ANDROID_PATH="android/build.gradle"
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s/{SDK_VERSION}/$VERSION/g" $IOS_PATH
-    sed -i '' "s/{SDK_VERSION}/$VERSION/g" $ANDROID_PATH
-else
-    sed -i -e "s|{SDK_VERSION}|$VERSION|g" $IOS_PATH
-    sed -i -e "s|{SDK_VERSION}|$VERSION|g" $ANDROID_PATH
-fi
+VERSION=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+mkdir -p lib
+printf "export const adyenSDKVersion = '%s';\n" "$VERSION" > lib/Version.ts

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-VERSION=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+VERSION=$(node -p "require('./package.json').version")
 mkdir -p lib
 printf "export const adyenSDKVersion = '%s';\n" "$VERSION" > lib/Version.ts


### PR DESCRIPTION
## Summary
- Generate the React Native SDK version into ignored `lib/Version.ts` after Bob builds.
- Read that generated manifest from Android Gradle and the iOS resource bundle instead of rewriting tracked native source files.
- Cover iOS parsing and resource resolution, and refresh the local podspec checksum.

Ticket: None

## Testing
- [x] yarn prepare
- [x] yarn test
- [x] yarn lint
- [x] yarn typecheck
- [x] yarn api-extractor
- [x] swiftformat ios
- [x] ktlint android -F
- [x] yarn app pod
- [x] Android `jacocoTestReport`
- [x] iOS `xcodebuild test`