### PR TITLE
feat: support external CardView submission

### DIFF
--- a/android/src/main/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModule.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModule.kt
@@ -48,6 +48,15 @@ class EmbeddedComponentBusModule(
   }
 
   @ReactMethod
+  fun submit(viewId: String) {
+    val consumer =
+      getConsumer(viewId)
+        ?: return sendError(ModuleException.NoConsumer(viewId))
+
+    consumer.onSubmit()
+  }
+
+  @ReactMethod
   fun handle(
     viewId: String,
     actionMap: ReadableMap?,
@@ -107,7 +116,11 @@ class EmbeddedComponentBusModule(
     success: Boolean,
     message: ReadableMap?,
   ) {
-    Companion.unregister(viewId)
+    if (success) {
+      Companion.unregister(viewId)
+    } else {
+      getConsumer(viewId)?.onStopLoading()
+    }
     if (subscribedViews.isEmpty()) {
       cleanup()
     }

--- a/android/src/main/java/com/adyenreactnativesdk/configuration/CardConfigurationParser.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/configuration/CardConfigurationParser.kt
@@ -25,6 +25,7 @@ class CardConfigurationParser(
   companion object {
     const val TAG = "CardConfigurationParser"
     const val ROOT_KEY = "card"
+    const val SHOW_SUBMIT_BUTTON_KEY = "showSubmitButton"
     const val SHOW_STORE_PAYMENT_FIELD_KEY = "showStorePaymentField"
     const val HOLDER_NAME_REQUIRED_KEY = "holderNameRequired"
     const val HIDE_CVC_STORED_CARD_KEY = "hideCvcStoredCard"
@@ -50,6 +51,7 @@ class CardConfigurationParser(
 
   fun applyConfiguration(builder: CardConfiguration.Builder) {
     supportedCardTypes?.let { builder.supportedCardBrands = it }
+    showSubmitButton?.let { builder.isSubmitButtonVisible = it }
     showStorePaymentField?.let { builder.isStorePaymentFieldVisible = it }
     hideCvcStoredCard?.let { builder.isHideCvcStoredCard = it }
     hideCvc?.let { builder.isHideCvc = it }
@@ -64,6 +66,14 @@ class CardConfigurationParser(
     showStorePaymentField?.let { builder.showStorePaymentField = it }
     holderNameRequired?.let { builder.isHolderNameRequired = it }
   }
+
+  private val showSubmitButton: Boolean?
+    get() =
+      if (config.hasKey(SHOW_SUBMIT_BUTTON_KEY)) {
+        config.getBoolean(SHOW_SUBMIT_BUTTON_KEY)
+      } else {
+        null
+      }
 
   private val showStorePaymentField: Boolean?
     get() =

--- a/android/src/main/java/com/adyenreactnativesdk/react/ComponentContract.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/react/ComponentContract.kt
@@ -5,6 +5,10 @@ import com.adyen.checkout.components.core.LookupAddress
 import com.adyen.checkout.components.core.action.Action
 
 interface ComponentContract {
+  fun onSubmit()
+
+  fun onStopLoading()
+
   fun onAction(action: Action)
 
   fun onAddressLookupResult(result: AddressLookupResult)

--- a/android/src/main/java/com/adyenreactnativesdk/react/card/CardComponentManager.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/react/card/CardComponentManager.kt
@@ -86,6 +86,14 @@ class CardComponentManager(
     component?.setAddressLookupResult(addressLookupResult)
   }
 
+  fun submit() {
+    component?.submit() ?: Log.e("CardComponentManager", "Can not submit, Component is null")
+  }
+
+  fun stopLoading() {
+    component?.setInteractionBlocked(false) ?: Log.e("CardComponentManager", "Can not stop loading, Component is null")
+  }
+
   fun handleAction(action: Action) {
     component?.let {
       AdyenCheckout.setComponent(it)

--- a/android/src/main/java/com/adyenreactnativesdk/react/card/CardComponentManager.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/react/card/CardComponentManager.kt
@@ -87,11 +87,15 @@ class CardComponentManager(
   }
 
   fun submit() {
-    component?.submit() ?: Log.e("CardComponentManager", "Can not submit, Component is null")
+    activity.runOnUiThread {
+      component?.submit() ?: Log.e("CardComponentManager", "Can not submit, Component is null")
+    }
   }
 
   fun stopLoading() {
-    component?.setInteractionBlocked(false) ?: Log.e("CardComponentManager", "Can not stop loading, Component is null")
+    activity.runOnUiThread {
+      component?.setInteractionBlocked(false) ?: Log.e("CardComponentManager", "Can not stop loading, Component is null")
+    }
   }
 
   fun handleAction(action: Action) {

--- a/android/src/main/java/com/adyenreactnativesdk/react/card/CardViewState.kt
+++ b/android/src/main/java/com/adyenreactnativesdk/react/card/CardViewState.kt
@@ -57,6 +57,14 @@ class CardViewState(
     eventDispatcher?.dispatchEvent(event)
   }
 
+  override fun onSubmit() {
+    componentManager?.submit()
+  }
+
+  override fun onStopLoading() {
+    componentManager?.stopLoading()
+  }
+
   override fun onAction(action: Action) {
     componentManager?.handleAction(action)
   }

--- a/android/src/test/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModuleTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/component/EmbeddedComponentBusModuleTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ */
+
+package com.adyenreactnativesdk.component
+
+import com.adyenreactnativesdk.react.ComponentContract
+import com.adyenreactnativesdk.util.messaging.MessageBus
+import org.junit.After
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+class EmbeddedComponentBusModuleTest {
+  private val messageBus = mock(MessageBus::class.java)
+  private val consumer = mock(ComponentContract::class.java)
+  private val sut = EmbeddedComponentBusModule(context = null, messageBus)
+
+  @After
+  fun tearDown() {
+    EmbeddedComponentBusModule.clearConsumers()
+  }
+
+  @Test
+  fun submitRoutesToRegisteredConsumer() {
+    EmbeddedComponentBusModule.register(VIEW_ID, consumer)
+
+    sut.submit(VIEW_ID)
+
+    verify(consumer, times(1)).onSubmit()
+  }
+
+  @Test
+  fun hideFailureStopsLoadingWithoutUnregisteringConsumer() {
+    EmbeddedComponentBusModule.register(VIEW_ID, consumer)
+
+    sut.hide(VIEW_ID, success = false, message = null)
+
+    verify(consumer, times(1)).onStopLoading()
+    sut.submit(VIEW_ID)
+    verify(consumer, times(1)).onSubmit()
+  }
+
+  companion object {
+    private const val VIEW_ID = "card-view"
+  }
+}

--- a/android/src/test/java/com/adyenreactnativesdk/configuration/CardConfigurationParserTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/configuration/CardConfigurationParserTest.kt
@@ -36,6 +36,7 @@ class CardConfigurationParserTest {
     sut.applyConfiguration(mockBuilder)
 
     // THEN
+    verify(mockBuilder, times(0)).setSubmitButtonVisible(any())
     verify(mockBuilder, times(0)).setShowStorePaymentField(any())
     verify(mockBuilder, times(0)).setHolderNameRequired(any())
     verify(mockBuilder, times(0)).setHideCvc(any())
@@ -111,6 +112,7 @@ class CardConfigurationParserTest {
   fun testApplyConfiguration() {
     // GIVEN
     val config = WritableMapMock()
+    config.putBoolean(CardConfigurationParser.SHOW_SUBMIT_BUTTON_KEY, false)
     config.putBoolean(CardConfigurationParser.SHOW_STORE_PAYMENT_FIELD_KEY, false)
     config.putBoolean(CardConfigurationParser.HOLDER_NAME_REQUIRED_KEY, true)
     config.putBoolean(CardConfigurationParser.HIDE_CVC_KEY, true)
@@ -135,6 +137,7 @@ class CardConfigurationParserTest {
     val mockBuilder = mock(CardConfiguration.Builder::class.java)
     sut.applyConfiguration(mockBuilder)
 
+    verify(mockBuilder, times(1)).isSubmitButtonVisible = false
     verify(mockBuilder, times(1)).isStorePaymentFieldVisible = false
     verify(mockBuilder, times(1)).isHolderNameRequired = true
     verify(mockBuilder, times(1)).isHideCvc = true

--- a/android/src/test/java/com/adyenreactnativesdk/react/card/CardComponentManagerTest.kt
+++ b/android/src/test/java/com/adyenreactnativesdk/react/card/CardComponentManagerTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ */
+
+package com.adyenreactnativesdk.react.card
+
+import android.os.Looper
+import androidx.fragment.app.FragmentActivity
+import com.adyen.checkout.card.CardComponent
+import com.adyenreactnativesdk.util.messaging.MessageBus
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class CardComponentManagerTest {
+  private val activity = Robolectric.buildActivity(FragmentActivity::class.java).setup().get()
+  private val component = mock<CardComponent>()
+  private val sut =
+    CardComponentManager(activity, mock<MessageBus>()).apply {
+      component = this@CardComponentManagerTest.component
+    }
+
+  @Test
+  fun `submit invokes the card component on the main thread`() {
+    var invocationThread: Thread? = null
+    doAnswer {
+      invocationThread = Thread.currentThread()
+    }.whenever(component).submit()
+
+    runFromBackgroundThread(sut::submit)
+
+    assertSame(Looper.getMainLooper().thread, invocationThread)
+  }
+
+  @Test
+  fun `stop loading invokes the card component on the main thread`() {
+    var invocationThread: Thread? = null
+    doAnswer {
+      invocationThread = Thread.currentThread()
+    }.whenever(component).setInteractionBlocked(false)
+
+    runFromBackgroundThread(sut::stopLoading)
+
+    assertSame(Looper.getMainLooper().thread, invocationThread)
+  }
+
+  private fun runFromBackgroundThread(action: () -> Unit) {
+    Thread(action).apply {
+      start()
+      join()
+    }
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+}

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -76,7 +76,7 @@ src/
     │   └── DropInWrapper.ts
     ├── embedded/                           # Embedded component bus (for CardView and future embedded views)
     │   ├── EmbeddedComponentBus.ts           # Singleton bus instance
-    │   ├── EmbeddedComponentBusWrapper.ts    # Wrapper with subscribe/unsubscribe/handle/hide/update/confirm
+    │   ├── EmbeddedComponentBusWrapper.ts    # Wrapper with subscribe/unsubscribe/submit/handle/hide/update/confirm
     │   └── EmbeddedComponentProxy.ts         # Per-component proxy that binds a key to bus calls
     ├── googlepay/                          # Google Pay module
     │   ├── AdyenGooglePay.ts
@@ -140,6 +140,8 @@ EventListenerWrapper<EmbeddedNativeModule>
     │
     └──► EmbeddedComponentBusWrapper                         # Bus for all embedded views
             - subscribe(key), unsubscribe(key)
+            - submit(key)
+            - addSubmissionAvailabilityListener(key, listener)
             - handle(key, action), hide(key, success)
             - update(key, results), confirm(key, success, body)
 
@@ -359,6 +361,7 @@ Embedded views are rendered inline within the React tree using Fabric codegen. U
 │  CardView.tsx                                                            │
 │    ├── ref → findNodeHandle() → reactTag                                 │
 │    ├── subscribe(reactTag) → EmbeddedComponentBus                        │
+│    ├── ref.submit() → EmbeddedComponentBus.submit(reactTag)              │
 │    └── <NativeCardView paymentMethod={...} configuration={...} />        │
 │                                                                          │
 │  useSubscriptionManager                                                  │
@@ -420,7 +423,7 @@ CardViewState                                        # Per-view state holder
     - cardComponentManager: CardComponentManager
     - renderComponentIfNeeded(view) — creates component, registers with bus
     - dispose(view) — unregisters, clears state
-    - onAction/onAddressLookup* — delegates to cardComponentManager
+    - onSubmit/onStopLoading/onAction/onAddressLookup* — delegates to cardComponentManager
 
 CardComponentManager                                 # Creates and manages CardComponent
     - createComponent(config, paymentMethod) → CardComponent
@@ -698,4 +701,3 @@ override fun getConstants(): MutableMap<String, Any> =
 | ---------------- | ---------------- | ------------------------------------ |
 | `onLayoutChange` | `CardView`       | Embedded view size changed (w × h)   |
 | `onButtonPress`  | `PlatformPayView`| Pay button tapped                    |
-

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -141,7 +141,6 @@ EventListenerWrapper<EmbeddedNativeModule>
     └──► EmbeddedComponentBusWrapper                         # Bus for all embedded views
             - subscribe(key), unsubscribe(key)
             - submit(key)
-            - addSubmissionAvailabilityListener(key, listener)
             - handle(key, action), hide(key, success)
             - update(key, results), confirm(key, success, body)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -61,20 +61,18 @@
 Set `card.showSubmitButton` to `false` and use a `CardViewHandle` ref when your checkout owns the primary submit button:
 
 ```tsx
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { Button } from 'react-native';
 import { CardView, type CardViewHandle } from '@adyen/react-native';
 
 function CheckoutCard() {
   const cardViewRef = useRef<CardViewHandle>(null);
-  const [isCardReady, setIsCardReady] = useState(false);
 
   return (
     <>
-      <CardView ref={cardViewRef} onReadyChange={setIsCardReady} />
+      <CardView ref={cardViewRef} />
       <Button
         title="Pay"
-        disabled={!isCardReady}
         onPress={() => cardViewRef.current?.submit()}
       />
     </>
@@ -82,7 +80,7 @@ function CheckoutCard() {
 }
 ```
 
-`submit()` returns `false` until the native component is ready. Once submitted, the existing `onSubmit` callback receives the payment data and component proxy. Call `component.hide(false)` after a recoverable submission failure to restore card interaction and allow another attempt.
+Calling `submit()` validates the card form and, when valid, invokes the existing `onSubmit` callback with the payment data and component proxy. Call `component.hide(false)` after a recoverable submission failure to restore card interaction and allow another attempt.
 
 ### 3D Secure 2
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -45,6 +45,7 @@
 | `hideCvcStoredCard`                         | Indicates whether to show the security code field on a stored card payment. Defaults to **false**.                                                        | No       |
 | `holderNameRequired`                        | Indicates if the field for entering the holder name should be displayed in the form. Defaults to **false**.                                               | No       |
 | `kcpVisibility`                             | Indicates whether to show the security fields for South Korea-issued cards. Options: **"show"** or **"hide"**. Defaults to **"hide"**.                    | No       |
+| `showSubmitButton`                          | Indicates whether the native Card Component submit button is displayed. Set to **false** when submitting through an external button. Defaults to **true**. | No       |
 | `showStorePaymentField`                     | Indicates if the field for storing the card payment method should be displayed in the form. Defaults to **true**.                                         | No       |
 | `socialSecurity`                            | Indicates the visibility mode for the social security number field (CPF/CNPJ) for Brazilian cards. Options: "show" or **"hide"**. Defaults to **"hide"**. | No       |
 | `supported`                                 | The list of allowed card types. By default, a list of `brands` from the payment method is used. Fallbacks to a list of all known cards.                     | No       |
@@ -54,6 +55,34 @@
 | `onBinValue: (binValue) => {}`              | An optional callback that is triggered when the BIN (first 6 or 8 PAN digits) typed by the shopper in the PAN field in `CardComponent` changes.           | No       |
 | `installmentOptions`                        | Configuration for installment options. Each key is a card brand (e.g., `"visa"`, `"mc"`, `"amex"`) or `"card"` for defaults that apply to all brands. Each entry has `values` (array of allowed installment counts) and optional `plans` (`"regular"` and/or `"revolving"`). | No       |
 | `showInstallmentAmount`                     | Indicates whether to show the installment amount in the payment form. Defaults to **false**.                                                              | No       |
+
+#### External CardView submission
+
+Set `card.showSubmitButton` to `false` and use a `CardViewHandle` ref when your checkout owns the primary submit button:
+
+```tsx
+import { useRef, useState } from 'react';
+import { Button } from 'react-native';
+import { CardView, type CardViewHandle } from '@adyen/react-native';
+
+function CheckoutCard() {
+  const cardViewRef = useRef<CardViewHandle>(null);
+  const [isCardReady, setIsCardReady] = useState(false);
+
+  return (
+    <>
+      <CardView ref={cardViewRef} onReadyChange={setIsCardReady} />
+      <Button
+        title="Pay"
+        disabled={!isCardReady}
+        onPress={() => cardViewRef.current?.submit()}
+      />
+    </>
+  );
+}
+```
+
+`submit()` returns `false` until the native component is ready. Once submitted, the existing `onSubmit` callback receives the payment data and component proxy. Call `component.hide(false)` after a recoverable submission failure to restore card interaction and allow another attempt.
 
 ### 3D Secure 2
 

--- a/etc/api/adyen-react-native.api.md
+++ b/etc/api/adyen-react-native.api.md
@@ -360,15 +360,22 @@ export interface CardsConfiguration {
     onUpdateAddress?(prompt: string, lookup: AddressLookup): void;
     showInstallmentAmount?: boolean;
     showStorePaymentField?: boolean;
+    showSubmitButton?: boolean;
     socialSecurity?: FieldVisibility;
     supported?: string[];
 }
 
 // @public
-export const CardView: React_2.FC<CardViewProps>;
+export const CardView: React_2.ForwardRefExoticComponent<CardViewProps & React_2.RefAttributes<CardViewHandle>>;
+
+// @public
+export interface CardViewHandle {
+    submit(): boolean;
+}
 
 // @public (undocumented)
 export interface CardViewProps {
+    onReadyChange?: (isReady: boolean) => void;
     paymentMethod?: PaymentMethod;
 }
 

--- a/etc/api/adyen-react-native.api.md
+++ b/etc/api/adyen-react-native.api.md
@@ -370,12 +370,11 @@ export const CardView: React_2.ForwardRefExoticComponent<CardViewProps & React_2
 
 // @public
 export interface CardViewHandle {
-    submit(): boolean;
+    submit(): void;
 }
 
 // @public (undocumented)
 export interface CardViewProps {
-    onReadyChange?: (isReady: boolean) => void;
     paymentMethod?: PaymentMethod;
 }
 

--- a/example/ios/AdyenExampleTests/CardConfigurationTests.swift
+++ b/example/ios/AdyenExampleTests/CardConfigurationTests.swift
@@ -42,6 +42,28 @@ final class CardConfigurationTests: XCTestCase {
         XCTAssertNotNil(sut.configuration)
     }
 
+    func test_configuration_showsSubmitButtonByDefault() {
+        // GIVEN
+        let configDict: NSDictionary = ["card": [:]]
+
+        // WHEN
+        let sut = CardConfigurationParser(configuration: configDict, delegate: mockAddressLookupProvider)
+
+        // THEN
+        XCTAssertTrue(sut.configuration.showsSubmitButton)
+    }
+
+    func test_configuration_hidesSubmitButton_whenConfigured() {
+        // GIVEN
+        let configDict: NSDictionary = ["card": ["showSubmitButton": false]]
+
+        // WHEN
+        let sut = CardConfigurationParser(configuration: configDict, delegate: mockAddressLookupProvider)
+
+        // THEN
+        XCTAssertFalse(sut.configuration.showsSubmitButton)
+    }
+
     func test_configuration_setsShowStorePaymentField_whenProvided() {
         // GIVEN
         let configDict: NSDictionary = ["card": ["showStorePaymentField": false]]

--- a/example/ios/AdyenExampleTests/CardConfigurationTests.swift
+++ b/example/ios/AdyenExampleTests/CardConfigurationTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import adyen_react_native
+@testable import adyen_react_native
 import PassKit
 import XCTest
 
@@ -50,7 +50,7 @@ final class CardConfigurationTests: XCTestCase {
         let sut = CardConfigurationParser(configuration: configDict, delegate: mockAddressLookupProvider)
 
         // THEN
-        XCTAssertTrue(sut.configuration.showsSubmitButton)
+        XCTAssertTrue(sut.showsSubmitButton)
     }
 
     func test_configuration_hidesSubmitButton_whenConfigured() {
@@ -61,7 +61,7 @@ final class CardConfigurationTests: XCTestCase {
         let sut = CardConfigurationParser(configuration: configDict, delegate: mockAddressLookupProvider)
 
         // THEN
-        XCTAssertFalse(sut.configuration.showsSubmitButton)
+        XCTAssertFalse(sut.showsSubmitButton)
     }
 
     func test_configuration_setsShowStorePaymentField_whenProvided() {

--- a/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
+++ b/example/ios/AdyenExampleTests/Modules/ThreadingSafetyTests.swift
@@ -197,7 +197,7 @@ final class ThreadingSafetyTests: XCTestCase {
         let bus = EmbeddedComponentBusModule()
         EmbeddedComponentBusModule.shared = bus
         bus.createActionHandlerIfNeeded(context: Self.context, locale: nil)
-        _ = bus.register(viewId: "card-view")
+        _ = bus.register(viewId: "card-view", submitHandler: {}, stopLoadingHandler: {})
 
         let proxy = CardComponentViewProxy(frame: .zero)
         proxy.viewId = "card-view"
@@ -214,7 +214,7 @@ final class ThreadingSafetyTests: XCTestCase {
         // THEN dispose completes without crashing and the bus state is not corrupted
         wait(for: [disposeExpectation], timeout: 1.0)
 
-        let newProxy = bus.register(viewId: "card-view-2")
+        let newProxy = bus.register(viewId: "card-view-2", submitHandler: {}, stopLoadingHandler: {})
         XCTAssertNotNil(newProxy)
     }
 
@@ -258,7 +258,7 @@ final class ThreadingSafetyTests: XCTestCase {
         }
         BaseModule.presenterStack = [presenter]
 
-        _ = sut.register(viewId: "card-view")
+        _ = sut.register(viewId: "card-view", submitHandler: {}, stopLoadingHandler: {})
 
         // WHEN hide() is called from a background thread
         DispatchQueue.global().async {
@@ -290,6 +290,50 @@ final class ThreadingSafetyTests: XCTestCase {
             expectation.fulfill()
         }
 
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_embeddedComponentBusSubmit_fromBackgroundThread_callsHandlerOnMainThread() {
+        // GIVEN an EmbeddedComponentBusModule with a registered submit handler
+        let expectation = expectation(description: "Submit handler should be called")
+        let sut = EmbeddedComponentBusModule()
+        _ = sut.register(
+            viewId: "card-view",
+            submitHandler: {
+                XCTAssertTrue(Thread.isMainThread)
+                expectation.fulfill()
+            },
+            stopLoadingHandler: {}
+        )
+
+        // WHEN submit() is called from a background thread
+        DispatchQueue.global().async {
+            sut.submit("card-view")
+        }
+
+        // THEN the handler is invoked on the main thread
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_embeddedComponentBusHideFailure_fromBackgroundThread_callsStopLoadingOnMainThread() {
+        // GIVEN an EmbeddedComponentBusModule with a registered stop-loading handler
+        let expectation = expectation(description: "Stop-loading handler should be called")
+        let sut = EmbeddedComponentBusModule()
+        _ = sut.register(
+            viewId: "card-view",
+            submitHandler: {},
+            stopLoadingHandler: {
+                XCTAssertTrue(Thread.isMainThread)
+                expectation.fulfill()
+            }
+        )
+
+        // WHEN hide(false) is called from a background thread
+        DispatchQueue.global().async {
+            sut.hide("card-view", success: NSNumber(value: false), event: [:])
+        }
+
+        // THEN the handler is invoked on the main thread
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -343,7 +387,7 @@ final class ThreadingSafetyTests: XCTestCase {
         let emitter = MockEmitter()
         sut.emitterOverride = emitter
         sut.createActionHandlerIfNeeded(context: Self.context, locale: nil)
-        _ = sut.register(viewId: "card-view")
+        _ = sut.register(viewId: "card-view", submitHandler: {}, stopLoadingHandler: {})
 
         // WHEN handle() is called from a background thread
         DispatchQueue.global().async {

--- a/ios/AdyenModule.m
+++ b/ios/AdyenModule.m
@@ -149,6 +149,8 @@ RCT_EXTERN_METHOD(subscribe:(nonnull NSString *)viewId)
 
 RCT_EXTERN_METHOD(unsubscribe:(nonnull NSString *)viewId)
 
+RCT_EXTERN_METHOD(submit:(nonnull NSString *)viewId)
+
 RCT_EXTERN_METHOD(hide:(nonnull NSString *)viewId
                   success:(nonnull NSNumber *)success
                   event:(NSDictionary *)event)
@@ -164,5 +166,4 @@ RCT_EXTERN_METHOD(confirm:(nonnull NSString *)viewId
                   address:(nullable NSDictionary *)address)
 
 @end
-
 

--- a/ios/Components/Embedded/EmbeddedComponentBusModule.swift
+++ b/ios/Components/Embedded/EmbeddedComponentBusModule.swift
@@ -18,6 +18,14 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
     /// Per-viewId delegate proxies
     private var delegates: [String: EmbeddedComponentDelegateProxy] = [:]
 
+    private struct ComponentHandlers {
+        let submit: () -> Void
+        let stopLoading: () -> Void
+    }
+
+    /// Per-viewId handlers for externally submitted embedded components
+    private var componentHandlers: [String: ComponentHandlers] = [:]
+
     /// Shared action handler for all embedded views
     private var actionHandler: AdyenActionComponent?
 
@@ -39,14 +47,23 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
 
     // MARK: - Registration
 
-    func register(viewId: String) -> EmbeddedComponentDelegateProxy {
+    func register(
+        viewId: String,
+        submitHandler: @escaping () -> Void,
+        stopLoadingHandler: @escaping () -> Void
+    ) -> EmbeddedComponentDelegateProxy {
         let proxy = EmbeddedComponentDelegateProxy(viewId: viewId, bus: self)
         delegates[viewId] = proxy
+        componentHandlers[viewId] = ComponentHandlers(
+            submit: submitHandler,
+            stopLoading: stopLoadingHandler
+        )
         return proxy
     }
 
     func unregister(viewId: String) {
         delegates.removeValue(forKey: viewId)
+        componentHandlers.removeValue(forKey: viewId)
         lookupHandlers.removeValue(forKey: viewId)
         lookupCompletionHandlers.removeValue(forKey: viewId)
         if delegates.isEmpty {
@@ -97,6 +114,13 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
     }
 
     // MARK: - ViewId-routed commands (called from JS)
+
+    @objc
+    func submit(_ viewId: String) {
+        ensureMainThread { [weak self] in
+            self?.performSubmit(viewId)
+        }
+    }
 
     @objc
     func handle(_ viewId: String, action actionDict: NSDictionary?) {
@@ -163,6 +187,14 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
         }
     }
 
+    private func performSubmit(_ viewId: String) {
+        guard let submitHandler = componentHandlers[viewId]?.submit else {
+            sendError(error: ModuleException.componentNotRegistered(viewId))
+            return
+        }
+        submitHandler()
+    }
+
     private func performUpdate(_ viewId: String, results: NSArray?) {
         guard let lookupHandler = lookupHandlers[viewId] else { return }
 
@@ -188,14 +220,19 @@ internal final class EmbeddedComponentBusModule: BaseAddressModule {
     }
 
     private func performHide(_ viewId: String, success: NSNumber) {
-        unregister(viewId: viewId)
-        if delegates.isEmpty {
-            dismiss(success.boolValue)
+        if success.boolValue {
+            unregister(viewId: viewId)
+            if delegates.isEmpty {
+                dismiss(true)
+            }
+        } else {
+            componentHandlers[viewId]?.stopLoading()
         }
     }
 
     private func performCleanUp() {
         delegates.removeAll()
+        componentHandlers.removeAll()
         subscribedViews.removeAll()
         actionHandler?.cancelIfNeeded()
         actionHandler = nil

--- a/ios/Configuration/CardConfigurationParser.swift
+++ b/ios/Configuration/CardConfigurationParser.swift
@@ -24,6 +24,10 @@ public struct CardConfigurationParser {
         dict[CardKeys.showStorePaymentField] as? Bool ?? true
     }
 
+    var showsSubmitButton: Bool {
+        dict[CardKeys.showSubmitButton] as? Bool ?? true
+    }
+
     var showsHolderNameField: Bool {
         dict[CardKeys.holderNameRequired] as? Bool ?? false
     }
@@ -100,6 +104,7 @@ public struct CardConfigurationParser {
 
     public var configuration: CardComponent.Configuration {
         .init(style: FormComponentStyle(),
+              showsSubmitButton: showsSubmitButton,
               shopperInformation: nil,
               localizationParameters: nil,
               showsHolderNameField: showsHolderNameField,

--- a/ios/Configuration/Parameters.swift
+++ b/ios/Configuration/Parameters.swift
@@ -36,6 +36,7 @@ internal enum DropInKeys: SubConfig {
 
 internal enum CardKeys: SubConfig {
     static let rootKey = "card"
+    static let showSubmitButton = "showSubmitButton"
     static let showStorePaymentField = "showStorePaymentField"
     static let holderNameRequired = "holderNameRequired"
     static let hideCvcStoredCard = "hideCvcStoredCard"

--- a/ios/Views/CardView/CardComponentViewProxy.swift
+++ b/ios/Views/CardView/CardComponentViewProxy.swift
@@ -112,7 +112,11 @@ public final class CardComponentViewProxy: UIStackView {
             return
         }
 
-        let proxy = componentBus.register(viewId: viewId)
+        let proxy = componentBus.register(
+            viewId: viewId,
+            submitHandler: { [weak self] in self?.cardComponent?.submit() },
+            stopLoadingHandler: { [weak self] in self?.cardComponent?.stopLoading() }
+        )
         do {
             let component = try createCardComponent(
                 paymentMethodJSON: paymentMethodJSON,

--- a/src/components/CardView.tsx
+++ b/src/components/CardView.tsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -12,10 +13,19 @@ import NativeCardView, {
 import { useAdyenCheckout } from '../hooks/useAdyenCheckout';
 import type { PaymentMethod } from '../core/types';
 import { useComponent } from '../hooks/useComponent';
+import { EmbeddedComponentBus } from '../modules/embedded/EmbeddedComponentBus';
 
 export interface CardViewProps {
   /** PaymentMethod object. If not provided, the first available payment method will be used. */
   paymentMethod?: PaymentMethod;
+  /** Called when the card component becomes ready, or stops being ready, for external submission. */
+  onReadyChange?: (isReady: boolean) => void;
+}
+
+/** Imperative controls exposed by {@link CardView}. */
+export interface CardViewHandle {
+  /** Submit the native card component. Returns false when the component is not ready. */
+  submit(): boolean;
 }
 
 const PAYMENT_METHOD_TYPE = 'scheme';
@@ -24,63 +34,117 @@ const PAYMENT_METHOD_TYPE = 'scheme';
  * Type-safe wrapper for the native CardView component.
  * Automatically serializes PaymentMethod and Configuration objects to JSON strings.
  */
-export const CardView: React.FC<CardViewProps> = ({ paymentMethod }) => {
-  const { config, paymentMethods } = useAdyenCheckout();
-  const { subscribe, unsubscribe } = useComponent();
-  const nativeRef = useRef(null);
-  const subscribedKey = useRef<string | null>(null);
+export const CardView = React.forwardRef<CardViewHandle, CardViewProps>(
+  function CardViewComponent({ paymentMethod, onReadyChange }, ref) {
+    const { config, paymentMethods } = useAdyenCheckout();
+    const { subscribe, unsubscribe } = useComponent();
+    const nativeRef = useRef(null);
+    const subscribedKey = useRef<string | null>(null);
+    const onReadyChangeRef = useRef(onReadyChange);
+    const hasLayoutRef = useRef(false);
+    const isReadyRef = useRef(false);
 
-  const [size, setSize] = useState<LayoutChangeEvent>();
+    const [size, setSize] = useState<LayoutChangeEvent>();
 
-  const handleLayoutChange = useCallback(
-    (event: { nativeEvent: LayoutChangeEvent }) => {
-      setSize(event.nativeEvent);
-    },
-    []
-  );
+    const updateReady = useCallback((isReady: boolean) => {
+      if (isReadyRef.current === isReady) return;
 
-  const _paymentMethod = useMemo(
-    () =>
-      paymentMethod ??
-      paymentMethods?.paymentMethods?.find(
-        (x) => x.type === PAYMENT_METHOD_TYPE
-      ),
-    [paymentMethod, paymentMethods]
-  );
+      isReadyRef.current = isReady;
+      onReadyChangeRef.current?.(isReady);
+    }, []);
 
-  useEffect(() => {
-    const tag = findNodeHandle(nativeRef.current);
-    if (tag == null) return;
+    const handleLayoutChange = useCallback(
+      (event: { nativeEvent: LayoutChangeEvent }) => {
+        hasLayoutRef.current = event.nativeEvent.height > 0;
+        updateReady(subscribedKey.current !== null && hasLayoutRef.current);
+        setSize(event.nativeEvent);
+      },
+      [updateReady]
+    );
 
-    const key = String(tag);
-    subscribedKey.current = key;
-    subscribe(key);
-    return () => {
-      unsubscribe(key);
-      subscribedKey.current = null;
-    };
-  }, [_paymentMethod, subscribe, unsubscribe]);
+    const _paymentMethod = useMemo(
+      () =>
+        paymentMethod ??
+        paymentMethods?.paymentMethods?.find(
+          (x) => x.type === PAYMENT_METHOD_TYPE
+        ),
+      [paymentMethod, paymentMethods]
+    );
+    const hasPaymentMethod = _paymentMethod != null;
 
-  useEffect(() => {
+    useEffect(() => {
+      onReadyChangeRef.current = onReadyChange;
+      onReadyChange?.(isReadyRef.current);
+    }, [onReadyChange]);
+
+    useEffect(() => {
+      if (hasPaymentMethod) return;
+
+      hasLayoutRef.current = false;
+      setSize(undefined);
+    }, [hasPaymentMethod]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        submit() {
+          const viewId = subscribedKey.current;
+          if (viewId === null || !isReadyRef.current) return false;
+
+          EmbeddedComponentBus.submit(viewId);
+          return true;
+        },
+      }),
+      []
+    );
+
+    useEffect(() => {
+      if (!hasPaymentMethod) return;
+
+      const tag = findNodeHandle(nativeRef.current);
+      if (tag == null) return;
+
+      const key = String(tag);
+      const removeAvailabilityListener =
+        EmbeddedComponentBus.addSubmissionAvailabilityListener(
+          key,
+          (isAvailable) => updateReady(isAvailable && hasLayoutRef.current)
+        );
+      subscribe(key);
+      subscribedKey.current = key;
+      updateReady(hasLayoutRef.current);
+      return () => {
+        hasLayoutRef.current = false;
+        subscribedKey.current = null;
+        updateReady(false);
+        removeAvailabilityListener();
+        unsubscribe(key);
+      };
+    }, [hasPaymentMethod, subscribe, unsubscribe, updateReady]);
+
+    useEffect(() => {
+      if (!_paymentMethod) {
+        console.error(
+          `No payment method found for type ${PAYMENT_METHOD_TYPE}`
+        );
+      }
+    }, [_paymentMethod]);
+
     if (!_paymentMethod) {
-      console.error(`No payment method found for type ${PAYMENT_METHOD_TYPE}`);
+      return null;
     }
-  }, [_paymentMethod]);
 
-  if (!_paymentMethod) {
-    return null;
+    return (
+      <NativeCardView
+        ref={nativeRef}
+        paymentMethod={JSON.stringify(_paymentMethod)}
+        configuration={JSON.stringify(config)}
+        onLayoutChange={handleLayoutChange}
+        style={{
+          height: size?.height,
+          width: '100%',
+        }}
+      />
+    );
   }
-
-  return (
-    <NativeCardView
-      ref={nativeRef}
-      paymentMethod={JSON.stringify(_paymentMethod)}
-      configuration={JSON.stringify(config)}
-      onLayoutChange={handleLayoutChange}
-      style={{
-        height: size?.height,
-        width: '100%',
-      }}
-    />
-  );
-};
+);

--- a/src/components/CardView.tsx
+++ b/src/components/CardView.tsx
@@ -18,14 +18,12 @@ import { EmbeddedComponentBus } from '../modules/embedded/EmbeddedComponentBus';
 export interface CardViewProps {
   /** PaymentMethod object. If not provided, the first available payment method will be used. */
   paymentMethod?: PaymentMethod;
-  /** Called when the card component becomes ready, or stops being ready, for external submission. */
-  onReadyChange?: (isReady: boolean) => void;
 }
 
 /** Imperative controls exposed by {@link CardView}. */
 export interface CardViewHandle {
-  /** Submit the native card component. Returns false when the component is not ready. */
-  submit(): boolean;
+  /** Submit the native card component. */
+  submit(): void;
 }
 
 const PAYMENT_METHOD_TYPE = 'scheme';
@@ -35,31 +33,17 @@ const PAYMENT_METHOD_TYPE = 'scheme';
  * Automatically serializes PaymentMethod and Configuration objects to JSON strings.
  */
 export const CardView = React.forwardRef<CardViewHandle, CardViewProps>(
-  function CardViewComponent({ paymentMethod, onReadyChange }, ref) {
+  function CardViewComponent({ paymentMethod }, ref) {
     const { config, paymentMethods } = useAdyenCheckout();
     const { subscribe, unsubscribe } = useComponent();
     const nativeRef = useRef(null);
     const subscribedKey = useRef<string | null>(null);
-    const onReadyChangeRef = useRef(onReadyChange);
-    const hasLayoutRef = useRef(false);
-    const isReadyRef = useRef(false);
 
     const [size, setSize] = useState<LayoutChangeEvent>();
 
-    const updateReady = useCallback((isReady: boolean) => {
-      if (isReadyRef.current === isReady) return;
-
-      isReadyRef.current = isReady;
-      onReadyChangeRef.current?.(isReady);
-    }, []);
-
     const handleLayoutChange = useCallback(
-      (event: { nativeEvent: LayoutChangeEvent }) => {
-        hasLayoutRef.current = event.nativeEvent.height > 0;
-        updateReady(subscribedKey.current !== null && hasLayoutRef.current);
-        setSize(event.nativeEvent);
-      },
-      [updateReady]
+      (event: { nativeEvent: LayoutChangeEvent }) => setSize(event.nativeEvent),
+      []
     );
 
     const _paymentMethod = useMemo(
@@ -70,57 +54,31 @@ export const CardView = React.forwardRef<CardViewHandle, CardViewProps>(
         ),
       [paymentMethod, paymentMethods]
     );
-    const hasPaymentMethod = _paymentMethod != null;
-
-    useEffect(() => {
-      onReadyChangeRef.current = onReadyChange;
-      onReadyChange?.(isReadyRef.current);
-    }, [onReadyChange]);
-
-    useEffect(() => {
-      if (hasPaymentMethod) return;
-
-      hasLayoutRef.current = false;
-      setSize(undefined);
-    }, [hasPaymentMethod]);
-
     useImperativeHandle(
       ref,
       () => ({
         submit() {
           const viewId = subscribedKey.current;
-          if (viewId === null || !isReadyRef.current) return false;
-
-          EmbeddedComponentBus.submit(viewId);
-          return true;
+          if (viewId !== null) {
+            EmbeddedComponentBus.submit(viewId);
+          }
         },
       }),
       []
     );
 
     useEffect(() => {
-      if (!hasPaymentMethod) return;
-
       const tag = findNodeHandle(nativeRef.current);
       if (tag == null) return;
 
       const key = String(tag);
-      const removeAvailabilityListener =
-        EmbeddedComponentBus.addSubmissionAvailabilityListener(
-          key,
-          (isAvailable) => updateReady(isAvailable && hasLayoutRef.current)
-        );
-      subscribe(key);
       subscribedKey.current = key;
-      updateReady(hasLayoutRef.current);
+      subscribe(key);
       return () => {
-        hasLayoutRef.current = false;
         subscribedKey.current = null;
-        updateReady(false);
-        removeAvailabilityListener();
         unsubscribe(key);
       };
-    }, [hasPaymentMethod, subscribe, unsubscribe, updateReady]);
+    }, [_paymentMethod, subscribe, unsubscribe]);
 
     useEffect(() => {
       if (!_paymentMethod) {

--- a/src/components/__tests__/CardView.test.tsx
+++ b/src/components/__tests__/CardView.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react';
-import { act, fireEvent, render } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { CardView, type CardViewHandle } from '../CardView';
 
@@ -8,8 +8,6 @@ const mockUnsubscribe = jest.fn();
 const mockSubmit = jest.fn();
 let mockPaymentMethods:
   { paymentMethods: { type: string; name: string }[] } | undefined;
-let mockSubmissionAvailabilityListener:
-  ((isAvailable: boolean) => void) | undefined;
 
 jest.mock('../../hooks/useAdyenCheckout', () => ({
   useAdyenCheckout: () => ({
@@ -27,17 +25,6 @@ jest.mock('../../hooks/useComponent', () => ({
 
 jest.mock('../../modules/embedded/EmbeddedComponentBus', () => ({
   EmbeddedComponentBus: {
-    addSubmissionAvailabilityListener: (
-      _viewId: string,
-      listener: (isAvailable: boolean) => void
-    ) => {
-      mockSubmissionAvailabilityListener = listener;
-      return () => {
-        if (mockSubmissionAvailabilityListener === listener) {
-          mockSubmissionAvailabilityListener = undefined;
-        }
-      };
-    },
     submit: (viewId: string) => mockSubmit(viewId),
   },
 }));
@@ -67,85 +54,34 @@ describe('CardView', () => {
     mockPaymentMethods = {
       paymentMethods: [{ type: 'scheme', name: 'Credit card' }],
     };
-    mockSubmissionAvailabilityListener = undefined;
   });
 
-  test('submits through the embedded component bus once ready', () => {
+  test('submits through the embedded component bus', () => {
     const ref = createRef<CardViewHandle>();
-    const onReadyChange = jest.fn();
-    const { getByTestId } = render(
-      <CardView ref={ref} onReadyChange={onReadyChange} />
-    );
+    render(<CardView ref={ref} />);
 
-    expect(ref.current?.submit()).toBe(false);
-    expect(mockSubmit).not.toHaveBeenCalled();
-
-    fireEvent(getByTestId('native-card-view'), 'layoutChange', {
-      nativeEvent: { height: 120, width: 320 },
-    });
-
-    expect(onReadyChange).toHaveBeenLastCalledWith(true);
-    expect(ref.current?.submit()).toBe(true);
+    ref.current?.submit();
     expect(mockSubmit).toHaveBeenCalledWith('42');
   });
 
-  test('stops reporting ready after successful native cleanup', () => {
+  test('ignores submission when the native view is unavailable', () => {
     const ref = createRef<CardViewHandle>();
-    const onReadyChange = jest.fn();
-    const { getByTestId } = render(
-      <CardView ref={ref} onReadyChange={onReadyChange} />
-    );
-    fireEvent(getByTestId('native-card-view'), 'layoutChange', {
-      nativeEvent: { height: 120, width: 320 },
-    });
-
-    act(() => mockSubmissionAvailabilityListener?.(false));
-
-    expect(onReadyChange).toHaveBeenLastCalledWith(false);
-    expect(ref.current?.submit()).toBe(false);
-  });
-
-  test('does not reuse layout readiness after the native view remounts', () => {
-    const ref = createRef<CardViewHandle>();
-    const onReadyChange = jest.fn();
     const consoleError = jest
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);
-    const { getByTestId, rerender } = render(
-      <CardView ref={ref} onReadyChange={onReadyChange} />
-    );
-    fireEvent(getByTestId('native-card-view'), 'layoutChange', {
-      nativeEvent: { height: 120, width: 320 },
-    });
-    expect(ref.current?.submit()).toBe(true);
-
     mockPaymentMethods = undefined;
-    rerender(<CardView ref={ref} onReadyChange={onReadyChange} />);
-    expect(ref.current?.submit()).toBe(false);
+    render(<CardView ref={ref} />);
 
-    mockPaymentMethods = {
-      paymentMethods: [{ type: 'scheme', name: 'Credit card' }],
-    };
-    rerender(<CardView ref={ref} onReadyChange={onReadyChange} />);
+    ref.current?.submit();
 
-    expect(ref.current?.submit()).toBe(false);
-    expect(onReadyChange).toHaveBeenLastCalledWith(false);
+    expect(mockSubmit).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
 
-  test('reports not ready and unsubscribes when unmounted', () => {
-    const onReadyChange = jest.fn();
-    const { getByTestId, unmount } = render(
-      <CardView onReadyChange={onReadyChange} />
-    );
+  test('unsubscribes when unmounted', () => {
+    const { unmount } = render(<CardView />);
 
-    fireEvent(getByTestId('native-card-view'), 'layoutChange', {
-      nativeEvent: { height: 120, width: 320 },
-    });
-
-    act(unmount);
-
-    expect(onReadyChange).toHaveBeenLastCalledWith(false);
+    unmount();
     expect(mockUnsubscribe).toHaveBeenCalledWith('42');
   });
 });

--- a/src/components/__tests__/CardView.test.tsx
+++ b/src/components/__tests__/CardView.test.tsx
@@ -1,0 +1,151 @@
+import React, { createRef } from 'react';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { CardView, type CardViewHandle } from '../CardView';
+
+const mockSubscribe = jest.fn();
+const mockUnsubscribe = jest.fn();
+const mockSubmit = jest.fn();
+let mockPaymentMethods:
+  { paymentMethods: { type: string; name: string }[] } | undefined;
+let mockSubmissionAvailabilityListener:
+  ((isAvailable: boolean) => void) | undefined;
+
+jest.mock('../../hooks/useAdyenCheckout', () => ({
+  useAdyenCheckout: () => ({
+    config: { environment: 'test', clientKey: 'test_key' },
+    paymentMethods: mockPaymentMethods,
+  }),
+}));
+
+jest.mock('../../hooks/useComponent', () => ({
+  useComponent: () => ({
+    subscribe: mockSubscribe,
+    unsubscribe: mockUnsubscribe,
+  }),
+}));
+
+jest.mock('../../modules/embedded/EmbeddedComponentBus', () => ({
+  EmbeddedComponentBus: {
+    addSubmissionAvailabilityListener: (
+      _viewId: string,
+      listener: (isAvailable: boolean) => void
+    ) => {
+      mockSubmissionAvailabilityListener = listener;
+      return () => {
+        if (mockSubmissionAvailabilityListener === listener) {
+          mockSubmissionAvailabilityListener = undefined;
+        }
+      };
+    },
+    submit: (viewId: string) => mockSubmit(viewId),
+  },
+}));
+
+jest.mock('../../specs/NativeCardView', () => ({
+  __esModule: true,
+  default: (() => {
+    const ReactModule = require('react');
+    const { View } = require('react-native');
+
+    return ReactModule.forwardRef(function MockNativeCardView(
+      props: object,
+      ref: React.Ref<number>
+    ) {
+      ReactModule.useImperativeHandle(ref, () => 42);
+      return ReactModule.createElement(View, {
+        testID: 'native-card-view',
+        ...props,
+      });
+    });
+  })(),
+}));
+
+describe('CardView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPaymentMethods = {
+      paymentMethods: [{ type: 'scheme', name: 'Credit card' }],
+    };
+    mockSubmissionAvailabilityListener = undefined;
+  });
+
+  test('submits through the embedded component bus once ready', () => {
+    const ref = createRef<CardViewHandle>();
+    const onReadyChange = jest.fn();
+    const { getByTestId } = render(
+      <CardView ref={ref} onReadyChange={onReadyChange} />
+    );
+
+    expect(ref.current?.submit()).toBe(false);
+    expect(mockSubmit).not.toHaveBeenCalled();
+
+    fireEvent(getByTestId('native-card-view'), 'layoutChange', {
+      nativeEvent: { height: 120, width: 320 },
+    });
+
+    expect(onReadyChange).toHaveBeenLastCalledWith(true);
+    expect(ref.current?.submit()).toBe(true);
+    expect(mockSubmit).toHaveBeenCalledWith('42');
+  });
+
+  test('stops reporting ready after successful native cleanup', () => {
+    const ref = createRef<CardViewHandle>();
+    const onReadyChange = jest.fn();
+    const { getByTestId } = render(
+      <CardView ref={ref} onReadyChange={onReadyChange} />
+    );
+    fireEvent(getByTestId('native-card-view'), 'layoutChange', {
+      nativeEvent: { height: 120, width: 320 },
+    });
+
+    act(() => mockSubmissionAvailabilityListener?.(false));
+
+    expect(onReadyChange).toHaveBeenLastCalledWith(false);
+    expect(ref.current?.submit()).toBe(false);
+  });
+
+  test('does not reuse layout readiness after the native view remounts', () => {
+    const ref = createRef<CardViewHandle>();
+    const onReadyChange = jest.fn();
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { getByTestId, rerender } = render(
+      <CardView ref={ref} onReadyChange={onReadyChange} />
+    );
+    fireEvent(getByTestId('native-card-view'), 'layoutChange', {
+      nativeEvent: { height: 120, width: 320 },
+    });
+    expect(ref.current?.submit()).toBe(true);
+
+    mockPaymentMethods = undefined;
+    rerender(<CardView ref={ref} onReadyChange={onReadyChange} />);
+    expect(ref.current?.submit()).toBe(false);
+
+    mockPaymentMethods = {
+      paymentMethods: [{ type: 'scheme', name: 'Credit card' }],
+    };
+    rerender(<CardView ref={ref} onReadyChange={onReadyChange} />);
+
+    expect(ref.current?.submit()).toBe(false);
+    expect(onReadyChange).toHaveBeenLastCalledWith(false);
+    consoleError.mockRestore();
+  });
+
+  test('reports not ready and unsubscribes when unmounted', () => {
+    const onReadyChange = jest.fn();
+    const { getByTestId, unmount } = render(
+      <CardView onReadyChange={onReadyChange} />
+    );
+
+    fireEvent(getByTestId('native-card-view'), 'layoutChange', {
+      nativeEvent: { height: 120, width: 320 },
+    });
+
+    act(unmount);
+
+    expect(onReadyChange).toHaveBeenLastCalledWith(false);
+    expect(mockUnsubscribe).toHaveBeenCalledWith('42');
+  });
+});

--- a/src/core/configurations/CardsConfiguration.ts
+++ b/src/core/configurations/CardsConfiguration.ts
@@ -17,6 +17,12 @@ export interface InstallmentOptions {
 
 export interface CardsConfiguration {
   /**
+   * Indicates whether the native card component submit button should be displayed.
+   * Disable it when submitting the component through an external button.
+   * @default true
+   */
+  showSubmitButton?: boolean;
+  /**
    * Determines whether the field for the cardholder's name is required.
    * @default false
    */

--- a/src/modules/embedded/EmbeddedComponentBus.ts
+++ b/src/modules/embedded/EmbeddedComponentBus.ts
@@ -7,6 +7,7 @@ import { NativeModules } from 'react-native';
 export interface EmbeddedNativeModule extends NativeModuleWithConstants {
   subscribe(viewId: string): void;
   unsubscribe(viewId: string): void;
+  submit(viewId: string): void;
   handle(viewId: string, action: PaymentAction): void;
   hide(viewId: string, success: boolean, option?: { message?: string }): void;
   update(viewId: string, results: AddressLookupItem[]): void;

--- a/src/modules/embedded/EmbeddedComponentBusWrapper.ts
+++ b/src/modules/embedded/EmbeddedComponentBusWrapper.ts
@@ -7,10 +7,6 @@ import type { EmbeddedNativeModule } from './EmbeddedComponentBus';
  * */
 export class EmbeddedComponentBusWrapper extends EventListenerWrapper<EmbeddedNativeModule> {
   name: string = 'AdyenComponentBus';
-  private submissionAvailabilityListeners = new Map<
-    string,
-    (isAvailable: boolean) => void
-  >();
 
   subscribe(viewId: string): void {
     this.nativeModule.subscribe(viewId);
@@ -18,19 +14,6 @@ export class EmbeddedComponentBusWrapper extends EventListenerWrapper<EmbeddedNa
 
   unsubscribe(viewId: string): void {
     this.nativeModule.unsubscribe(viewId);
-    this.submissionAvailabilityListeners.delete(viewId);
-  }
-
-  addSubmissionAvailabilityListener(
-    viewId: string,
-    listener: (isAvailable: boolean) => void
-  ): () => void {
-    this.submissionAvailabilityListeners.set(viewId, listener);
-    return () => {
-      if (this.submissionAvailabilityListeners.get(viewId) === listener) {
-        this.submissionAvailabilityListeners.delete(viewId);
-      }
-    };
   }
 
   submit(viewId: string): void {
@@ -43,10 +26,6 @@ export class EmbeddedComponentBusWrapper extends EventListenerWrapper<EmbeddedNa
 
   hide(viewId: string, success: boolean, option?: { message?: string }): void {
     this.nativeModule.hide(viewId, success, option);
-    this.submissionAvailabilityListeners.get(viewId)?.(!success);
-    if (success) {
-      this.submissionAvailabilityListeners.delete(viewId);
-    }
   }
 
   update(viewId: string, results: AddressLookupItem[]): void {

--- a/src/modules/embedded/EmbeddedComponentBusWrapper.ts
+++ b/src/modules/embedded/EmbeddedComponentBusWrapper.ts
@@ -7,6 +7,10 @@ import type { EmbeddedNativeModule } from './EmbeddedComponentBus';
  * */
 export class EmbeddedComponentBusWrapper extends EventListenerWrapper<EmbeddedNativeModule> {
   name: string = 'AdyenComponentBus';
+  private submissionAvailabilityListeners = new Map<
+    string,
+    (isAvailable: boolean) => void
+  >();
 
   subscribe(viewId: string): void {
     this.nativeModule.subscribe(viewId);
@@ -14,6 +18,23 @@ export class EmbeddedComponentBusWrapper extends EventListenerWrapper<EmbeddedNa
 
   unsubscribe(viewId: string): void {
     this.nativeModule.unsubscribe(viewId);
+    this.submissionAvailabilityListeners.delete(viewId);
+  }
+
+  addSubmissionAvailabilityListener(
+    viewId: string,
+    listener: (isAvailable: boolean) => void
+  ): () => void {
+    this.submissionAvailabilityListeners.set(viewId, listener);
+    return () => {
+      if (this.submissionAvailabilityListeners.get(viewId) === listener) {
+        this.submissionAvailabilityListeners.delete(viewId);
+      }
+    };
+  }
+
+  submit(viewId: string): void {
+    this.nativeModule.submit(viewId);
   }
 
   handle(viewId: string, action: PaymentAction): void {
@@ -22,6 +43,10 @@ export class EmbeddedComponentBusWrapper extends EventListenerWrapper<EmbeddedNa
 
   hide(viewId: string, success: boolean, option?: { message?: string }): void {
     this.nativeModule.hide(viewId, success, option);
+    this.submissionAvailabilityListeners.get(viewId)?.(!success);
+    if (success) {
+      this.submissionAvailabilityListeners.delete(viewId);
+    }
   }
 
   update(viewId: string, results: AddressLookupItem[]): void {

--- a/src/modules/embedded/__tests__/EmbeddedComponentBusWrapper.test.ts
+++ b/src/modules/embedded/__tests__/EmbeddedComponentBusWrapper.test.ts
@@ -74,17 +74,6 @@ describe('EmbeddedComponentBusWrapper', () => {
         'CardComponent'
       );
     });
-
-    test('should remove the submission availability listener', () => {
-      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
-      const listener = jest.fn();
-      wrapper.addSubmissionAvailabilityListener('CardComponent', listener);
-
-      wrapper.unsubscribe('CardComponent');
-      wrapper.hide('CardComponent', false);
-
-      expect(listener).not.toHaveBeenCalled();
-    });
   });
 
   describe('submit', () => {
@@ -126,21 +115,6 @@ describe('EmbeddedComponentBusWrapper', () => {
         false,
         undefined
       );
-    });
-
-    test('should report submission availability from the hide result', () => {
-      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
-      const listener = jest.fn();
-      wrapper.addSubmissionAvailabilityListener('CardComponent', listener);
-
-      wrapper.hide('CardComponent', false);
-      wrapper.hide('CardComponent', true);
-
-      expect(listener).toHaveBeenNthCalledWith(1, true);
-      expect(listener).toHaveBeenNthCalledWith(2, false);
-
-      wrapper.hide('CardComponent', false);
-      expect(listener).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/modules/embedded/__tests__/EmbeddedComponentBusWrapper.test.ts
+++ b/src/modules/embedded/__tests__/EmbeddedComponentBusWrapper.test.ts
@@ -9,6 +9,7 @@ function createMockEmbeddedModule(supportedEvents: string[] = []) {
     getConstants: jest.fn(() => ({ supportedEvents })),
     subscribe: jest.fn(),
     unsubscribe: jest.fn(),
+    submit: jest.fn(),
     handle: jest.fn(),
     hide: jest.fn(),
     update: jest.fn(),
@@ -73,6 +74,25 @@ describe('EmbeddedComponentBusWrapper', () => {
         'CardComponent'
       );
     });
+
+    test('should remove the submission availability listener', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      const listener = jest.fn();
+      wrapper.addSubmissionAvailabilityListener('CardComponent', listener);
+
+      wrapper.unsubscribe('CardComponent');
+      wrapper.hide('CardComponent', false);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submit', () => {
+    test('should call native module submit with viewId', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      wrapper.submit('CardComponent');
+      expect(mockNativeModule.submit).toHaveBeenCalledWith('CardComponent');
+    });
   });
 
   describe('handle', () => {
@@ -106,6 +126,21 @@ describe('EmbeddedComponentBusWrapper', () => {
         false,
         undefined
       );
+    });
+
+    test('should report submission availability from the hide result', () => {
+      const wrapper = new EmbeddedComponentBusWrapper(mockNativeModule);
+      const listener = jest.fn();
+      wrapper.addSubmissionAvailabilityListener('CardComponent', listener);
+
+      wrapper.hide('CardComponent', false);
+      wrapper.hide('CardComponent', true);
+
+      expect(listener).toHaveBeenNthCalledWith(1, true);
+      expect(listener).toHaveBeenNthCalledWith(2, false);
+
+      wrapper.hide('CardComponent', false);
+      expect(listener).toHaveBeenCalledTimes(2);
     });
   });
 


### PR DESCRIPTION
## Summary

- add `card.showSubmitButton` for iOS and Android while preserving the existing default
- expose `CardViewHandle.submit(): void` for merchant-owned CTAs, matching Adyen Web's imperative submit pattern
- keep embedded cards mounted and retryable after `hide(false)`
- dispatch Android submit and retry operations to the main thread
- document the public API and external-submit flow

## Testing

- `yarn typecheck`
- `yarn test --runInBand` (27 suites, 272 tests)
- Android `testDebugUnitTest` (96 tests)
- Android `ktlint`
- API Extractor validation
- Swift syntax parsing for the changed iOS source and test files
- changed TypeScript files pass ESLint; the full lint command is blocked by two existing Prettier errors in untouched `ApplePayConfiguration.ts` (and locally generated Android test reports match its broad glob)

No simulator or emulator was used.

Closes #1200
