### PR TITLE
chore: update Android SDK to v5.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![npm version](https://img.shields.io/npm/v/@adyen/react-native.svg?style=flat-square)](https://www.npmjs.com/package/@adyen/react-native)
 [![Adyen iOS](https://img.shields.io/badge/ios-v5.25.1-brightgreen.svg)](https://github.com/Adyen/adyen-ios/releases/tag/5.25.1)
-[![Adyen Android](https://img.shields.io/badge/android-v5.19.0-brightgreen.svg)](https://github.com/Adyen/adyen-android/releases/tag/5.19.0)
+[![Adyen Android](https://img.shields.io/badge/android-v5.20.0-brightgreen.svg)](https://github.com/Adyen/adyen-android/releases/tag/5.20.0)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=Adyen_adyen-react-native&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=Adyen_adyen-react-native)
 
 > [!Important]

--- a/android/dependencies.gradle
+++ b/android/dependencies.gradle
@@ -3,7 +3,7 @@ ext {
     jacoco_version = '0.8.12'
 
     // Adyen Dependencies
-    adyen_version = "5.19.0"
+    adyen_version = "5.20.0"
 
     // Android Dependencies
     gson_version = "2.9.1"


### PR DESCRIPTION
## Summary
Bumps the native Adyen Android SDK dependency from `5.19.0` to `5.20.0`.

- Updated `adyen_version` in `android/dependencies.gradle`
- Updated the Android badge in `README.md` to reference `5.20.0`

Release notes: https://github.com/Adyen/adyen-android/releases/tag/5.20.0

## Testing
- `yarn lint` and `yarn typecheck` pass
- `./gradlew assembleDebug` in `example/android` builds successfully against the new dependency