### PR TITLE
fix: restore Swift compatibility libraries in E2E

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -93,9 +93,6 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: 'yarn'
 
-      - name: Restore Swift compatibility library resolution
-        run: sudo rm -rf /var/run/com.apple.security.cryptexd/mnt/com.apple.MobileAsset.MetalToolchain*/Metal.xctoolchain
-
       - name: Setup Ruby & Cocoapods
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -93,6 +93,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: 'yarn'
 
+      - name: Restore Swift compatibility library resolution
+        run: sudo rm -rf /var/run/com.apple.security.cryptexd/mnt/com.apple.MobileAsset.MetalToolchain*/Metal.xctoolchain
+
       - name: Setup Ruby & Cocoapods
         uses: ruby/setup-ruby@v1
         with:

--- a/e2e-tests/scripts/setup.sh
+++ b/e2e-tests/scripts/setup.sh
@@ -31,6 +31,11 @@ else
     echo "== Building React-Native $version (CLI $cli_version)"
     npx @react-native-community/cli@"$cli_version" init --directory $path --version "$version" --install-pods false --skip-install "$PROJECT_NAME"
 
+    project_file="$path/ios/$PROJECT_NAME.xcodeproj/project.pbxproj"
+    if grep -q '\$(TOOLCHAIN_DIR)/usr/lib/swift/\$(PLATFORM_NAME)' "$project_file"; then
+        perl -0pi -e 's/\$\(TOOLCHAIN_DIR\)(\/usr\/lib\/swift\/\$\(PLATFORM_NAME\))/\$(DT_TOOLCHAIN_DIR)$1/g' "$project_file"
+    fi
+
     cd $path || exit 1
     
     # Add React Native-specific files


### PR DESCRIPTION
## Summary
- Remove the stale Xcode 26 Metal toolchain mount before iOS E2E setup.
- Restore linker access to Swift compatibility libraries required by the RN 0.76.8 fixture.

Ticket: Not provided

#### Test plan
- [x] Validated the workflow YAML with Ruby.
- [x] Ran git diff --check.
- [ ] Run the RN 0.76.8 iOS E2E job on GitHub Actions.

Generated with [Devin](https://devin.ai)